### PR TITLE
feat: .engram format — schema initialization and metadata

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,5 @@
 {
   "permissions": {
-    "deny": [
-      "Read(./.env)",
-      "Read(./.env.*)"
-    ]
+    "deny": ["Read(./.env)", "Read(./.env.*)"]
   }
 }

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -4,7 +4,19 @@
     "type-enum": [
       2,
       "always",
-      ["feat", "fix", "chore", "docs", "refactor", "test", "ci", "build", "perf", "style", "revert"]
+      [
+        "feat",
+        "fix",
+        "chore",
+        "docs",
+        "refactor",
+        "test",
+        "ci",
+        "build",
+        "perf",
+        "style",
+        "revert"
+      ]
     ]
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,8 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
-  "organizeImports": {
-    "enabled": true
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "files": {
+    "includes": ["**/*.ts", "**/*.json", "!**/dist", "!**/node_modules"]
   },
   "linter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "verify": "bun run build && bun test && bun run lint"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.10"
   }
 }

--- a/packages/engram-cli/src/cli.ts
+++ b/packages/engram-cli/src/cli.ts
@@ -5,7 +5,9 @@ import { ENGINE_VERSION } from "engram-core";
 
 const program = new Command()
   .name("engram")
-  .description("A local-first temporal knowledge graph engine for developer memory")
+  .description(
+    "A local-first temporal knowledge graph engine for developer memory",
+  )
   .version(ENGINE_VERSION);
 
 program.parse();

--- a/packages/engram-core/package.json
+++ b/packages/engram-core/package.json
@@ -10,10 +10,6 @@
     "test": "bun test"
   },
   "dependencies": {
-    "better-sqlite3": "^11.0.0",
     "ulid": "^2.3.0"
-  },
-  "devDependencies": {
-    "@types/better-sqlite3": "^7.6.0"
   }
 }

--- a/packages/engram-core/src/format/graph.ts
+++ b/packages/engram-core/src/format/graph.ts
@@ -1,0 +1,139 @@
+/**
+ * graph.ts — lifecycle operations for .engram files.
+ *
+ * createGraph: creates a new .engram file with the full schema.
+ * openGraph:   opens an existing .engram file and validates format_version.
+ * closeGraph:  cleanly closes the database connection.
+ */
+
+import { Database } from "bun:sqlite";
+import { ulid } from "ulid";
+import { ENGINE_VERSION, FORMAT_VERSION } from "../index.js";
+import { SCHEMA_DDL } from "./schema.js";
+
+export interface EngramGraph {
+  db: Database;
+  path: string;
+  formatVersion: string;
+  engineVersion: string;
+  createdAt: string;
+  ownerId: string;
+}
+
+export interface CreateOpts {
+  ownerId?: string;
+  defaultTimezone?: string;
+}
+
+export class EngramFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EngramFormatError";
+  }
+}
+
+function applyPragmas(db: Database): void {
+  db.run("PRAGMA journal_mode = WAL");
+  db.run("PRAGMA foreign_keys = ON");
+}
+
+function applySchema(db: Database): void {
+  // Each entry in SCHEMA_DDL may contain multiple statements separated by semicolons.
+  // bun:sqlite's exec() handles multi-statement strings.
+  const allDdl = SCHEMA_DDL.join("\n");
+  db.exec(allDdl);
+}
+
+/**
+ * Creates a new .engram SQLite database at the given path.
+ * The file will be created if it doesn't exist.
+ */
+export function createGraph(path: string, opts: CreateOpts = {}): EngramGraph {
+  const db = new Database(path, { create: true });
+
+  applyPragmas(db);
+  applySchema(db);
+
+  const createdAt = new Date().toISOString();
+  const ownerId = opts.ownerId ?? ulid();
+  const defaultTimezone = opts.defaultTimezone ?? "UTC";
+
+  const insertMeta = db.prepare(
+    "INSERT INTO metadata (key, value) VALUES (?, ?)",
+  );
+
+  db.transaction(() => {
+    insertMeta.run("format_version", FORMAT_VERSION);
+    insertMeta.run("engine_version", ENGINE_VERSION);
+    insertMeta.run("created_at", createdAt);
+    insertMeta.run("owner_id", ownerId);
+    insertMeta.run("default_timezone", defaultTimezone);
+  })();
+
+  return {
+    db,
+    path,
+    formatVersion: FORMAT_VERSION,
+    engineVersion: ENGINE_VERSION,
+    createdAt,
+    ownerId,
+  };
+}
+
+/**
+ * Opens an existing .engram database, validates format_version, and returns the graph handle.
+ * Throws EngramFormatError if the file is missing required metadata or has an incompatible version.
+ */
+export function openGraph(path: string): EngramGraph {
+  const db = new Database(path);
+
+  applyPragmas(db);
+
+  const getMeta = (key: string): string | undefined => {
+    try {
+      const row = db
+        .query<{ value: string }, [string]>(
+          "SELECT value FROM metadata WHERE key = ?",
+        )
+        .get(key);
+      return row?.value;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const formatVersion = getMeta("format_version");
+  if (!formatVersion) {
+    db.close();
+    throw new EngramFormatError(
+      `openGraph: missing 'format_version' in metadata — not a valid .engram file: ${path}`,
+    );
+  }
+
+  if (formatVersion !== FORMAT_VERSION) {
+    db.close();
+    throw new EngramFormatError(
+      `openGraph: unsupported format_version '${formatVersion}' (expected '${FORMAT_VERSION}'): ${path}`,
+    );
+  }
+
+  const engineVersion = getMeta("engine_version") ?? ENGINE_VERSION;
+  const createdAt = getMeta("created_at") ?? "";
+  const ownerId = getMeta("owner_id") ?? "";
+
+  return {
+    db,
+    path,
+    formatVersion,
+    engineVersion,
+    createdAt,
+    ownerId,
+  };
+}
+
+/**
+ * Closes the database connection cleanly.
+ */
+export function closeGraph(graph: EngramGraph): void {
+  graph.db.close();
+}

--- a/packages/engram-core/src/format/graph.ts
+++ b/packages/engram-core/src/format/graph.ts
@@ -8,8 +8,8 @@
 
 import { Database } from "bun:sqlite";
 import { ulid } from "ulid";
-import { ENGINE_VERSION, FORMAT_VERSION } from "../index.js";
 import { SCHEMA_DDL } from "./schema.js";
+import { ENGINE_VERSION, FORMAT_VERSION } from "./version.js";
 
 export interface EngramGraph {
   db: Database;
@@ -51,33 +51,38 @@ function applySchema(db: Database): void {
 export function createGraph(path: string, opts: CreateOpts = {}): EngramGraph {
   const db = new Database(path, { create: true });
 
-  applyPragmas(db);
-  applySchema(db);
+  try {
+    applyPragmas(db);
+    applySchema(db);
 
-  const createdAt = new Date().toISOString();
-  const ownerId = opts.ownerId ?? ulid();
-  const defaultTimezone = opts.defaultTimezone ?? "UTC";
+    const createdAt = new Date().toISOString();
+    const ownerId = opts.ownerId ?? ulid();
+    const defaultTimezone = opts.defaultTimezone ?? "UTC";
 
-  const insertMeta = db.prepare(
-    "INSERT INTO metadata (key, value) VALUES (?, ?)",
-  );
+    const insertMeta = db.prepare(
+      "INSERT INTO metadata (key, value) VALUES (?, ?)",
+    );
 
-  db.transaction(() => {
-    insertMeta.run("format_version", FORMAT_VERSION);
-    insertMeta.run("engine_version", ENGINE_VERSION);
-    insertMeta.run("created_at", createdAt);
-    insertMeta.run("owner_id", ownerId);
-    insertMeta.run("default_timezone", defaultTimezone);
-  })();
+    db.transaction(() => {
+      insertMeta.run("format_version", FORMAT_VERSION);
+      insertMeta.run("engine_version", ENGINE_VERSION);
+      insertMeta.run("created_at", createdAt);
+      insertMeta.run("owner_id", ownerId);
+      insertMeta.run("default_timezone", defaultTimezone);
+    })();
 
-  return {
-    db,
-    path,
-    formatVersion: FORMAT_VERSION,
-    engineVersion: ENGINE_VERSION,
-    createdAt,
-    ownerId,
-  };
+    return {
+      db,
+      path,
+      formatVersion: FORMAT_VERSION,
+      engineVersion: ENGINE_VERSION,
+      createdAt,
+      ownerId,
+    };
+  } catch (err) {
+    db.close();
+    throw err;
+  }
 }
 
 /**
@@ -118,8 +123,22 @@ export function openGraph(path: string): EngramGraph {
   }
 
   const engineVersion = getMeta("engine_version") ?? ENGINE_VERSION;
-  const createdAt = getMeta("created_at") ?? "";
-  const ownerId = getMeta("owner_id") ?? "";
+
+  const createdAt = getMeta("created_at");
+  if (!createdAt) {
+    db.close();
+    throw new EngramFormatError(
+      `openGraph: missing 'created_at' in metadata — not a valid .engram file: ${path}`,
+    );
+  }
+
+  const ownerId = getMeta("owner_id");
+  if (!ownerId) {
+    db.close();
+    throw new EngramFormatError(
+      `openGraph: missing 'owner_id' in metadata — not a valid .engram file: ${path}`,
+    );
+  }
 
   return {
     db,

--- a/packages/engram-core/src/format/index.ts
+++ b/packages/engram-core/src/format/index.ts
@@ -1,0 +1,12 @@
+/**
+ * format/index.ts — public re-exports for the .engram format module.
+ */
+
+export type { CreateOpts, EngramGraph } from "./graph.js";
+export {
+  closeGraph,
+  createGraph,
+  EngramFormatError,
+  openGraph,
+} from "./graph.js";
+export { SCHEMA_DDL } from "./schema.js";

--- a/packages/engram-core/src/format/schema.ts
+++ b/packages/engram-core/src/format/schema.ts
@@ -1,0 +1,235 @@
+/**
+ * DDL SQL constants for the .engram file format (SQLite schema).
+ * Schema version: 0.1.0
+ */
+
+export const CREATE_METADATA = `
+CREATE TABLE metadata (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+`;
+
+export const CREATE_ENTITIES = `
+CREATE TABLE entities (
+  _rowid         INTEGER PRIMARY KEY,
+  id             TEXT NOT NULL UNIQUE,
+  canonical_name TEXT NOT NULL,
+  entity_type    TEXT NOT NULL,
+  summary        TEXT,
+  status         TEXT NOT NULL DEFAULT 'active',
+  created_at     TEXT NOT NULL,
+  updated_at     TEXT NOT NULL,
+  owner_id       TEXT
+);
+`;
+
+export const CREATE_ENTITIES_INDEXES = `
+CREATE INDEX idx_entities_type ON entities(entity_type);
+CREATE INDEX idx_entities_name ON entities(canonical_name);
+`;
+
+export const CREATE_ENTITY_ALIASES = `
+CREATE TABLE entity_aliases (
+  id          TEXT PRIMARY KEY,
+  entity_id   TEXT NOT NULL REFERENCES entities(id),
+  alias       TEXT NOT NULL,
+  valid_from  TEXT,
+  valid_until TEXT,
+  episode_id  TEXT REFERENCES episodes(id),
+  created_at  TEXT NOT NULL
+);
+`;
+
+export const CREATE_ENTITY_ALIASES_INDEXES = `
+CREATE INDEX idx_aliases_entity ON entity_aliases(entity_id);
+CREATE INDEX idx_aliases_name ON entity_aliases(alias);
+`;
+
+export const CREATE_EDGES = `
+CREATE TABLE edges (
+  _rowid         INTEGER PRIMARY KEY,
+  id             TEXT NOT NULL UNIQUE,
+  source_id      TEXT NOT NULL REFERENCES entities(id),
+  target_id      TEXT NOT NULL REFERENCES entities(id),
+  relation_type  TEXT NOT NULL,
+  edge_kind      TEXT NOT NULL,
+  fact           TEXT NOT NULL,
+  weight         REAL DEFAULT 1.0,
+  valid_from     TEXT,
+  valid_until    TEXT,
+  created_at     TEXT NOT NULL,
+  invalidated_at TEXT,
+  superseded_by  TEXT REFERENCES edges(id),
+  confidence     REAL DEFAULT 1.0,
+  owner_id       TEXT
+);
+`;
+
+export const CREATE_EDGES_INDEXES = `
+CREATE INDEX idx_edges_source ON edges(source_id);
+CREATE INDEX idx_edges_target ON edges(target_id);
+CREATE INDEX idx_edges_type ON edges(relation_type);
+CREATE INDEX idx_edges_kind ON edges(edge_kind);
+CREATE INDEX idx_edges_valid ON edges(valid_from, valid_until);
+CREATE INDEX idx_edges_active ON edges(invalidated_at) WHERE invalidated_at IS NULL;
+`;
+
+export const CREATE_EPISODES = `
+CREATE TABLE episodes (
+  _rowid            INTEGER PRIMARY KEY,
+  id                TEXT NOT NULL UNIQUE,
+  source_type       TEXT NOT NULL,
+  source_ref        TEXT,
+  content           TEXT NOT NULL,
+  content_hash      TEXT NOT NULL,
+  actor             TEXT,
+  status            TEXT NOT NULL DEFAULT 'active',
+  timestamp         TEXT NOT NULL,
+  ingested_at       TEXT NOT NULL,
+  owner_id          TEXT,
+  extractor_version TEXT NOT NULL,
+  metadata          TEXT
+);
+`;
+
+export const CREATE_EPISODES_INDEXES = `
+CREATE UNIQUE INDEX idx_episodes_identity ON episodes(source_type, source_ref) WHERE source_ref IS NOT NULL;
+CREATE INDEX idx_episodes_source ON episodes(source_type);
+CREATE INDEX idx_episodes_time ON episodes(timestamp);
+CREATE INDEX idx_episodes_hash ON episodes(content_hash);
+`;
+
+export const CREATE_ENTITY_EVIDENCE = `
+CREATE TABLE entity_evidence (
+  entity_id  TEXT NOT NULL REFERENCES entities(id),
+  episode_id TEXT NOT NULL REFERENCES episodes(id),
+  extractor  TEXT NOT NULL,
+  confidence REAL NOT NULL DEFAULT 1.0,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (entity_id, episode_id, extractor)
+);
+`;
+
+export const CREATE_EDGE_EVIDENCE = `
+CREATE TABLE edge_evidence (
+  edge_id    TEXT NOT NULL REFERENCES edges(id),
+  episode_id TEXT NOT NULL REFERENCES episodes(id),
+  extractor  TEXT NOT NULL,
+  confidence REAL NOT NULL DEFAULT 1.0,
+  created_at TEXT NOT NULL,
+  PRIMARY KEY (edge_id, episode_id, extractor)
+);
+`;
+
+export const CREATE_EMBEDDINGS = `
+CREATE TABLE embeddings (
+  id          TEXT PRIMARY KEY,
+  target_type TEXT NOT NULL,
+  target_id   TEXT NOT NULL,
+  model       TEXT NOT NULL,
+  dimensions  INTEGER NOT NULL,
+  vector      BLOB NOT NULL,
+  source_text TEXT NOT NULL,
+  created_at  TEXT NOT NULL,
+  UNIQUE(target_type, target_id, model)
+);
+`;
+
+export const CREATE_EMBEDDINGS_INDEXES = `
+CREATE INDEX idx_embeddings_target ON embeddings(target_type, target_id);
+`;
+
+export const CREATE_INGESTION_RUNS = `
+CREATE TABLE ingestion_runs (
+  id                TEXT PRIMARY KEY,
+  source_type       TEXT NOT NULL,
+  source_scope      TEXT NOT NULL,
+  started_at        TEXT NOT NULL,
+  completed_at      TEXT,
+  cursor            TEXT,
+  extractor_version TEXT NOT NULL,
+  episodes_created  INTEGER DEFAULT 0,
+  entities_created  INTEGER DEFAULT 0,
+  edges_created     INTEGER DEFAULT 0,
+  status            TEXT NOT NULL DEFAULT 'running',
+  error             TEXT
+);
+`;
+
+export const CREATE_INGESTION_RUNS_INDEXES = `
+CREATE INDEX idx_runs_scope ON ingestion_runs(source_type, source_scope);
+`;
+
+export const CREATE_FTS_TABLES = `
+CREATE VIRTUAL TABLE entities_fts USING fts5(
+  canonical_name, summary,
+  content=entities, content_rowid=_rowid
+);
+CREATE VIRTUAL TABLE edges_fts USING fts5(
+  fact,
+  content=edges, content_rowid=_rowid
+);
+CREATE VIRTUAL TABLE episodes_fts USING fts5(
+  content,
+  content=episodes, content_rowid=_rowid
+);
+`;
+
+export const CREATE_FTS_TRIGGERS = `
+CREATE TRIGGER entities_ai AFTER INSERT ON entities BEGIN
+  INSERT INTO entities_fts(rowid, canonical_name, summary) VALUES (new._rowid, new.canonical_name, new.summary);
+END;
+CREATE TRIGGER entities_ad AFTER DELETE ON entities BEGIN
+  INSERT INTO entities_fts(entities_fts, rowid, canonical_name, summary) VALUES ('delete', old._rowid, old.canonical_name, old.summary);
+END;
+CREATE TRIGGER entities_au AFTER UPDATE ON entities BEGIN
+  INSERT INTO entities_fts(entities_fts, rowid, canonical_name, summary) VALUES ('delete', old._rowid, old.canonical_name, old.summary);
+  INSERT INTO entities_fts(rowid, canonical_name, summary) VALUES (new._rowid, new.canonical_name, new.summary);
+END;
+CREATE TRIGGER edges_ai AFTER INSERT ON edges BEGIN
+  INSERT INTO edges_fts(rowid, fact) VALUES (new._rowid, new.fact);
+END;
+CREATE TRIGGER edges_ad AFTER DELETE ON edges BEGIN
+  INSERT INTO edges_fts(edges_fts, rowid, fact) VALUES ('delete', old._rowid, old.fact);
+END;
+CREATE TRIGGER edges_au AFTER UPDATE ON edges BEGIN
+  INSERT INTO edges_fts(edges_fts, rowid, fact) VALUES ('delete', old._rowid, old.fact);
+  INSERT INTO edges_fts(rowid, fact) VALUES (new._rowid, new.fact);
+END;
+CREATE TRIGGER episodes_ai AFTER INSERT ON episodes BEGIN
+  INSERT INTO episodes_fts(rowid, content) VALUES (new._rowid, new.content);
+END;
+CREATE TRIGGER episodes_ad AFTER DELETE ON episodes BEGIN
+  INSERT INTO episodes_fts(episodes_fts, rowid, content) VALUES ('delete', old._rowid, old.content);
+END;
+CREATE TRIGGER episodes_au AFTER UPDATE ON episodes BEGIN
+  INSERT INTO episodes_fts(episodes_fts, rowid, content) VALUES ('delete', old._rowid, old.content);
+  INSERT INTO episodes_fts(rowid, content) VALUES (new._rowid, new.content);
+END;
+`;
+
+/**
+ * All DDL statements in the order they must be applied.
+ * Tables with foreign key dependencies come after their referenced tables.
+ */
+export const SCHEMA_DDL: string[] = [
+  CREATE_METADATA,
+  CREATE_ENTITIES,
+  CREATE_ENTITIES_INDEXES,
+  // episodes must come before entity_aliases (which references episodes)
+  CREATE_EPISODES,
+  CREATE_EPISODES_INDEXES,
+  CREATE_ENTITY_ALIASES,
+  CREATE_ENTITY_ALIASES_INDEXES,
+  CREATE_EDGES,
+  CREATE_EDGES_INDEXES,
+  CREATE_ENTITY_EVIDENCE,
+  CREATE_EDGE_EVIDENCE,
+  CREATE_EMBEDDINGS,
+  CREATE_EMBEDDINGS_INDEXES,
+  CREATE_INGESTION_RUNS,
+  CREATE_INGESTION_RUNS_INDEXES,
+  CREATE_FTS_TABLES,
+  CREATE_FTS_TRIGGERS,
+];

--- a/packages/engram-core/src/format/version.ts
+++ b/packages/engram-core/src/format/version.ts
@@ -1,0 +1,8 @@
+/**
+ * version.ts — canonical version constants for format and engine.
+ *
+ * Extracted from index.ts to break circular imports between format/ and graph/ modules.
+ */
+
+export const FORMAT_VERSION = "0.1.0";
+export const ENGINE_VERSION = "0.1.0";

--- a/packages/engram-core/src/graph/edges.ts
+++ b/packages/engram-core/src/graph/edges.ts
@@ -1,0 +1,185 @@
+/**
+ * edges.ts — edge CRUD operations.
+ */
+
+import { ulid } from "ulid";
+import type { EngramGraph } from "../format/index.js";
+import type { EvidenceInput } from "./entities.js";
+import { EvidenceRequiredError } from "./errors.js";
+
+export interface EdgeInput {
+  source_id: string;
+  target_id: string;
+  relation_type: string;
+  edge_kind: string;
+  fact: string;
+  weight?: number;
+  valid_from?: string;
+  valid_until?: string;
+  confidence?: number;
+  owner_id?: string;
+}
+
+export interface Edge {
+  id: string;
+  source_id: string;
+  target_id: string;
+  relation_type: string;
+  edge_kind: string;
+  fact: string;
+  weight: number;
+  valid_from: string | null;
+  valid_until: string | null;
+  created_at: string;
+  invalidated_at: string | null;
+  superseded_by: string | null;
+  confidence: number;
+  owner_id: string | null;
+}
+
+export interface FindEdgesQuery {
+  source_id?: string;
+  target_id?: string;
+  relation_type?: string;
+  edge_kind?: string;
+  active_only?: boolean;
+}
+
+/**
+ * Creates an edge and its evidence links in a single transaction.
+ * Throws EvidenceRequiredError if evidence array is empty or not provided.
+ */
+export function addEdge(
+  graph: EngramGraph,
+  edge: EdgeInput,
+  evidence: EvidenceInput[],
+): Edge {
+  if (!evidence || evidence.length === 0) {
+    throw new EvidenceRequiredError("addEdge");
+  }
+
+  const id = ulid();
+  const now = new Date().toISOString();
+
+  const insertEdge = graph.db.prepare<
+    void,
+    [
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+      number,
+      string | null,
+      string | null,
+      string,
+      number,
+      string | null,
+    ]
+  >(
+    `INSERT INTO edges
+       (id, source_id, target_id, relation_type, edge_kind, fact, weight, valid_from, valid_until, created_at, confidence, owner_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  const insertEvidence = graph.db.prepare<
+    void,
+    [string, string, string, number, string]
+  >(
+    `INSERT INTO edge_evidence (edge_id, episode_id, extractor, confidence, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+
+  graph.db.transaction(() => {
+    insertEdge.run(
+      id,
+      edge.source_id,
+      edge.target_id,
+      edge.relation_type,
+      edge.edge_kind,
+      edge.fact,
+      edge.weight ?? 1.0,
+      edge.valid_from ?? null,
+      edge.valid_until ?? null,
+      now,
+      edge.confidence ?? 1.0,
+      edge.owner_id ?? null,
+    );
+
+    for (const ev of evidence) {
+      insertEvidence.run(
+        id,
+        ev.episode_id,
+        ev.extractor,
+        ev.confidence ?? 1.0,
+        now,
+      );
+    }
+  })();
+
+  const row = graph.db
+    .query<Edge, [string]>("SELECT * FROM edges WHERE id = ?")
+    .get(id);
+
+  if (!row) {
+    throw new Error(`addEdge: failed to retrieve inserted edge ${id}`);
+  }
+
+  return row;
+}
+
+/**
+ * Returns an edge by ID, or null if not found.
+ */
+export function getEdge(graph: EngramGraph, id: string): Edge | null {
+  return (
+    graph.db
+      .query<Edge, [string]>("SELECT * FROM edges WHERE id = ?")
+      .get(id) ?? null
+  );
+}
+
+/**
+ * Finds edges matching the given query filters.
+ * All filters are ANDed together. Omitting a field means no filter on that field.
+ * When `active_only` is true, only edges with `invalidated_at IS NULL` are returned.
+ */
+export function findEdges(
+  graph: EngramGraph,
+  query: FindEdgesQuery = {},
+): Edge[] {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (query.source_id !== undefined) {
+    conditions.push("source_id = ?");
+    params.push(query.source_id);
+  }
+
+  if (query.target_id !== undefined) {
+    conditions.push("target_id = ?");
+    params.push(query.target_id);
+  }
+
+  if (query.relation_type !== undefined) {
+    conditions.push("relation_type = ?");
+    params.push(query.relation_type);
+  }
+
+  if (query.edge_kind !== undefined) {
+    conditions.push("edge_kind = ?");
+    params.push(query.edge_kind);
+  }
+
+  if (query.active_only) {
+    conditions.push("invalidated_at IS NULL");
+  }
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `SELECT * FROM edges ${where} ORDER BY created_at ASC`;
+
+  return graph.db.query<Edge, unknown[]>(sql).all(...params);
+}

--- a/packages/engram-core/src/graph/edges.ts
+++ b/packages/engram-core/src/graph/edges.ts
@@ -43,6 +43,10 @@ export interface FindEdgesQuery {
   relation_type?: string;
   edge_kind?: string;
   active_only?: boolean;
+  /** ISO8601 UTC timestamp. If provided, only returns edges valid at that point in time. */
+  valid_at?: string;
+  /** If false (default), only active edges (invalidated_at IS NULL) are returned. */
+  include_invalidated?: boolean;
 }
 
 /**
@@ -64,7 +68,6 @@ export function addEdge(
   const insertEdge = graph.db.prepare<
     void,
     [
-      string,
       string,
       string,
       string,
@@ -173,8 +176,19 @@ export function findEdges(
     params.push(query.edge_kind);
   }
 
-  if (query.active_only) {
+  // Exclude invalidated edges unless include_invalidated is explicitly true.
+  // active_only is a legacy alias for the same behaviour.
+  if (query.active_only || !query.include_invalidated) {
     conditions.push("invalidated_at IS NULL");
+  }
+
+  if (query.valid_at !== undefined) {
+    // Half-open interval: valid_from <= valid_at < valid_until
+    // NULL valid_from = -∞ (treat as always started), NULL valid_until = +∞ (treat as still current)
+    conditions.push(
+      "(valid_from IS NULL OR valid_from <= ?) AND (valid_until IS NULL OR valid_until > ?)",
+    );
+    params.push(query.valid_at, query.valid_at);
   }
 
   const where =

--- a/packages/engram-core/src/graph/entities.ts
+++ b/packages/engram-core/src/graph/entities.ts
@@ -1,0 +1,157 @@
+/**
+ * entities.ts — entity CRUD operations.
+ */
+
+import { ulid } from "ulid";
+import type { EngramGraph } from "../format/index.js";
+import { EvidenceRequiredError } from "./errors.js";
+
+export interface EvidenceInput {
+  episode_id: string;
+  extractor: string;
+  confidence?: number;
+}
+
+export interface EntityInput {
+  canonical_name: string;
+  entity_type: string;
+  summary?: string;
+  status?: string;
+  owner_id?: string;
+}
+
+export interface Entity {
+  id: string;
+  canonical_name: string;
+  entity_type: string;
+  summary: string | null;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  owner_id: string | null;
+}
+
+export interface FindEntitiesQuery {
+  entity_type?: string;
+  canonical_name?: string;
+  status?: string;
+}
+
+/**
+ * Creates an entity and its evidence links in a single transaction.
+ * Throws EvidenceRequiredError if evidence array is empty or not provided.
+ */
+export function addEntity(
+  graph: EngramGraph,
+  entity: EntityInput,
+  evidence: EvidenceInput[],
+): Entity {
+  if (!evidence || evidence.length === 0) {
+    throw new EvidenceRequiredError("addEntity");
+  }
+
+  const id = ulid();
+  const now = new Date().toISOString();
+
+  const insertEntity = graph.db.prepare<
+    void,
+    [
+      string,
+      string,
+      string,
+      string | null,
+      string,
+      string,
+      string,
+      string | null,
+    ]
+  >(
+    `INSERT INTO entities (id, canonical_name, entity_type, summary, status, created_at, updated_at, owner_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  const insertEvidence = graph.db.prepare<
+    void,
+    [string, string, string, number, string]
+  >(
+    `INSERT INTO entity_evidence (entity_id, episode_id, extractor, confidence, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+
+  graph.db.transaction(() => {
+    insertEntity.run(
+      id,
+      entity.canonical_name,
+      entity.entity_type,
+      entity.summary ?? null,
+      entity.status ?? "active",
+      now,
+      now,
+      entity.owner_id ?? null,
+    );
+
+    for (const ev of evidence) {
+      insertEvidence.run(
+        id,
+        ev.episode_id,
+        ev.extractor,
+        ev.confidence ?? 1.0,
+        now,
+      );
+    }
+  })();
+
+  const row = graph.db
+    .query<Entity, [string]>("SELECT * FROM entities WHERE id = ?")
+    .get(id);
+
+  if (!row) {
+    throw new Error(`addEntity: failed to retrieve inserted entity ${id}`);
+  }
+
+  return row;
+}
+
+/**
+ * Returns an entity by ID, or null if not found.
+ */
+export function getEntity(graph: EngramGraph, id: string): Entity | null {
+  return (
+    graph.db
+      .query<Entity, [string]>("SELECT * FROM entities WHERE id = ?")
+      .get(id) ?? null
+  );
+}
+
+/**
+ * Finds entities matching the given query filters.
+ * All filters are ANDed together. Omitting a field means no filter on that field.
+ */
+export function findEntities(
+  graph: EngramGraph,
+  query: FindEntitiesQuery = {},
+): Entity[] {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (query.entity_type !== undefined) {
+    conditions.push("entity_type = ?");
+    params.push(query.entity_type);
+  }
+
+  if (query.canonical_name !== undefined) {
+    conditions.push("canonical_name = ?");
+    params.push(query.canonical_name);
+  }
+
+  if (query.status !== undefined) {
+    conditions.push("status = ?");
+    params.push(query.status);
+  }
+
+  const where =
+    conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  const sql = `SELECT * FROM entities ${where} ORDER BY created_at ASC`;
+
+  return graph.db.query<Entity, unknown[]>(sql).all(...params);
+}

--- a/packages/engram-core/src/graph/episodes.ts
+++ b/packages/engram-core/src/graph/episodes.ts
@@ -5,7 +5,7 @@
 import { createHash } from "node:crypto";
 import { ulid } from "ulid";
 import type { EngramGraph } from "../format/index.js";
-import { ENGINE_VERSION } from "../index.js";
+import { ENGINE_VERSION } from "../format/version.js";
 
 export interface EpisodeInput {
   source_type: string;
@@ -40,6 +40,16 @@ export interface Episode {
  * returns the existing episode instead of throwing.
  */
 export function addEpisode(graph: EngramGraph, input: EpisodeInput): Episode {
+  // If source_ref provided, check for existing episode first (idempotent dedup)
+  if (input.source_ref != null) {
+    const existing = graph.db
+      .query<Episode, [string, string]>(
+        "SELECT * FROM episodes WHERE source_type = ? AND source_ref = ?",
+      )
+      .get(input.source_type, input.source_ref);
+    if (existing) return existing;
+  }
+
   const id = ulid();
   const now = new Date().toISOString();
   const content_hash = createHash("sha256").update(input.content).digest("hex");
@@ -50,18 +60,17 @@ export function addEpisode(graph: EngramGraph, input: EpisodeInput): Episode {
   const insert = graph.db.prepare<
     void,
     [
-      string,
-      string,
-      string | null,
-      string,
-      string,
-      string | null,
-      string,
-      string,
-      string | null,
-      string,
-      string,
-      string | null,
+      string, // id
+      string, // source_type
+      string | null, // source_ref
+      string, // content
+      string, // content_hash
+      string | null, // actor
+      string, // timestamp
+      string, // ingested_at
+      string | null, // owner_id
+      string, // extractor_version
+      string | null, // metadata
     ]
   >(
     `INSERT INTO episodes
@@ -69,38 +78,21 @@ export function addEpisode(graph: EngramGraph, input: EpisodeInput): Episode {
      VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)`,
   );
 
-  try {
-    graph.db.transaction(() => {
-      insert.run(
-        id,
-        input.source_type,
-        input.source_ref ?? null,
-        input.content,
-        content_hash,
-        input.actor ?? null,
-        input.timestamp,
-        now,
-        input.owner_id ?? null,
-        extractor_version,
-        metadata,
-      );
-    })();
-  } catch (err: unknown) {
-    // Handle duplicate (source_type, source_ref) constraint violation
-    if (
-      input.source_ref != null &&
-      err instanceof Error &&
-      err.message.includes("UNIQUE constraint failed")
-    ) {
-      const existing = graph.db
-        .query<Episode, [string, string]>(
-          "SELECT * FROM episodes WHERE source_type = ? AND source_ref = ?",
-        )
-        .get(input.source_type, input.source_ref);
-      if (existing) return existing;
-    }
-    throw err;
-  }
+  graph.db.transaction(() => {
+    insert.run(
+      id,
+      input.source_type,
+      input.source_ref ?? null,
+      input.content,
+      content_hash,
+      input.actor ?? null,
+      input.timestamp,
+      now,
+      input.owner_id ?? null,
+      extractor_version,
+      metadata,
+    );
+  })();
 
   const row = graph.db
     .query<Episode, [string]>("SELECT * FROM episodes WHERE id = ?")

--- a/packages/engram-core/src/graph/episodes.ts
+++ b/packages/engram-core/src/graph/episodes.ts
@@ -1,0 +1,125 @@
+/**
+ * episodes.ts — episode (immutable raw evidence) CRUD operations.
+ */
+
+import { createHash } from "node:crypto";
+import { ulid } from "ulid";
+import type { EngramGraph } from "../format/index.js";
+import { ENGINE_VERSION } from "../index.js";
+
+export interface EpisodeInput {
+  source_type: string;
+  source_ref?: string;
+  content: string;
+  actor?: string;
+  timestamp: string;
+  owner_id?: string;
+  extractor_version?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface Episode {
+  id: string;
+  source_type: string;
+  source_ref: string | null;
+  content: string;
+  content_hash: string;
+  actor: string | null;
+  status: string;
+  timestamp: string;
+  ingested_at: string;
+  owner_id: string | null;
+  extractor_version: string;
+  metadata: string | null;
+}
+
+/**
+ * Creates a new episode (immutable raw evidence record).
+ *
+ * If `source_ref` is provided and a duplicate `(source_type, source_ref)` exists,
+ * returns the existing episode instead of throwing.
+ */
+export function addEpisode(graph: EngramGraph, input: EpisodeInput): Episode {
+  const id = ulid();
+  const now = new Date().toISOString();
+  const content_hash = createHash("sha256").update(input.content).digest("hex");
+  const extractor_version = input.extractor_version ?? ENGINE_VERSION;
+  const metadata =
+    input.metadata != null ? JSON.stringify(input.metadata) : null;
+
+  const insert = graph.db.prepare<
+    void,
+    [
+      string,
+      string,
+      string | null,
+      string,
+      string,
+      string | null,
+      string,
+      string,
+      string | null,
+      string,
+      string,
+      string | null,
+    ]
+  >(
+    `INSERT INTO episodes
+       (id, source_type, source_ref, content, content_hash, actor, status, timestamp, ingested_at, owner_id, extractor_version, metadata)
+     VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?, ?)`,
+  );
+
+  try {
+    graph.db.transaction(() => {
+      insert.run(
+        id,
+        input.source_type,
+        input.source_ref ?? null,
+        input.content,
+        content_hash,
+        input.actor ?? null,
+        input.timestamp,
+        now,
+        input.owner_id ?? null,
+        extractor_version,
+        metadata,
+      );
+    })();
+  } catch (err: unknown) {
+    // Handle duplicate (source_type, source_ref) constraint violation
+    if (
+      input.source_ref != null &&
+      err instanceof Error &&
+      err.message.includes("UNIQUE constraint failed")
+    ) {
+      const existing = graph.db
+        .query<Episode, [string, string]>(
+          "SELECT * FROM episodes WHERE source_type = ? AND source_ref = ?",
+        )
+        .get(input.source_type, input.source_ref);
+      if (existing) return existing;
+    }
+    throw err;
+  }
+
+  const row = graph.db
+    .query<Episode, [string]>("SELECT * FROM episodes WHERE id = ?")
+    .get(id);
+
+  if (!row) {
+    throw new Error(`addEpisode: failed to retrieve inserted episode ${id}`);
+  }
+
+  return row;
+}
+
+/**
+ * Returns an episode by ID, or null if not found.
+ */
+export function getEpisode(graph: EngramGraph, id: string): Episode | null {
+  return (
+    graph.db
+      .query<Episode, [string]>("SELECT * FROM episodes WHERE id = ?")
+      .get(id) ?? null
+  );
+}

--- a/packages/engram-core/src/graph/errors.ts
+++ b/packages/engram-core/src/graph/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * errors.ts — typed error classes for graph CRUD operations.
+ */
+
+export class EvidenceRequiredError extends Error {
+  constructor(operation: string) {
+    super(
+      `${operation}: evidence is required — every entity and edge must have at least one evidence link`,
+    );
+    this.name = "EvidenceRequiredError";
+  }
+}
+
+export class EntityNotFoundError extends Error {
+  constructor(id: string) {
+    super(`entity not found: ${id}`);
+    this.name = "EntityNotFoundError";
+  }
+}
+
+export class EdgeNotFoundError extends Error {
+  constructor(id: string) {
+    super(`edge not found: ${id}`);
+    this.name = "EdgeNotFoundError";
+  }
+}

--- a/packages/engram-core/src/graph/evidence.ts
+++ b/packages/engram-core/src/graph/evidence.ts
@@ -1,0 +1,128 @@
+/**
+ * evidence.ts — evidence chain retrieval operations.
+ */
+
+import type { EngramGraph } from "../format/index.js";
+import type { Episode } from "./episodes.js";
+
+export interface EvidenceLink {
+  episode_id: string;
+  extractor: string;
+  confidence: number;
+  created_at: string;
+  episode: Episode;
+}
+
+interface EvidenceLinkRow {
+  episode_id: string;
+  extractor: string;
+  confidence: number;
+  created_at: string;
+  ep_id: string;
+  ep_source_type: string;
+  ep_source_ref: string | null;
+  ep_content: string;
+  ep_content_hash: string;
+  ep_actor: string | null;
+  ep_status: string;
+  ep_timestamp: string;
+  ep_ingested_at: string;
+  ep_owner_id: string | null;
+  ep_extractor_version: string;
+  ep_metadata: string | null;
+}
+
+function rowToEvidenceLink(row: EvidenceLinkRow): EvidenceLink {
+  return {
+    episode_id: row.episode_id,
+    extractor: row.extractor,
+    confidence: row.confidence,
+    created_at: row.created_at,
+    episode: {
+      id: row.ep_id,
+      source_type: row.ep_source_type,
+      source_ref: row.ep_source_ref,
+      content: row.ep_content,
+      content_hash: row.ep_content_hash,
+      actor: row.ep_actor,
+      status: row.ep_status,
+      timestamp: row.ep_timestamp,
+      ingested_at: row.ep_ingested_at,
+      owner_id: row.ep_owner_id,
+      extractor_version: row.ep_extractor_version,
+      metadata: row.ep_metadata,
+    },
+  };
+}
+
+/**
+ * Returns the evidence chain for an entity, including full episode details.
+ */
+export function getEvidenceForEntity(
+  graph: EngramGraph,
+  entity_id: string,
+): EvidenceLink[] {
+  const rows = graph.db
+    .query<EvidenceLinkRow, [string]>(
+      `SELECT
+         ee.episode_id,
+         ee.extractor,
+         ee.confidence,
+         ee.created_at,
+         ep.id        AS ep_id,
+         ep.source_type AS ep_source_type,
+         ep.source_ref  AS ep_source_ref,
+         ep.content     AS ep_content,
+         ep.content_hash AS ep_content_hash,
+         ep.actor       AS ep_actor,
+         ep.status      AS ep_status,
+         ep.timestamp   AS ep_timestamp,
+         ep.ingested_at AS ep_ingested_at,
+         ep.owner_id    AS ep_owner_id,
+         ep.extractor_version AS ep_extractor_version,
+         ep.metadata    AS ep_metadata
+       FROM entity_evidence ee
+       JOIN episodes ep ON ep.id = ee.episode_id
+       WHERE ee.entity_id = ?
+       ORDER BY ee.created_at ASC`,
+    )
+    .all(entity_id);
+
+  return rows.map(rowToEvidenceLink);
+}
+
+/**
+ * Returns the evidence chain for an edge, including full episode details.
+ */
+export function getEvidenceForEdge(
+  graph: EngramGraph,
+  edge_id: string,
+): EvidenceLink[] {
+  const rows = graph.db
+    .query<EvidenceLinkRow, [string]>(
+      `SELECT
+         eedge.episode_id,
+         eedge.extractor,
+         eedge.confidence,
+         eedge.created_at,
+         ep.id        AS ep_id,
+         ep.source_type AS ep_source_type,
+         ep.source_ref  AS ep_source_ref,
+         ep.content     AS ep_content,
+         ep.content_hash AS ep_content_hash,
+         ep.actor       AS ep_actor,
+         ep.status      AS ep_status,
+         ep.timestamp   AS ep_timestamp,
+         ep.ingested_at AS ep_ingested_at,
+         ep.owner_id    AS ep_owner_id,
+         ep.extractor_version AS ep_extractor_version,
+         ep.metadata    AS ep_metadata
+       FROM edge_evidence eedge
+       JOIN episodes ep ON ep.id = eedge.episode_id
+       WHERE eedge.edge_id = ?
+       ORDER BY eedge.created_at ASC`,
+    )
+    .all(edge_id);
+
+  return rows.map(rowToEvidenceLink);
+}

--- a/packages/engram-core/src/graph/index.ts
+++ b/packages/engram-core/src/graph/index.ts
@@ -1,0 +1,23 @@
+/**
+ * graph/index.ts — re-exports for the graph CRUD module.
+ */
+
+export type { Edge, EdgeInput, FindEdgesQuery } from "./edges.js";
+export { addEdge, findEdges, getEdge } from "./edges.js";
+export type {
+  Entity,
+  EntityInput,
+  EvidenceInput,
+  FindEntitiesQuery,
+} from "./entities.js";
+export { addEntity, findEntities, getEntity } from "./entities.js";
+export type { Episode, EpisodeInput } from "./episodes.js";
+export { addEpisode, getEpisode } from "./episodes.js";
+export {
+  EdgeNotFoundError,
+  EntityNotFoundError,
+  EvidenceRequiredError,
+} from "./errors.js";
+
+export type { EvidenceLink } from "./evidence.js";
+export { getEvidenceForEdge, getEvidenceForEntity } from "./evidence.js";

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -6,3 +6,12 @@
 
 export const FORMAT_VERSION = "0.1.0";
 export const ENGINE_VERSION = "0.1.0";
+
+export type { CreateOpts, EngramGraph } from "./format/index.js";
+export {
+  closeGraph,
+  createGraph,
+  EngramFormatError,
+  openGraph,
+  SCHEMA_DDL,
+} from "./format/index.js";

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -4,25 +4,18 @@
  * Public API surface. All consumer-facing types and functions are re-exported from here.
  */
 
-export type {
-  CreateOpts,
-  EngramGraph,
-  VerifyResult,
-  Violation,
-  ViolationSeverity,
-} from "./format/index.js";
+export const FORMAT_VERSION = "0.1.0";
+export const ENGINE_VERSION = "0.1.0";
+
+export type { CreateOpts, EngramGraph } from "./format/index.js";
 export {
   closeGraph,
   createGraph,
   EngramFormatError,
   openGraph,
   SCHEMA_DDL,
-  verifyGraph,
 } from "./format/index.js";
-export { ENGINE_VERSION, FORMAT_VERSION } from "./format/version.js";
 export type {
-  Alias,
-  AliasInput,
   Edge,
   EdgeInput,
   Entity,
@@ -37,7 +30,6 @@ export type {
 export {
   addEdge,
   addEntity,
-  addEntityAlias,
   addEpisode,
   EdgeNotFoundError,
   EntityNotFoundError,
@@ -49,39 +41,4 @@ export {
   getEpisode,
   getEvidenceForEdge,
   getEvidenceForEntity,
-  resolveEntity,
 } from "./graph/index.js";
-export type { EnrichmentAdapter, EnrichOpts } from "./ingest/adapter.js";
-export { GitHubAdapter } from "./ingest/adapters/github.js";
-export type { GitIngestOpts, IngestResult } from "./ingest/git.js";
-export { ingestGitRepo } from "./ingest/git.js";
-export type { MarkdownIngestOpts } from "./ingest/markdown.js";
-export { ingestMarkdown } from "./ingest/markdown.js";
-export type { TextIngestOpts } from "./ingest/text.js";
-export { ingestText } from "./ingest/text.js";
-export type {
-  DecayCategory,
-  DecayItem,
-  DecayOpts,
-  DecayReport,
-  DecaySeverity,
-  PathResult,
-  ScoreComponents,
-  SearchOpts,
-  SearchResult,
-  SubGraph,
-  TraversalOpts,
-} from "./retrieval/index.js";
-export {
-  getDecayReport,
-  getNeighbors,
-  getPath,
-  search,
-} from "./retrieval/index.js";
-export type { TemporalSnapshot } from "./temporal/index.js";
-export {
-  checkActiveEdgeConflict,
-  getFactHistory,
-  getSnapshot,
-  supersedeEdge,
-} from "./temporal/index.js";

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -15,3 +15,30 @@ export {
   openGraph,
   SCHEMA_DDL,
 } from "./format/index.js";
+export type {
+  Edge,
+  EdgeInput,
+  Entity,
+  EntityInput,
+  Episode,
+  EpisodeInput,
+  EvidenceInput,
+  EvidenceLink,
+  FindEdgesQuery,
+  FindEntitiesQuery,
+} from "./graph/index.js";
+export {
+  addEdge,
+  addEntity,
+  addEpisode,
+  EdgeNotFoundError,
+  EntityNotFoundError,
+  EvidenceRequiredError,
+  findEdges,
+  findEntities,
+  getEdge,
+  getEntity,
+  getEpisode,
+  getEvidenceForEdge,
+  getEvidenceForEntity,
+} from "./graph/index.js";

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -4,18 +4,25 @@
  * Public API surface. All consumer-facing types and functions are re-exported from here.
  */
 
-export const FORMAT_VERSION = "0.1.0";
-export const ENGINE_VERSION = "0.1.0";
-
-export type { CreateOpts, EngramGraph } from "./format/index.js";
+export type {
+  CreateOpts,
+  EngramGraph,
+  VerifyResult,
+  Violation,
+  ViolationSeverity,
+} from "./format/index.js";
 export {
   closeGraph,
   createGraph,
   EngramFormatError,
   openGraph,
   SCHEMA_DDL,
+  verifyGraph,
 } from "./format/index.js";
+export { ENGINE_VERSION, FORMAT_VERSION } from "./format/version.js";
 export type {
+  Alias,
+  AliasInput,
   Edge,
   EdgeInput,
   Entity,
@@ -30,6 +37,7 @@ export type {
 export {
   addEdge,
   addEntity,
+  addEntityAlias,
   addEpisode,
   EdgeNotFoundError,
   EntityNotFoundError,
@@ -41,4 +49,39 @@ export {
   getEpisode,
   getEvidenceForEdge,
   getEvidenceForEntity,
+  resolveEntity,
 } from "./graph/index.js";
+export type { EnrichmentAdapter, EnrichOpts } from "./ingest/adapter.js";
+export { GitHubAdapter } from "./ingest/adapters/github.js";
+export type { GitIngestOpts, IngestResult } from "./ingest/git.js";
+export { ingestGitRepo } from "./ingest/git.js";
+export type { MarkdownIngestOpts } from "./ingest/markdown.js";
+export { ingestMarkdown } from "./ingest/markdown.js";
+export type { TextIngestOpts } from "./ingest/text.js";
+export { ingestText } from "./ingest/text.js";
+export type {
+  DecayCategory,
+  DecayItem,
+  DecayOpts,
+  DecayReport,
+  DecaySeverity,
+  PathResult,
+  ScoreComponents,
+  SearchOpts,
+  SearchResult,
+  SubGraph,
+  TraversalOpts,
+} from "./retrieval/index.js";
+export {
+  getDecayReport,
+  getNeighbors,
+  getPath,
+  search,
+} from "./retrieval/index.js";
+export type { TemporalSnapshot } from "./temporal/index.js";
+export {
+  checkActiveEdgeConflict,
+  getFactHistory,
+  getSnapshot,
+  supersedeEdge,
+} from "./temporal/index.js";

--- a/packages/engram-core/test/format/graph.test.ts
+++ b/packages/engram-core/test/format/graph.test.ts
@@ -16,7 +16,7 @@ import {
 import { ENGINE_VERSION, FORMAT_VERSION } from "../../src/index.js";
 
 function tmpPath(name: string): string {
-  return join(tmpdir(), `engram-test-${name}-${Date.now()}.engram`);
+  return join(tmpdir(), `engram-test-${name}-${crypto.randomUUID()}.engram`);
 }
 
 function cleanupFiles(paths: string[]): void {
@@ -141,12 +141,18 @@ describe("schema: all required tables exist", () => {
 
   const REQUIRED_FTS_TABLES = ["entities_fts", "edges_fts", "episodes_fts"];
 
-  let path: string;
-  let graph: ReturnType<typeof createGraph>;
+  let path: string | undefined;
+  let graph: ReturnType<typeof createGraph> | undefined;
 
   afterEach(() => {
-    if (graph) closeGraph(graph);
-    cleanupFiles([path]);
+    if (graph) {
+      closeGraph(graph);
+      graph = undefined;
+    }
+    if (path) {
+      cleanupFiles([path]);
+      path = undefined;
+    }
   });
 
   it("has all required base tables", () => {

--- a/packages/engram-core/test/format/graph.test.ts
+++ b/packages/engram-core/test/format/graph.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Tests for the .engram format lifecycle: createGraph, openGraph, closeGraph.
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  closeGraph,
+  createGraph,
+  EngramFormatError,
+  openGraph,
+} from "../../src/format/index.js";
+import { ENGINE_VERSION, FORMAT_VERSION } from "../../src/index.js";
+
+function tmpPath(name: string): string {
+  return join(tmpdir(), `engram-test-${name}-${Date.now()}.engram`);
+}
+
+function cleanupFiles(paths: string[]): void {
+  for (const p of paths) {
+    // SQLite WAL mode creates -wal and -shm sidecar files
+    for (const suffix of ["", "-wal", "-shm"]) {
+      const full = p + suffix;
+      if (existsSync(full)) {
+        try {
+          unlinkSync(full);
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+}
+
+describe("createGraph", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    cleanupFiles(created);
+    created.length = 0;
+  });
+
+  it("creates a new .engram file and returns a graph handle", () => {
+    const path = tmpPath("create-basic");
+    created.push(path);
+
+    const graph = createGraph(path);
+    expect(graph.path).toBe(path);
+    expect(graph.formatVersion).toBe(FORMAT_VERSION);
+    expect(graph.engineVersion).toBe(ENGINE_VERSION);
+    expect(graph.createdAt).toBeTruthy();
+    expect(graph.ownerId).toBeTruthy();
+    closeGraph(graph);
+  });
+
+  it("stores required metadata keys", () => {
+    const path = tmpPath("create-meta");
+    created.push(path);
+
+    const graph = createGraph(path, {
+      ownerId: "owner-123",
+      defaultTimezone: "America/New_York",
+    });
+
+    const getMeta = (key: string) =>
+      (
+        graph.db.prepare("SELECT value FROM metadata WHERE key = ?").get(key) as
+          | { value: string }
+          | undefined
+      )?.value;
+
+    expect(getMeta("format_version")).toBe(FORMAT_VERSION);
+    expect(getMeta("engine_version")).toBe(ENGINE_VERSION);
+    expect(getMeta("owner_id")).toBe("owner-123");
+    expect(getMeta("default_timezone")).toBe("America/New_York");
+    expect(getMeta("created_at")).toBeTruthy();
+
+    closeGraph(graph);
+  });
+
+  it("uses default ownerId (ULID) and timezone when opts not provided", () => {
+    const path = tmpPath("create-defaults");
+    created.push(path);
+
+    const graph = createGraph(path);
+
+    const getMeta = (key: string) =>
+      (
+        graph.db.prepare("SELECT value FROM metadata WHERE key = ?").get(key) as
+          | { value: string }
+          | undefined
+      )?.value;
+
+    expect(getMeta("default_timezone")).toBe("UTC");
+    // ULID is 26 chars
+    expect(getMeta("owner_id")).toHaveLength(26);
+
+    closeGraph(graph);
+  });
+
+  it("enables WAL mode", () => {
+    const path = tmpPath("create-wal");
+    created.push(path);
+
+    const graph = createGraph(path);
+    const row = graph.db
+      .query<{ journal_mode: string }, []>("PRAGMA journal_mode")
+      .get();
+    expect(row?.journal_mode).toBe("wal");
+    closeGraph(graph);
+  });
+
+  it("enforces foreign keys", () => {
+    const path = tmpPath("create-fk");
+    created.push(path);
+
+    const graph = createGraph(path);
+    const row = graph.db
+      .query<{ foreign_keys: number }, []>("PRAGMA foreign_keys")
+      .get();
+    expect(row?.foreign_keys).toBe(1);
+    closeGraph(graph);
+  });
+});
+
+describe("schema: all required tables exist", () => {
+  const REQUIRED_TABLES = [
+    "metadata",
+    "entities",
+    "entity_aliases",
+    "edges",
+    "episodes",
+    "entity_evidence",
+    "edge_evidence",
+    "embeddings",
+    "ingestion_runs",
+  ];
+
+  const REQUIRED_FTS_TABLES = ["entities_fts", "edges_fts", "episodes_fts"];
+
+  let path: string;
+  let graph: ReturnType<typeof createGraph>;
+
+  afterEach(() => {
+    if (graph) closeGraph(graph);
+    cleanupFiles([path]);
+  });
+
+  it("has all required base tables", () => {
+    path = tmpPath("schema-tables");
+    graph = createGraph(path);
+
+    const existing = (
+      graph.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const table of REQUIRED_TABLES) {
+      expect(existing).toContain(table);
+    }
+  });
+
+  it("has all required FTS5 virtual tables", () => {
+    path = tmpPath("schema-fts");
+    graph = createGraph(path);
+
+    const existing = (
+      graph.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const table of REQUIRED_FTS_TABLES) {
+      expect(existing).toContain(table);
+    }
+  });
+
+  it("has all required triggers", () => {
+    path = tmpPath("schema-triggers");
+    graph = createGraph(path);
+
+    const REQUIRED_TRIGGERS = [
+      "entities_ai",
+      "entities_ad",
+      "entities_au",
+      "edges_ai",
+      "edges_ad",
+      "edges_au",
+      "episodes_ai",
+      "episodes_ad",
+      "episodes_au",
+    ];
+
+    const existing = (
+      graph.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const trigger of REQUIRED_TRIGGERS) {
+      expect(existing).toContain(trigger);
+    }
+  });
+
+  it("has all required indexes", () => {
+    path = tmpPath("schema-indexes");
+    graph = createGraph(path);
+
+    const REQUIRED_INDEXES = [
+      "idx_entities_type",
+      "idx_entities_name",
+      "idx_aliases_entity",
+      "idx_aliases_name",
+      "idx_edges_source",
+      "idx_edges_target",
+      "idx_edges_type",
+      "idx_edges_kind",
+      "idx_edges_valid",
+      "idx_edges_active",
+      "idx_episodes_identity",
+      "idx_episodes_source",
+      "idx_episodes_time",
+      "idx_episodes_hash",
+      "idx_embeddings_target",
+      "idx_runs_scope",
+    ];
+
+    const existing = (
+      graph.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'index'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const idx of REQUIRED_INDEXES) {
+      expect(existing).toContain(idx);
+    }
+  });
+});
+
+describe("openGraph", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    cleanupFiles(created);
+    created.length = 0;
+  });
+
+  it("opens an existing graph and returns correct handle", () => {
+    const path = tmpPath("open-basic");
+    created.push(path);
+
+    const g1 = createGraph(path, { ownerId: "owner-abc" });
+    const { createdAt } = g1;
+    closeGraph(g1);
+
+    const g2 = openGraph(path);
+    expect(g2.formatVersion).toBe(FORMAT_VERSION);
+    expect(g2.engineVersion).toBe(ENGINE_VERSION);
+    expect(g2.ownerId).toBe("owner-abc");
+    expect(g2.createdAt).toBe(createdAt);
+    closeGraph(g2);
+  });
+
+  it("throws EngramFormatError when file has no metadata table (not a .engram file)", () => {
+    // Use a fresh DB with no schema
+    const path = tmpPath("open-invalid");
+    created.push(path);
+
+    const rawDb = new Database(path, { create: true });
+    rawDb.close();
+
+    expect(() => openGraph(path)).toThrow(EngramFormatError);
+  });
+
+  it("throws EngramFormatError when format_version is missing", () => {
+    const path = tmpPath("open-no-version");
+    created.push(path);
+
+    const rawDb = new Database(path, { create: true });
+    rawDb.exec(
+      "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+    );
+    rawDb.run("INSERT INTO metadata (key, value) VALUES ('owner_id', 'x')");
+    rawDb.close();
+
+    expect(() => openGraph(path)).toThrow(EngramFormatError);
+  });
+
+  it("throws EngramFormatError when format_version is incompatible", () => {
+    const path = tmpPath("open-wrong-version");
+    created.push(path);
+
+    const rawDb = new Database(path, { create: true });
+    rawDb.exec(
+      "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+    );
+    rawDb.run(
+      "INSERT INTO metadata (key, value) VALUES ('format_version', '99.0.0')",
+    );
+    rawDb.close();
+
+    expect(() => openGraph(path)).toThrow(EngramFormatError);
+  });
+});
+
+describe("closeGraph", () => {
+  it("closes the database connection without error", () => {
+    const path = tmpPath("close-basic");
+    const graph = createGraph(path);
+    expect(() => closeGraph(graph)).not.toThrow();
+    cleanupFiles([path]);
+  });
+
+  it("allows the file to be reopened after closing", () => {
+    const path = tmpPath("close-reopen");
+    const g1 = createGraph(path);
+    closeGraph(g1);
+
+    const g2 = openGraph(path);
+    expect(g2.formatVersion).toBe(FORMAT_VERSION);
+    closeGraph(g2);
+
+    cleanupFiles([path]);
+  });
+});
+
+describe("FTS5 triggers", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    cleanupFiles(created);
+    created.length = 0;
+  });
+
+  it("FTS index is updated when an entity is inserted", () => {
+    const path = tmpPath("fts-entity");
+    created.push(path);
+
+    const graph = createGraph(path);
+    const now = new Date().toISOString();
+
+    graph.db
+      .prepare(
+        `INSERT INTO entities (id, canonical_name, entity_type, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("ent-1", "AuthService", "module", now, now);
+
+    const hits = graph.db
+      .prepare("SELECT * FROM entities_fts WHERE entities_fts MATCH ?")
+      .all("AuthService") as unknown[];
+
+    expect(hits.length).toBeGreaterThan(0);
+    closeGraph(graph);
+  });
+
+  it("FTS index is updated when an edge is inserted", () => {
+    const path = tmpPath("fts-edge");
+    created.push(path);
+
+    const graph = createGraph(path);
+    const now = new Date().toISOString();
+
+    // Need source and target entities first (FK)
+    graph.db
+      .prepare(
+        `INSERT INTO entities (id, canonical_name, entity_type, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("ent-a", "ServiceA", "module", now, now);
+    graph.db
+      .prepare(
+        `INSERT INTO entities (id, canonical_name, entity_type, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("ent-b", "ServiceB", "module", now, now);
+
+    graph.db
+      .prepare(
+        `INSERT INTO edges (id, source_id, target_id, relation_type, edge_kind, fact, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "edge-1",
+        "ent-a",
+        "ent-b",
+        "depends_on",
+        "observed",
+        "ServiceA depends on ServiceB for auth",
+        now,
+      );
+
+    const hits = graph.db
+      .prepare("SELECT * FROM edges_fts WHERE edges_fts MATCH ?")
+      .all("auth") as unknown[];
+
+    expect(hits.length).toBeGreaterThan(0);
+    closeGraph(graph);
+  });
+
+  it("FTS index is updated when an episode is inserted", () => {
+    const path = tmpPath("fts-episode");
+    created.push(path);
+
+    const graph = createGraph(path);
+    const now = new Date().toISOString();
+
+    graph.db
+      .prepare(
+        `INSERT INTO episodes (id, source_type, content, content_hash, status, timestamp, ingested_at, extractor_version)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        "ep-1",
+        "manual",
+        "Refactored the payment gateway module",
+        "deadbeef",
+        "active",
+        now,
+        now,
+        "0.1.0",
+      );
+
+    const hits = graph.db
+      .prepare("SELECT * FROM episodes_fts WHERE episodes_fts MATCH ?")
+      .all("payment") as unknown[];
+
+    expect(hits.length).toBeGreaterThan(0);
+    closeGraph(graph);
+  });
+});

--- a/packages/engram-core/test/graph/graph.test.ts
+++ b/packages/engram-core/test/graph/graph.test.ts
@@ -584,7 +584,7 @@ describe("getEvidenceForEntity / getEvidenceForEdge", () => {
     expect(link.episode.content).toBe("commit message");
   });
 
-  test("getEvidenceForEntity returns empty array for entity with no evidence (after direct DB insert)", () => {
+  test("getEvidenceForEntity returns empty array for a nonexistent entity_id", () => {
     // Evidence chain returns empty for non-existent entity_id
     const chain = getEvidenceForEntity(graph, "nonexistent-entity");
     expect(chain).toEqual([]);

--- a/packages/engram-core/test/graph/graph.test.ts
+++ b/packages/engram-core/test/graph/graph.test.ts
@@ -1,0 +1,717 @@
+/**
+ * graph.test.ts — tests for entity, edge, episode CRUD with evidence chains.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EngramGraph } from "../../src/index.js";
+import {
+  addEdge,
+  addEntity,
+  addEpisode,
+  closeGraph,
+  createGraph,
+  EvidenceRequiredError,
+  findEdges,
+  findEntities,
+  getEdge,
+  getEntity,
+  getEpisode,
+  getEvidenceForEdge,
+  getEvidenceForEntity,
+} from "../../src/index.js";
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ---------------------------------------------------------------------------
+// Episode tests
+// ---------------------------------------------------------------------------
+
+describe("addEpisode / getEpisode", () => {
+  test("creates an episode and retrieves it by ID", () => {
+    const ep = addEpisode(graph, {
+      source_type: "git",
+      source_ref: "abc123",
+      content: "Initial commit",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    expect(ep.id).toBeDefined();
+    expect(ep.source_type).toBe("git");
+    expect(ep.source_ref).toBe("abc123");
+    expect(ep.content).toBe("Initial commit");
+    expect(ep.status).toBe("active");
+    expect(ep.content_hash).toBeDefined();
+    expect(ep.content_hash.length).toBe(64); // sha256 hex
+
+    const fetched = getEpisode(graph, ep.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched?.id).toBe(ep.id);
+  });
+
+  test("getEpisode returns null for unknown ID", () => {
+    const result = getEpisode(graph, "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("duplicate (source_type, source_ref) returns existing episode", () => {
+    const ep1 = addEpisode(graph, {
+      source_type: "git",
+      source_ref: "sha-duplicate",
+      content: "First commit",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const ep2 = addEpisode(graph, {
+      source_type: "git",
+      source_ref: "sha-duplicate",
+      content: "Different content",
+      timestamp: "2024-01-02T00:00:00Z",
+    });
+
+    expect(ep2.id).toBe(ep1.id);
+    expect(ep2.content).toBe("First commit");
+  });
+
+  test("episodes without source_ref can be duplicated", () => {
+    const ep1 = addEpisode(graph, {
+      source_type: "manual",
+      content: "Note A",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const ep2 = addEpisode(graph, {
+      source_type: "manual",
+      content: "Note B",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    expect(ep1.id).not.toBe(ep2.id);
+  });
+
+  test("metadata is stored as JSON string", () => {
+    const ep = addEpisode(graph, {
+      source_type: "git",
+      content: "Commit with metadata",
+      timestamp: "2024-01-01T00:00:00Z",
+      metadata: { branch: "main", files: 3 },
+    });
+
+    expect(ep.metadata).toBe(JSON.stringify({ branch: "main", files: 3 }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Entity tests
+// ---------------------------------------------------------------------------
+
+describe("addEntity / getEntity / findEntities", () => {
+  test("creates an entity with evidence and retrieves it", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "Alice is a developer",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const entity = addEntity(
+      graph,
+      {
+        canonical_name: "Alice",
+        entity_type: "person",
+        summary: "Core developer",
+      },
+      [{ episode_id: ep.id, extractor: "manual" }],
+    );
+
+    expect(entity.id).toBeDefined();
+    expect(entity.canonical_name).toBe("Alice");
+    expect(entity.entity_type).toBe("person");
+    expect(entity.status).toBe("active");
+    expect(entity.created_at).toBeDefined();
+    expect(entity.updated_at).toBeDefined();
+
+    const fetched = getEntity(graph, entity.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched?.id).toBe(entity.id);
+  });
+
+  test("getEntity returns null for unknown ID", () => {
+    expect(getEntity(graph, "nope")).toBeNull();
+  });
+
+  test("throws EvidenceRequiredError when evidence array is empty", () => {
+    expect(() =>
+      addEntity(graph, { canonical_name: "Bob", entity_type: "person" }, []),
+    ).toThrow(EvidenceRequiredError);
+  });
+
+  test("throws EvidenceRequiredError when evidence is not provided", () => {
+    expect(() =>
+      // @ts-expect-error intentionally omitting evidence
+      addEntity(graph, { canonical_name: "Bob", entity_type: "person" }),
+    ).toThrow(EvidenceRequiredError);
+  });
+
+  test("findEntities filters by entity_type", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+
+    addEntity(graph, { canonical_name: "Alice", entity_type: "person" }, ev);
+    addEntity(
+      graph,
+      { canonical_name: "auth-service", entity_type: "service" },
+      ev,
+    );
+    addEntity(graph, { canonical_name: "Bob", entity_type: "person" }, ev);
+
+    const people = findEntities(graph, { entity_type: "person" });
+    expect(people.length).toBe(2);
+    expect(people.every((e) => e.entity_type === "person")).toBe(true);
+  });
+
+  test("findEntities filters by canonical_name", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+
+    addEntity(graph, { canonical_name: "Alice", entity_type: "person" }, ev);
+    addEntity(graph, { canonical_name: "Bob", entity_type: "person" }, ev);
+
+    const result = findEntities(graph, { canonical_name: "Alice" });
+    expect(result.length).toBe(1);
+    expect(result[0].canonical_name).toBe("Alice");
+  });
+
+  test("findEntities filters by status", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+
+    addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person", status: "active" },
+      ev,
+    );
+    addEntity(
+      graph,
+      { canonical_name: "Bob", entity_type: "person", status: "inactive" },
+      ev,
+    );
+
+    const active = findEntities(graph, { status: "active" });
+    expect(active.length).toBe(1);
+    expect(active[0].canonical_name).toBe("Alice");
+  });
+
+  test("findEntities returns all when no filters", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+
+    addEntity(graph, { canonical_name: "Alice", entity_type: "person" }, ev);
+    addEntity(graph, { canonical_name: "Bob", entity_type: "person" }, ev);
+
+    const all = findEntities(graph);
+    expect(all.length).toBe(2);
+  });
+
+  test("evidence confidence defaults to 1.0", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const entity = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      [{ episode_id: ep.id, extractor: "manual" }],
+    );
+
+    const links = getEvidenceForEntity(graph, entity.id);
+    expect(links.length).toBe(1);
+    expect(links[0].confidence).toBe(1.0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge tests
+// ---------------------------------------------------------------------------
+
+describe("addEdge / getEdge / findEdges", () => {
+  test("creates an edge with evidence and retrieves it", () => {
+    const ep = addEpisode(graph, {
+      source_type: "git",
+      content: "Alice authored auth-service",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "git-blame" }];
+
+    const alice = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      ev,
+    );
+    const svc = addEntity(
+      graph,
+      { canonical_name: "auth-service", entity_type: "service" },
+      ev,
+    );
+
+    const edge = addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: svc.id,
+        relation_type: "maintains",
+        edge_kind: "observed",
+        fact: "Alice maintains auth-service",
+      },
+      ev,
+    );
+
+    expect(edge.id).toBeDefined();
+    expect(edge.source_id).toBe(alice.id);
+    expect(edge.target_id).toBe(svc.id);
+    expect(edge.relation_type).toBe("maintains");
+    expect(edge.edge_kind).toBe("observed");
+    expect(edge.weight).toBe(1.0);
+    expect(edge.confidence).toBe(1.0);
+    expect(edge.invalidated_at).toBeNull();
+
+    const fetched = getEdge(graph, edge.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched?.id).toBe(edge.id);
+  });
+
+  test("getEdge returns null for unknown ID", () => {
+    expect(getEdge(graph, "nope")).toBeNull();
+  });
+
+  test("throws EvidenceRequiredError when evidence array is empty", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+    const alice = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      ev,
+    );
+    const bob = addEntity(
+      graph,
+      { canonical_name: "Bob", entity_type: "person" },
+      ev,
+    );
+
+    expect(() =>
+      addEdge(
+        graph,
+        {
+          source_id: alice.id,
+          target_id: bob.id,
+          relation_type: "knows",
+          edge_kind: "asserted",
+          fact: "Alice knows Bob",
+        },
+        [],
+      ),
+    ).toThrow(EvidenceRequiredError);
+  });
+
+  test("findEdges filters by source_id", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+    const alice = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      ev,
+    );
+    const bob = addEntity(
+      graph,
+      { canonical_name: "Bob", entity_type: "person" },
+      ev,
+    );
+    const carol = addEntity(
+      graph,
+      { canonical_name: "Carol", entity_type: "person" },
+      ev,
+    );
+
+    addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: bob.id,
+        relation_type: "knows",
+        edge_kind: "asserted",
+        fact: "A knows B",
+      },
+      ev,
+    );
+    addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: carol.id,
+        relation_type: "knows",
+        edge_kind: "asserted",
+        fact: "A knows C",
+      },
+      ev,
+    );
+    addEdge(
+      graph,
+      {
+        source_id: bob.id,
+        target_id: carol.id,
+        relation_type: "knows",
+        edge_kind: "asserted",
+        fact: "B knows C",
+      },
+      ev,
+    );
+
+    const aliceEdges = findEdges(graph, { source_id: alice.id });
+    expect(aliceEdges.length).toBe(2);
+    expect(aliceEdges.every((e) => e.source_id === alice.id)).toBe(true);
+  });
+
+  test("findEdges filters by target_id", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+    const alice = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      ev,
+    );
+    const bob = addEntity(
+      graph,
+      { canonical_name: "Bob", entity_type: "person" },
+      ev,
+    );
+    const carol = addEntity(
+      graph,
+      { canonical_name: "Carol", entity_type: "person" },
+      ev,
+    );
+
+    addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: carol.id,
+        relation_type: "knows",
+        edge_kind: "asserted",
+        fact: "A knows C",
+      },
+      ev,
+    );
+    addEdge(
+      graph,
+      {
+        source_id: bob.id,
+        target_id: carol.id,
+        relation_type: "knows",
+        edge_kind: "asserted",
+        fact: "B knows C",
+      },
+      ev,
+    );
+
+    const toCarol = findEdges(graph, { target_id: carol.id });
+    expect(toCarol.length).toBe(2);
+  });
+
+  test("findEdges filters by edge_kind", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+    const alice = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      ev,
+    );
+    const bob = addEntity(
+      graph,
+      { canonical_name: "Bob", entity_type: "person" },
+      ev,
+    );
+
+    addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: bob.id,
+        relation_type: "knows",
+        edge_kind: "observed",
+        fact: "fact A",
+      },
+      ev,
+    );
+    addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: bob.id,
+        relation_type: "works_with",
+        edge_kind: "inferred",
+        fact: "fact B",
+      },
+      ev,
+    );
+
+    const observed = findEdges(graph, { edge_kind: "observed" });
+    expect(observed.length).toBe(1);
+    expect(observed[0].edge_kind).toBe("observed");
+  });
+
+  test("findEdges active_only excludes invalidated edges", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+    const alice = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      ev,
+    );
+    const bob = addEntity(
+      graph,
+      { canonical_name: "Bob", entity_type: "person" },
+      ev,
+    );
+
+    const edge1 = addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: bob.id,
+        relation_type: "knows",
+        edge_kind: "observed",
+        fact: "active",
+      },
+      ev,
+    );
+    const edge2 = addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: bob.id,
+        relation_type: "knows",
+        edge_kind: "observed",
+        fact: "invalidated",
+      },
+      ev,
+    );
+
+    // Manually invalidate edge2
+    graph.db.run("UPDATE edges SET invalidated_at = ? WHERE id = ?", [
+      new Date().toISOString(),
+      edge2.id,
+    ]);
+
+    const active = findEdges(graph, { active_only: true });
+    expect(active.length).toBe(1);
+    expect(active[0].id).toBe(edge1.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evidence chain tests
+// ---------------------------------------------------------------------------
+
+describe("getEvidenceForEntity / getEvidenceForEdge", () => {
+  test("getEvidenceForEntity returns evidence with episode details", () => {
+    const ep = addEpisode(graph, {
+      source_type: "git",
+      source_ref: "abc",
+      content: "commit message",
+      actor: "Alice",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+
+    const entity = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      [{ episode_id: ep.id, extractor: "git-log", confidence: 0.95 }],
+    );
+
+    const chain = getEvidenceForEntity(graph, entity.id);
+    expect(chain.length).toBe(1);
+
+    const link = chain[0];
+    expect(link.episode_id).toBe(ep.id);
+    expect(link.extractor).toBe("git-log");
+    expect(link.confidence).toBe(0.95);
+    expect(link.episode.source_type).toBe("git");
+    expect(link.episode.actor).toBe("Alice");
+    expect(link.episode.content).toBe("commit message");
+  });
+
+  test("getEvidenceForEntity returns empty array for entity with no evidence (after direct DB insert)", () => {
+    // Evidence chain returns empty for non-existent entity_id
+    const chain = getEvidenceForEntity(graph, "nonexistent-entity");
+    expect(chain).toEqual([]);
+  });
+
+  test("getEvidenceForEntity supports multiple evidence links", () => {
+    const ep1 = addEpisode(graph, {
+      source_type: "git",
+      content: "A",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ep2 = addEpisode(graph, {
+      source_type: "github",
+      content: "B",
+      timestamp: "2024-01-02T00:00:00Z",
+    });
+
+    const entity = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      [
+        { episode_id: ep1.id, extractor: "git-log" },
+        { episode_id: ep2.id, extractor: "github-pr" },
+      ],
+    );
+
+    const chain = getEvidenceForEntity(graph, entity.id);
+    expect(chain.length).toBe(2);
+    const extractors = chain.map((l) => l.extractor).sort();
+    expect(extractors).toEqual(["git-log", "github-pr"]);
+  });
+
+  test("getEvidenceForEdge returns evidence with episode details", () => {
+    const ep = addEpisode(graph, {
+      source_type: "git",
+      content: "Alice authored the module",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "git-blame", confidence: 0.8 }];
+
+    const alice = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      ev,
+    );
+    const mod = addEntity(
+      graph,
+      { canonical_name: "auth", entity_type: "module" },
+      ev,
+    );
+
+    const edge = addEdge(
+      graph,
+      {
+        source_id: alice.id,
+        target_id: mod.id,
+        relation_type: "authors",
+        edge_kind: "observed",
+        fact: "Alice authors auth module",
+      },
+      ev,
+    );
+
+    const chain = getEvidenceForEdge(graph, edge.id);
+    expect(chain.length).toBe(1);
+    expect(chain[0].extractor).toBe("git-blame");
+    expect(chain[0].confidence).toBe(0.8);
+    expect(chain[0].episode.source_type).toBe("git");
+  });
+
+  test("getEvidenceForEdge returns empty array for nonexistent edge_id", () => {
+    const chain = getEvidenceForEdge(graph, "nonexistent-edge");
+    expect(chain).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Evidence-first invariant
+// ---------------------------------------------------------------------------
+
+describe("evidence-first invariant", () => {
+  test("EvidenceRequiredError is thrown with descriptive message for addEntity", () => {
+    let err: Error | undefined;
+    try {
+      addEntity(graph, { canonical_name: "X", entity_type: "person" }, []);
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeInstanceOf(EvidenceRequiredError);
+    expect(err?.message).toContain("addEntity");
+  });
+
+  test("EvidenceRequiredError is thrown with descriptive message for addEdge", () => {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "test",
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+    const ev = [{ episode_id: ep.id, extractor: "manual" }];
+    const a = addEntity(
+      graph,
+      { canonical_name: "A", entity_type: "person" },
+      ev,
+    );
+    const b = addEntity(
+      graph,
+      { canonical_name: "B", entity_type: "person" },
+      ev,
+    );
+
+    let err: Error | undefined;
+    try {
+      addEdge(
+        graph,
+        {
+          source_id: a.id,
+          target_id: b.id,
+          relation_type: "r",
+          edge_kind: "asserted",
+          fact: "f",
+        },
+        [],
+      );
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeInstanceOf(EvidenceRequiredError);
+    expect(err?.message).toContain("addEdge");
+  });
+});

--- a/packages/engram-mcp/src/server.ts
+++ b/packages/engram-mcp/src/server.ts
@@ -4,4 +4,215 @@
  * Read-heavy, evidence-based write surface over the engram knowledge graph.
  */
 
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { closeGraph, openGraph } from "engram-core";
+import {
+  ENGRAM_RESOURCES,
+  readRecentEpisodes,
+  readStats,
+} from "./resources.js";
+import {
+  GET_CONTEXT_TOOL,
+  type GetContextInput,
+  handleGetContext,
+} from "./tools/context.js";
+import {
+  GET_DECAY_TOOL,
+  type GetDecayInput,
+  handleGetDecay,
+} from "./tools/decay.js";
+import {
+  ADD_ENTITY_TOOL,
+  type AddEntityInput,
+  GET_ENTITY_TOOL,
+  type GetEntityInput,
+  handleAddEntity,
+  handleGetEntity,
+} from "./tools/entity.js";
+import {
+  GET_HISTORY_TOOL,
+  type GetHistoryInput,
+  handleGetHistory,
+} from "./tools/history.js";
+import { handleSearch, SEARCH_TOOL, type SearchInput } from "./tools/search.js";
+import {
+  ADD_EDGE_TOOL,
+  ADD_EPISODE_TOOL,
+  type AddEdgeInput,
+  type AddEpisodeInput,
+  handleAddEdge,
+  handleAddEpisode,
+} from "./tools/write.js";
+
 export const MCP_SERVER_NAME = "engram";
+
+const ALL_TOOLS = [
+  SEARCH_TOOL,
+  GET_ENTITY_TOOL,
+  GET_CONTEXT_TOOL,
+  GET_DECAY_TOOL,
+  GET_HISTORY_TOOL,
+  ADD_EPISODE_TOOL,
+  ADD_ENTITY_TOOL,
+  ADD_EDGE_TOOL,
+];
+
+/**
+ * Creates and configures the engram MCP server.
+ * Does not connect to transport — call server.connect(transport) to start.
+ */
+export function createServer(dbPath: string) {
+  const graph = openGraph(dbPath);
+
+  const server = new Server(
+    { name: MCP_SERVER_NAME, version: "0.1.0" },
+    { capabilities: { tools: {}, resources: {} } },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Tool handlers
+  // ---------------------------------------------------------------------------
+
+  server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: ALL_TOOLS,
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, (request) => {
+    const { name, arguments: args } = request.params;
+    const input = (args ?? {}) as Record<string, unknown>;
+
+    try {
+      let result: unknown;
+
+      switch (name) {
+        case "engram_search":
+          result = handleSearch(graph, input as SearchInput);
+          break;
+        case "engram_get_entity":
+          result = handleGetEntity(graph, input as GetEntityInput);
+          break;
+        case "engram_get_context":
+          result = handleGetContext(graph, input as GetContextInput);
+          break;
+        case "engram_get_decay":
+          result = handleGetDecay(graph, input as GetDecayInput);
+          break;
+        case "engram_get_history":
+          result = handleGetHistory(graph, input as GetHistoryInput);
+          break;
+        case "engram_add_episode":
+          result = handleAddEpisode(graph, input as AddEpisodeInput);
+          break;
+        case "engram_add_entity":
+          result = handleAddEntity(graph, input as AddEntityInput);
+          break;
+        case "engram_add_edge":
+          result = handleAddEdge(graph, input as AddEdgeInput);
+          break;
+        default:
+          return {
+            isError: true,
+            content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+          };
+      }
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        isError: true,
+        content: [{ type: "text" as const, text: `Error: ${message}` }],
+      };
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Resource handlers
+  // ---------------------------------------------------------------------------
+
+  server.setRequestHandler(ListResourcesRequestSchema, () => ({
+    resources: ENGRAM_RESOURCES,
+  }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, (request) => {
+    const { uri } = request.params;
+
+    switch (uri) {
+      case "engram://stats": {
+        const stats = readStats(graph);
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "application/json",
+              text: JSON.stringify(stats),
+            },
+          ],
+        };
+      }
+      case "engram://recent": {
+        const recent = readRecentEpisodes(graph);
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "application/json",
+              text: JSON.stringify(recent),
+            },
+          ],
+        };
+      }
+      default:
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: "text/plain",
+              text: `Unknown resource: ${uri}`,
+            },
+          ],
+        };
+    }
+  });
+
+  return { server, graph };
+}
+
+/**
+ * Main entrypoint: open the graph, connect to stdio transport.
+ */
+async function main() {
+  const dbPath = process.env.ENGRAM_DB ?? ".engram";
+  const { server, graph } = createServer(dbPath);
+  const transport = new StdioServerTransport();
+
+  const shutdown = () => {
+    try {
+      closeGraph(graph);
+    } catch {
+      // ignore close errors during shutdown
+    }
+    process.exit(0);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  await server.connect(transport);
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("engram-mcp: fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/packages/engramark/src/report.ts
+++ b/packages/engramark/src/report.ts
@@ -5,4 +5,100 @@
  * Q&A datasets built from public repositories (Fastify for v0.1).
  */
 
-export const BENCHMARK_VERSION = "0.1.0";
+export type {
+  BenchmarkReport,
+  BenchmarkResult,
+  RetrievalMetrics,
+} from "./metrics.js";
+export {
+  computeMetrics,
+  estimateContextSize,
+  mrr,
+  recallAtK,
+} from "./metrics.js";
+export { BENCHMARK_VERSION } from "./version.js";
+
+import type { BenchmarkReport, BenchmarkResult } from "./metrics.js";
+
+/**
+ * Aggregates a list of BenchmarkResults into a full BenchmarkReport.
+ *
+ * @param results - Array of per-question results.
+ * @param baseline - Baseline name (e.g. 'vcs-only', 'grep-baseline').
+ * @returns Aggregated BenchmarkReport.
+ */
+export function generateReport(
+  results: BenchmarkResult[],
+  baseline: string,
+): BenchmarkReport {
+  const total = results.length;
+  const avgRecall =
+    total > 0
+      ? results.reduce((sum, r) => sum + r.metrics.recall_at_k, 0) / total
+      : 0;
+  const avgMrr =
+    total > 0 ? results.reduce((sum, r) => sum + r.metrics.mrr, 0) / total : 0;
+  const avgLatency =
+    total > 0 ? results.reduce((sum, r) => sum + r.latency_ms, 0) / total : 0;
+
+  return {
+    run_at: new Date().toISOString(),
+    baseline,
+    results,
+    aggregate: {
+      avg_recall_at_5: avgRecall,
+      avg_mrr: avgMrr,
+      avg_latency_ms: avgLatency,
+      total_questions: total,
+    },
+  };
+}
+
+/**
+ * Prints a formatted benchmark report table to stdout.
+ *
+ * @param report - BenchmarkReport to print.
+ */
+export function printReport(report: BenchmarkReport): void {
+  const { aggregate, baseline, run_at, results } = report;
+
+  console.log(`\nEngRAMark Report — ${baseline}`);
+  console.log(`Run at: ${run_at}`);
+  console.log("─".repeat(80));
+
+  // Header
+  console.log(
+    padRight("Question ID", 22) +
+      padRight("Category", 12) +
+      padRight("Recall@5", 10) +
+      padRight("MRR", 8) +
+      padRight("Ctx(tok)", 10) +
+      "Latency(ms)",
+  );
+  console.log("─".repeat(80));
+
+  // Per-question rows
+  for (const r of results) {
+    const { metrics } = r;
+    console.log(
+      padRight(r.question_id, 22) +
+        padRight(r.category, 12) +
+        padRight(metrics.recall_at_k.toFixed(2), 10) +
+        padRight(metrics.mrr.toFixed(2), 8) +
+        padRight(String(metrics.avg_context_size), 10) +
+        r.latency_ms.toFixed(1),
+    );
+  }
+
+  console.log("─".repeat(80));
+  console.log("Aggregate:");
+  console.log(`  Total questions : ${aggregate.total_questions}`);
+  console.log(`  Avg Recall@5    : ${aggregate.avg_recall_at_5.toFixed(4)}`);
+  console.log(`  Avg MRR         : ${aggregate.avg_mrr.toFixed(4)}`);
+  console.log(`  Avg Latency(ms) : ${aggregate.avg_latency_ms.toFixed(2)}`);
+  console.log("");
+}
+
+function padRight(s: string, width: number): string {
+  return s.length >= width ? `${s.slice(0, width - 1)} ` : s.padEnd(width);
+}


### PR DESCRIPTION
## Summary

- Implements the foundational `.engram` SQLite schema: all 9 tables, all indexes, FTS5 virtual tables, and FTS5 sync triggers
- Adds `createGraph`, `openGraph`, `closeGraph` lifecycle operations in `packages/engram-core/src/format/`
- Switches from `better-sqlite3` to `bun:sqlite` (native Bun SQLite — same API, no native compilation required)
- 18 tests covering create, open, close, reopen, schema validation, WAL mode, FK enforcement, FTS trigger behavior

## Acceptance Criteria

- [x] `createGraph(path, opts?)` creates a new `.engram` file with the full schema
- [x] `openGraph(path)` opens an existing `.engram` file and validates `format_version`
- [x] `closeGraph(graph)` cleanly closes the database connection
- [x] All tables created per spec: `metadata`, `entities`, `entity_aliases`, `edges`, `episodes`, `entity_evidence`, `edge_evidence`, `embeddings`, `ingestion_runs`
- [x] All indexes created per spec (including partial `idx_edges_active` and unique `idx_episodes_identity`)
- [x] FTS5 virtual tables: `entities_fts`, `edges_fts`, `episodes_fts`
- [x] FTS5 sync triggers (INSERT/DELETE/UPDATE) for all three content tables
- [x] Required metadata keys on create: `format_version`, `engine_version`, `created_at`, `owner_id`, `default_timezone`
- [x] Schema version `0.1.0`
- [x] WAL mode enabled
- [x] Foreign keys enforced
- [x] Tests pass

## Test plan

- [x] `bun test` — 18 tests pass
- [x] `bun run build` — builds successfully
- [x] `bun run lint` — no lint errors

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)