### PR TITLE
feat: entity resolution and aliases

### DIFF
--- a/packages/engram-core/src/graph/aliases.ts
+++ b/packages/engram-core/src/graph/aliases.ts
@@ -1,0 +1,139 @@
+/**
+ * aliases.ts — entity alias management and resolution.
+ */
+
+import { ulid } from "ulid";
+import type { EngramGraph } from "../format/index.js";
+import type { Entity } from "./entities.js";
+import { EntityNotFoundError } from "./errors.js";
+
+export interface AliasInput {
+  alias: string;
+  entity_id: string;
+  valid_from?: string; // ISO8601 UTC
+  valid_until?: string; // ISO8601 UTC
+  episode_id?: string; // FK to episodes.id — evidence of the rename
+}
+
+export interface Alias {
+  id: string;
+  entity_id: string;
+  alias: string;
+  valid_from: string | null;
+  valid_until: string | null;
+  episode_id: string | null;
+  created_at: string;
+}
+
+/**
+ * Resolves an entity by exact canonical_name match or by active alias.
+ * Active aliases are those where valid_until IS NULL or valid_until > now.
+ * If `type` is provided, narrows results to that entity_type.
+ * Returns the first match or null — never auto-creates.
+ */
+export function resolveEntity(
+  graph: EngramGraph,
+  name: string,
+  type?: string,
+): Entity | null {
+  // Step 1: Try exact canonical_name match
+  if (type !== undefined) {
+    const row = graph.db
+      .query<Entity, [string, string]>(
+        "SELECT * FROM entities WHERE canonical_name = ? AND entity_type = ? LIMIT 1",
+      )
+      .get(name, type);
+    if (row) return row;
+  } else {
+    const row = graph.db
+      .query<Entity, [string]>(
+        "SELECT * FROM entities WHERE canonical_name = ? LIMIT 1",
+      )
+      .get(name);
+    if (row) return row;
+  }
+
+  // Step 2: Try active alias match
+  const now = new Date().toISOString();
+
+  if (type !== undefined) {
+    const row = graph.db
+      .query<Entity, [string, string, string]>(
+        `SELECT e.* FROM entities e
+         JOIN entity_aliases a ON a.entity_id = e.id
+         WHERE a.alias = ?
+           AND (a.valid_until IS NULL OR a.valid_until > ?)
+           AND e.entity_type = ?
+         LIMIT 1`,
+      )
+      .get(name, now, type);
+    return row ?? null;
+  } else {
+    const row = graph.db
+      .query<Entity, [string, string]>(
+        `SELECT e.* FROM entities e
+         JOIN entity_aliases a ON a.entity_id = e.id
+         WHERE a.alias = ?
+           AND (a.valid_until IS NULL OR a.valid_until > ?)
+         LIMIT 1`,
+      )
+      .get(name, now);
+    return row ?? null;
+  }
+}
+
+/**
+ * Creates an alias for an existing entity.
+ * Throws EntityNotFoundError if the entity_id does not exist.
+ */
+export function addEntityAlias(graph: EngramGraph, input: AliasInput): Alias {
+  // Verify the entity exists
+  const entity = graph.db
+    .query<{ id: string }, [string]>(
+      "SELECT id FROM entities WHERE id = ? LIMIT 1",
+    )
+    .get(input.entity_id);
+
+  if (!entity) {
+    throw new EntityNotFoundError(input.entity_id);
+  }
+
+  const id = ulid();
+  const now = new Date().toISOString();
+
+  graph.db
+    .prepare<
+      void,
+      [
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+        string | null,
+        string,
+      ]
+    >(
+      `INSERT INTO entity_aliases (id, entity_id, alias, valid_from, valid_until, episode_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      input.entity_id,
+      input.alias,
+      input.valid_from ?? null,
+      input.valid_until ?? null,
+      input.episode_id ?? null,
+      now,
+    );
+
+  const row = graph.db
+    .query<Alias, [string]>("SELECT * FROM entity_aliases WHERE id = ?")
+    .get(id);
+
+  if (!row) {
+    throw new Error(`addEntityAlias: failed to retrieve inserted alias ${id}`);
+  }
+
+  return row;
+}

--- a/packages/engram-core/src/graph/aliases.ts
+++ b/packages/engram-core/src/graph/aliases.ts
@@ -40,14 +40,14 @@ export function resolveEntity(
   if (type !== undefined) {
     const row = graph.db
       .query<Entity, [string, string]>(
-        "SELECT * FROM entities WHERE canonical_name = ? AND entity_type = ? LIMIT 1",
+        "SELECT * FROM entities WHERE canonical_name = ? AND entity_type = ? ORDER BY created_at ASC LIMIT 1",
       )
       .get(name, type);
     if (row) return row;
   } else {
     const row = graph.db
       .query<Entity, [string]>(
-        "SELECT * FROM entities WHERE canonical_name = ? LIMIT 1",
+        "SELECT * FROM entities WHERE canonical_name = ? ORDER BY created_at ASC LIMIT 1",
       )
       .get(name);
     if (row) return row;
@@ -58,26 +58,30 @@ export function resolveEntity(
 
   if (type !== undefined) {
     const row = graph.db
+      .query<Entity, [string, string, string, string]>(
+        `SELECT e.* FROM entities e
+         JOIN entity_aliases a ON a.entity_id = e.id
+         WHERE a.alias = ?
+           AND (a.valid_from IS NULL OR a.valid_from <= ?)
+           AND (a.valid_until IS NULL OR a.valid_until > ?)
+           AND e.entity_type = ?
+         ORDER BY a.created_at DESC, e.created_at ASC
+         LIMIT 1`,
+      )
+      .get(name, now, now, type);
+    return row ?? null;
+  } else {
+    const row = graph.db
       .query<Entity, [string, string, string]>(
         `SELECT e.* FROM entities e
          JOIN entity_aliases a ON a.entity_id = e.id
          WHERE a.alias = ?
+           AND (a.valid_from IS NULL OR a.valid_from <= ?)
            AND (a.valid_until IS NULL OR a.valid_until > ?)
-           AND e.entity_type = ?
+         ORDER BY a.created_at DESC, e.created_at ASC
          LIMIT 1`,
       )
-      .get(name, now, type);
-    return row ?? null;
-  } else {
-    const row = graph.db
-      .query<Entity, [string, string]>(
-        `SELECT e.* FROM entities e
-         JOIN entity_aliases a ON a.entity_id = e.id
-         WHERE a.alias = ?
-           AND (a.valid_until IS NULL OR a.valid_until > ?)
-         LIMIT 1`,
-      )
-      .get(name, now);
+      .get(name, now, now);
     return row ?? null;
   }
 }
@@ -101,23 +105,26 @@ export function addEntityAlias(graph: EngramGraph, input: AliasInput): Alias {
   const id = ulid();
   const now = new Date().toISOString();
 
-  graph.db
-    .prepare<
-      void,
-      [
-        string,
-        string,
-        string,
-        string | null,
-        string | null,
-        string | null,
-        string,
-      ]
-    >(
-      `INSERT INTO entity_aliases (id, entity_id, alias, valid_from, valid_until, episode_id, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-    )
-    .run(
+  const insertStmt = graph.db.prepare<
+    void,
+    [
+      string,
+      string,
+      string,
+      string | null,
+      string | null,
+      string | null,
+      string,
+    ]
+  >(
+    `INSERT INTO entity_aliases (id, entity_id, alias, valid_from, valid_until, episode_id, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  );
+
+  let row: Alias | null = null;
+
+  graph.db.transaction(() => {
+    insertStmt.run(
       id,
       input.entity_id,
       input.alias,
@@ -127,9 +134,11 @@ export function addEntityAlias(graph: EngramGraph, input: AliasInput): Alias {
       now,
     );
 
-  const row = graph.db
-    .query<Alias, [string]>("SELECT * FROM entity_aliases WHERE id = ?")
-    .get(id);
+    row =
+      graph.db
+        .query<Alias, [string]>("SELECT * FROM entity_aliases WHERE id = ?")
+        .get(id) ?? null;
+  })();
 
   if (!row) {
     throw new Error(`addEntityAlias: failed to retrieve inserted alias ${id}`);

--- a/packages/engram-core/src/graph/index.ts
+++ b/packages/engram-core/src/graph/index.ts
@@ -2,6 +2,8 @@
  * graph/index.ts — re-exports for the graph CRUD module.
  */
 
+export type { Alias, AliasInput } from "./aliases.js";
+export { addEntityAlias, resolveEntity } from "./aliases.js";
 export type { Edge, EdgeInput, FindEdgesQuery } from "./edges.js";
 export { addEdge, findEdges, getEdge } from "./edges.js";
 export type {

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -16,6 +16,8 @@ export {
   SCHEMA_DDL,
 } from "./format/index.js";
 export type {
+  Alias,
+  AliasInput,
   Edge,
   EdgeInput,
   Entity,
@@ -30,6 +32,7 @@ export type {
 export {
   addEdge,
   addEntity,
+  addEntityAlias,
   addEpisode,
   EdgeNotFoundError,
   EntityNotFoundError,
@@ -41,4 +44,5 @@ export {
   getEpisode,
   getEvidenceForEdge,
   getEvidenceForEntity,
+  resolveEntity,
 } from "./graph/index.js";

--- a/packages/engram-core/test/graph/aliases.test.ts
+++ b/packages/engram-core/test/graph/aliases.test.ts
@@ -1,0 +1,275 @@
+/**
+ * aliases.test.ts — tests for entity resolution and alias management.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EngramGraph } from "../../src/index.js";
+import {
+  addEntity,
+  addEntityAlias,
+  addEpisode,
+  closeGraph,
+  createGraph,
+  EntityNotFoundError,
+  resolveEntity,
+} from "../../src/index.js";
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function makeEpisode() {
+  return addEpisode(graph, {
+    source_type: "manual",
+    content: "test evidence",
+    timestamp: "2024-01-01T00:00:00Z",
+  });
+}
+
+function makeEntity(
+  canonical_name: string,
+  entity_type: string,
+  ep_id?: string,
+) {
+  const ep_id_ = ep_id ?? makeEpisode().id;
+  return addEntity(graph, { canonical_name, entity_type }, [
+    { episode_id: ep_id_, extractor: "manual" },
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// resolveEntity — exact canonical_name match
+// ---------------------------------------------------------------------------
+
+describe("resolveEntity — exact canonical_name match", () => {
+  test("returns entity by exact canonical_name", () => {
+    const entity = makeEntity("Alice", "person");
+    const result = resolveEntity(graph, "Alice");
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(entity.id);
+    expect(result?.canonical_name).toBe("Alice");
+  });
+
+  test("returns null when no entity matches", () => {
+    makeEntity("Alice", "person");
+    const result = resolveEntity(graph, "Bob");
+    expect(result).toBeNull();
+  });
+
+  test("returns null on empty graph", () => {
+    expect(resolveEntity(graph, "Alice")).toBeNull();
+  });
+
+  test("type filter narrows exact match — matching type", () => {
+    makeEntity("Alice", "person");
+    const result = resolveEntity(graph, "Alice", "person");
+    expect(result).not.toBeNull();
+    expect(result?.entity_type).toBe("person");
+  });
+
+  test("type filter narrows exact match — wrong type returns null", () => {
+    makeEntity("Alice", "person");
+    const result = resolveEntity(graph, "Alice", "service");
+    expect(result).toBeNull();
+  });
+
+  test("resolves the correct entity when multiple entities exist", () => {
+    makeEntity("Alice", "person");
+    const bob = makeEntity("Bob", "person");
+    const result = resolveEntity(graph, "Bob");
+    expect(result?.id).toBe(bob.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addEntityAlias
+// ---------------------------------------------------------------------------
+
+describe("addEntityAlias", () => {
+  test("creates an alias for an existing entity", () => {
+    const entity = makeEntity("Alice", "person");
+    const alias = addEntityAlias(graph, {
+      alias: "Al",
+      entity_id: entity.id,
+    });
+
+    expect(alias.id).toBeDefined();
+    expect(alias.entity_id).toBe(entity.id);
+    expect(alias.alias).toBe("Al");
+    expect(alias.valid_from).toBeNull();
+    expect(alias.valid_until).toBeNull();
+    expect(alias.episode_id).toBeNull();
+    expect(alias.created_at).toBeDefined();
+  });
+
+  test("creates an alias with valid_from and valid_until", () => {
+    const entity = makeEntity("Alice", "person");
+    const alias = addEntityAlias(graph, {
+      alias: "Alicia",
+      entity_id: entity.id,
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2024-06-01T00:00:00Z",
+    });
+
+    expect(alias.valid_from).toBe("2024-01-01T00:00:00Z");
+    expect(alias.valid_until).toBe("2024-06-01T00:00:00Z");
+  });
+
+  test("creates an alias with episode_id as evidence of rename", () => {
+    const ep = makeEpisode();
+    const entity = makeEntity("Alice", "person");
+    const alias = addEntityAlias(graph, {
+      alias: "Alicia",
+      entity_id: entity.id,
+      episode_id: ep.id,
+    });
+
+    expect(alias.episode_id).toBe(ep.id);
+  });
+
+  test("throws EntityNotFoundError when entity_id does not exist", () => {
+    expect(() =>
+      addEntityAlias(graph, {
+        alias: "Ghost",
+        entity_id: "nonexistent-id",
+      }),
+    ).toThrow(EntityNotFoundError);
+  });
+
+  test("EntityNotFoundError message contains the unknown id", () => {
+    let err: Error | undefined;
+    try {
+      addEntityAlias(graph, { alias: "Ghost", entity_id: "bad-id" });
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).toBeInstanceOf(EntityNotFoundError);
+    expect(err?.message).toContain("bad-id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEntity — alias match
+// ---------------------------------------------------------------------------
+
+describe("resolveEntity — alias match", () => {
+  test("resolves entity by active alias (no temporal bounds)", () => {
+    const entity = makeEntity("Alice", "person");
+    addEntityAlias(graph, { alias: "Al", entity_id: entity.id });
+
+    const result = resolveEntity(graph, "Al");
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(entity.id);
+  });
+
+  test("resolves entity by alias when canonical_name does not match", () => {
+    const entity = makeEntity("Alice", "person");
+    addEntityAlias(graph, { alias: "Alicia", entity_id: entity.id });
+
+    expect(resolveEntity(graph, "Alicia")?.id).toBe(entity.id);
+    expect(resolveEntity(graph, "Alice")?.id).toBe(entity.id);
+  });
+
+  test("type filter works with alias match", () => {
+    const person = makeEntity("Alice", "person");
+    addEntityAlias(graph, { alias: "Al", entity_id: person.id });
+
+    const result = resolveEntity(graph, "Al", "person");
+    expect(result?.id).toBe(person.id);
+  });
+
+  test("type filter excludes alias match of wrong type", () => {
+    const person = makeEntity("Alice", "person");
+    addEntityAlias(graph, { alias: "Al", entity_id: person.id });
+
+    const result = resolveEntity(graph, "Al", "service");
+    expect(result).toBeNull();
+  });
+
+  test("returns null when alias does not exist", () => {
+    makeEntity("Alice", "person");
+    expect(resolveEntity(graph, "unknown-alias")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEntity — temporal alias windows
+// ---------------------------------------------------------------------------
+
+describe("resolveEntity — temporal alias windows", () => {
+  test("active alias with valid_until = NULL is returned", () => {
+    const entity = makeEntity("Alice", "person");
+    addEntityAlias(graph, {
+      alias: "Al",
+      entity_id: entity.id,
+      valid_from: "2020-01-01T00:00:00Z",
+      valid_until: undefined, // still active
+    });
+
+    expect(resolveEntity(graph, "Al")?.id).toBe(entity.id);
+  });
+
+  test("alias with valid_until in the future is returned", () => {
+    const entity = makeEntity("Alice", "person");
+    addEntityAlias(graph, {
+      alias: "Al",
+      entity_id: entity.id,
+      valid_until: "2099-12-31T23:59:59Z",
+    });
+
+    expect(resolveEntity(graph, "Al")?.id).toBe(entity.id);
+  });
+
+  test("alias with valid_until in the past is not returned", () => {
+    const entity = makeEntity("Alice", "person");
+    addEntityAlias(graph, {
+      alias: "Al",
+      entity_id: entity.id,
+      valid_until: "2000-01-01T00:00:00Z", // already expired
+    });
+
+    expect(resolveEntity(graph, "Al")).toBeNull();
+  });
+
+  test("expired alias does not shadow canonical_name resolution", () => {
+    // A different entity has the alias "Al" but it has expired
+    const entity1 = makeEntity("Alice", "person");
+    const entity2 = makeEntity("Al", "person");
+    addEntityAlias(graph, {
+      alias: "Al",
+      entity_id: entity1.id,
+      valid_until: "2000-01-01T00:00:00Z", // expired
+    });
+
+    // Canonical match on entity2 should win
+    const result = resolveEntity(graph, "Al");
+    expect(result?.id).toBe(entity2.id);
+  });
+
+  test("multiple aliases: only active alias is returned", () => {
+    const entity = makeEntity("Alice", "person");
+    addEntityAlias(graph, {
+      alias: "OldAlias",
+      entity_id: entity.id,
+      valid_until: "2000-01-01T00:00:00Z", // expired
+    });
+    addEntityAlias(graph, {
+      alias: "NewAlias",
+      entity_id: entity.id,
+      // no valid_until — still active
+    });
+
+    expect(resolveEntity(graph, "OldAlias")).toBeNull();
+    expect(resolveEntity(graph, "NewAlias")?.id).toBe(entity.id);
+  });
+});


### PR DESCRIPTION
## Summary

- `resolveEntity(graph, name, type?)` — exact match on `canonical_name` then active alias. Returns entity or null. Never auto-creates.
- `addEntityAlias(graph, input)` — creates temporal alias with `valid_from`/`valid_until`/`episode_id` for provenance
- Conservative v0.1 strategy: no fuzzy or semantic matching — duplicates are safer than incorrect merges

## Acceptance Criteria

- [x] `resolveEntity` — exact canonical_name match, then active alias match
- [x] Active alias filter: `valid_until IS NULL OR valid_until > now`
- [x] Optional `type` parameter narrows by `entity_type`
- [x] Returns null if no match — never auto-creates
- [x] `addEntityAlias` — ULID, temporal validity windows, optional `episode_id` linking rename evidence
- [x] Throws `EntityNotFoundError` if entity doesn't exist

## Test plan

- [x] `bun test` — 86 tests pass
- [x] `bun run build` — succeeds
- [x] `bun run lint` — clean

> **Note:** Stacked on `feat/temporal-engine-issue-3` (PR #18). Merge order: #15 → #17 → #18 → this PR.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)