### PR TITLE
feat: GitHub enrichment adapter — PRs and issues

### DIFF
--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -46,6 +46,8 @@ export {
   getEvidenceForEntity,
   resolveEntity,
 } from "./graph/index.js";
+export type { EnrichmentAdapter, EnrichOpts } from "./ingest/adapter.js";
+export { GitHubAdapter } from "./ingest/adapters/github.js";
 export type { GitIngestOpts, IngestResult } from "./ingest/git.js";
 export { ingestGitRepo } from "./ingest/git.js";
 export {

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -46,3 +46,8 @@ export {
   getEvidenceForEntity,
   resolveEntity,
 } from "./graph/index.js";
+export {
+  checkActiveEdgeConflict,
+  getFactHistory,
+  supersedeEdge,
+} from "./temporal/index.js";

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -46,6 +46,8 @@ export {
   getEvidenceForEntity,
   resolveEntity,
 } from "./graph/index.js";
+export type { GitIngestOpts, IngestResult } from "./ingest/git.js";
+export { ingestGitRepo } from "./ingest/git.js";
 export {
   checkActiveEdgeConflict,
   getFactHistory,

--- a/packages/engram-core/src/ingest/adapter.ts
+++ b/packages/engram-core/src/ingest/adapter.ts
@@ -1,0 +1,36 @@
+/**
+ * adapter.ts — EnrichmentAdapter interface for pluggable enrichment sources.
+ *
+ * Each enrichment adapter (GitHub, Gerrit, Jira, etc.) implements this interface
+ * and is called after the VCS layer to add context to the graph.
+ */
+
+import type { EngramGraph } from "../format/index.js";
+import type { IngestResult } from "./git.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface EnrichOpts {
+  /** Auth token for the remote API. NEVER stored in the graph. */
+  token: string;
+  /** ISO8601 date — only fetch items updated after this date */
+  since?: string;
+  /** API endpoint base URL (default: 'https://api.github.com') */
+  endpoint?: string;
+  /** Repository in 'owner/repo' format */
+  repo?: string;
+}
+
+export interface EnrichmentAdapter {
+  /** Unique adapter name (e.g. 'github') */
+  name: string;
+  /** Adapter category (e.g. 'enrichment') */
+  kind: string;
+  /**
+   * Enrich the graph with data from the remote source.
+   * Must be idempotent — safe to call multiple times.
+   */
+  enrich(graph: EngramGraph, opts: EnrichOpts): Promise<IngestResult>;
+}

--- a/packages/engram-core/src/ingest/adapters/github.ts
+++ b/packages/engram-core/src/ingest/adapters/github.ts
@@ -9,11 +9,11 @@
 
 import { ulid } from "ulid";
 import type { EngramGraph } from "../../format/index.js";
+import { ENGINE_VERSION } from "../../format/version.js";
 import { resolveEntity } from "../../graph/aliases.js";
 import { addEdge } from "../../graph/edges.js";
 import { addEntity, type EvidenceInput } from "../../graph/entities.js";
 import { addEpisode } from "../../graph/episodes.js";
-import { ENGINE_VERSION } from "../../index.js";
 import type { EnrichmentAdapter, EnrichOpts } from "../adapter.js";
 import type { IngestResult } from "../git.js";
 
@@ -268,6 +268,18 @@ function ingestPR(
     .join("\n")
     .trim();
 
+  // Pre-check for existing episode (idempotent dedup)
+  const existingEpisode = graph.db
+    .query<{ id: string }, [string, string]>(
+      "SELECT id FROM episodes WHERE source_type = ? AND source_ref = ?",
+    )
+    .get("github_pr", pr.html_url);
+
+  if (existingEpisode) {
+    counts.episodesSkipped++;
+    return;
+  }
+
   const episode = addEpisode(graph, {
     source_type: "github_pr",
     source_ref: pr.html_url,
@@ -283,19 +295,7 @@ function ingestPR(
     },
   });
 
-  // addEpisode returns existing on UNIQUE collision (dedup via source_ref).
-  // Detect whether this episode pre-existed by checking for another row with the same source_ref.
-  const existingBefore = graph.db
-    .query<{ id: string }, [string, string, string]>(
-      "SELECT id FROM episodes WHERE source_type = ? AND source_ref = ? AND id != ?",
-    )
-    .get("github_pr", pr.html_url, episode.id);
-
-  if (existingBefore) {
-    counts.episodesSkipped++;
-  } else {
-    counts.episodesCreated++;
-  }
+  counts.episodesCreated++;
 
   const episodeId = episode.id;
   const evidence: EvidenceInput[] = [
@@ -399,17 +399,22 @@ function ingestIssue(
     { episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 },
   ];
 
-  // Create issue entity for references edges
-  const issueEntity = addEntity(
-    graph,
-    {
-      canonical_name: issue.html_url,
-      entity_type: "issue",
-      summary: issue.title,
-    },
-    evidence,
-  );
-  counts.entitiesCreated++;
+  // Resolve or create issue entity for reference edges
+  let issueEntity = resolveEntity(graph, issue.html_url, "issue");
+  if (!issueEntity) {
+    issueEntity = addEntity(
+      graph,
+      {
+        canonical_name: issue.html_url,
+        entity_type: "issue",
+        summary: issue.title,
+      },
+      evidence,
+    );
+    counts.entitiesCreated++;
+  } else {
+    counts.entitiesResolved++;
+  }
 
   const body = issue.body ?? "";
 
@@ -426,6 +431,9 @@ function ingestIssue(
       .get(sha, "commit");
 
     if (!mentioned) continue;
+
+    // Self-reference guard
+    if (mentioned.id === issueEntity.id) continue;
 
     const existing = graph.db
       .query<{ id: string }, [string, string, string, string]>(
@@ -468,6 +476,9 @@ function ingestIssue(
       .get(`%/pull/${refNum}`, `%/issues/${refNum}`);
 
     if (!mentioned) continue;
+
+    // Self-reference guard
+    if (mentioned.id === issueEntity.id) continue;
 
     const existing = graph.db
       .query<{ id: string }, [string, string, string, string]>(

--- a/packages/engram-core/src/ingest/adapters/github.ts
+++ b/packages/engram-core/src/ingest/adapters/github.ts
@@ -1,0 +1,604 @@
+/**
+ * github.ts — GitHub enrichment adapter.
+ *
+ * Fetches PRs and issues from the GitHub REST API and ingests them into an
+ * EngramGraph. Uses ingestion_runs cursors for idempotency.
+ *
+ * Token is accepted via opts.token and NEVER written to the graph.
+ */
+
+import { ulid } from "ulid";
+import type { EngramGraph } from "../../format/index.js";
+import { resolveEntity } from "../../graph/aliases.js";
+import { addEdge } from "../../graph/edges.js";
+import { addEntity, type EvidenceInput } from "../../graph/entities.js";
+import { addEpisode } from "../../graph/episodes.js";
+import { ENGINE_VERSION } from "../../index.js";
+import type { EnrichmentAdapter, EnrichOpts } from "../adapter.js";
+import type { IngestResult } from "../git.js";
+
+// ---------------------------------------------------------------------------
+// Internal types (GitHub REST API shapes — only fields we use)
+// ---------------------------------------------------------------------------
+
+interface GitHubUser {
+  login: string;
+}
+
+interface GitHubPR {
+  number: number;
+  html_url: string;
+  title: string;
+  body: string | null;
+  state: string;
+  user: GitHubUser | null;
+  created_at: string;
+  updated_at: string;
+  requested_reviewers: GitHubUser[];
+  assignees: GitHubUser[];
+}
+
+interface GitHubIssue {
+  number: number;
+  html_url: string;
+  title: string;
+  body: string | null;
+  state: string;
+  user: GitHubUser | null;
+  created_at: string;
+  updated_at: string;
+  pull_request?: unknown; // present when this issue is actually a PR
+}
+
+interface IngestionRun {
+  id: string;
+  source_type: string;
+  source_scope: string;
+  started_at: string;
+  completed_at: string | null;
+  cursor: string | null;
+  extractor_version: string;
+  episodes_created: number;
+  entities_created: number;
+  edges_created: number;
+  status: string;
+  error: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+const REPO_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+function validateRepo(repo: string): void {
+  if (!REPO_RE.test(repo)) {
+    throw new Error(
+      `GitHubAdapter: repo must be in 'owner/repo' format, got: ${repo}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ingestion_runs helpers
+// ---------------------------------------------------------------------------
+
+const SOURCE_TYPE = "github";
+
+function createIngestionRun(
+  graph: EngramGraph,
+  sourceScope: string,
+): IngestionRun {
+  const id = ulid();
+  const now = new Date().toISOString();
+
+  graph.db
+    .prepare<
+      void,
+      [string, string, string, string, string, number, number, number, string]
+    >(
+      `INSERT INTO ingestion_runs
+         (id, source_type, source_scope, started_at, extractor_version,
+          episodes_created, entities_created, edges_created, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(id, SOURCE_TYPE, sourceScope, now, ENGINE_VERSION, 0, 0, 0, "running");
+
+  return graph.db
+    .query<IngestionRun, [string]>("SELECT * FROM ingestion_runs WHERE id = ?")
+    .get(id) as IngestionRun;
+}
+
+function completeIngestionRun(
+  graph: EngramGraph,
+  runId: string,
+  cursor: string | null,
+  counts: { episodes: number; entities: number; edges: number },
+): void {
+  const now = new Date().toISOString();
+  graph.db
+    .prepare<void, [string, string | null, number, number, number, string]>(
+      `UPDATE ingestion_runs
+       SET completed_at = ?, cursor = ?, episodes_created = ?,
+           entities_created = ?, edges_created = ?, status = 'completed'
+       WHERE id = ?`,
+    )
+    .run(now, cursor, counts.episodes, counts.entities, counts.edges, runId);
+}
+
+function failIngestionRun(
+  graph: EngramGraph,
+  runId: string,
+  error: string,
+): void {
+  const now = new Date().toISOString();
+  graph.db
+    .prepare<void, [string, string, string]>(
+      `UPDATE ingestion_runs SET completed_at = ?, status = 'failed', error = ? WHERE id = ?`,
+    )
+    .run(now, error, runId);
+}
+
+function getLastCursor(graph: EngramGraph, sourceScope: string): number {
+  const row = graph.db
+    .query<{ cursor: string | null }, [string, string]>(
+      `SELECT cursor FROM ingestion_runs
+       WHERE source_type = ? AND source_scope = ? AND status = 'completed'
+       ORDER BY completed_at DESC LIMIT 1`,
+    )
+    .get(SOURCE_TYPE, sourceScope);
+
+  if (!row?.cursor) return 0;
+  const n = parseInt(row.cursor, 10);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+type FetchFn = typeof fetch;
+
+async function apiGet<T>(
+  fetchFn: FetchFn,
+  endpoint: string,
+  path: string,
+  token: string,
+): Promise<T> {
+  const url = `${endpoint}${path}`;
+  const resp = await fetchFn(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!resp.ok) {
+    throw new Error(
+      `GitHubAdapter: GET ${url} returned HTTP ${resp.status}: ${await resp.text()}`,
+    );
+  }
+
+  return resp.json() as Promise<T>;
+}
+
+async function fetchAllPages<T>(
+  fetchFn: FetchFn,
+  endpoint: string,
+  basePath: string,
+  token: string,
+  since?: string,
+): Promise<T[]> {
+  const results: T[] = [];
+  let page = 1;
+
+  while (true) {
+    const sep = basePath.includes("?") ? "&" : "?";
+    let path = `${basePath}${sep}per_page=100&page=${page}`;
+    if (since) {
+      path += `&since=${encodeURIComponent(since)}`;
+    }
+
+    const batch = await apiGet<T[]>(fetchFn, endpoint, path, token);
+    if (!Array.isArray(batch) || batch.length === 0) break;
+
+    results.push(...batch);
+    if (batch.length < 100) break;
+    page++;
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Entity helpers
+// ---------------------------------------------------------------------------
+
+const EXTRACTOR = "github-ingest";
+
+function getOrCreatePerson(
+  graph: EngramGraph,
+  login: string,
+  episodeId: string,
+  counts: { entitiesCreated: number; entitiesResolved: number },
+): string {
+  const existing = resolveEntity(graph, login, "person");
+
+  if (existing) {
+    counts.entitiesResolved++;
+    return existing.id;
+  }
+
+  const entity = addEntity(
+    graph,
+    { canonical_name: login, entity_type: "person" },
+    [{ episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 }],
+  );
+
+  counts.entitiesCreated++;
+  return entity.id;
+}
+
+// ---------------------------------------------------------------------------
+// PR ingestion
+// ---------------------------------------------------------------------------
+
+function ingestPR(
+  graph: EngramGraph,
+  pr: GitHubPR,
+  counts: {
+    episodesCreated: number;
+    episodesSkipped: number;
+    entitiesCreated: number;
+    entitiesResolved: number;
+    edgesCreated: number;
+    edgesSuperseded: number;
+  },
+): void {
+  const content = [
+    `PR #${pr.number}: ${pr.title}`,
+    `URL: ${pr.html_url}`,
+    `State: ${pr.state}`,
+    `Author: ${pr.user?.login ?? "unknown"}`,
+    `Created: ${pr.created_at}`,
+    "",
+    pr.body ?? "",
+  ]
+    .join("\n")
+    .trim();
+
+  const episode = addEpisode(graph, {
+    source_type: "github_pr",
+    source_ref: pr.html_url,
+    content,
+    actor: pr.user?.login ?? undefined,
+    timestamp: pr.created_at,
+    extractor_version: ENGINE_VERSION,
+    metadata: {
+      number: pr.number,
+      title: pr.title,
+      state: pr.state,
+      html_url: pr.html_url,
+    },
+  });
+
+  // addEpisode returns existing on UNIQUE collision (dedup via source_ref).
+  // Detect whether this episode pre-existed by checking for another row with the same source_ref.
+  const existingBefore = graph.db
+    .query<{ id: string }, [string, string, string]>(
+      "SELECT id FROM episodes WHERE source_type = ? AND source_ref = ? AND id != ?",
+    )
+    .get("github_pr", pr.html_url, episode.id);
+
+  if (existingBefore) {
+    counts.episodesSkipped++;
+  } else {
+    counts.episodesCreated++;
+  }
+
+  const episodeId = episode.id;
+  const evidence: EvidenceInput[] = [
+    { episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 },
+  ];
+
+  if (!pr.user?.login) return;
+
+  const authorId = getOrCreatePerson(graph, pr.user.login, episodeId, counts);
+
+  // Create reviewed_by edges: reviewer → author
+  for (const reviewer of pr.requested_reviewers ?? []) {
+    if (!reviewer.login || reviewer.login === pr.user.login) continue;
+
+    const reviewerId = getOrCreatePerson(
+      graph,
+      reviewer.login,
+      episodeId,
+      counts,
+    );
+
+    // Dedup: check for existing reviewed_by edge
+    const existing = graph.db
+      .query<{ id: string }, [string, string, string, string]>(
+        `SELECT id FROM edges
+         WHERE source_id = ? AND target_id = ? AND relation_type = ?
+           AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
+      )
+      .get(reviewerId, authorId, "reviewed_by", "observed");
+
+    if (!existing) {
+      addEdge(
+        graph,
+        {
+          source_id: reviewerId,
+          target_id: authorId,
+          relation_type: "reviewed_by",
+          edge_kind: "observed",
+          fact: `${reviewer.login} reviewed PR #${pr.number} by ${pr.user.login}`,
+          valid_from: pr.created_at,
+          confidence: 1.0,
+        },
+        evidence,
+      );
+      counts.edgesCreated++;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Issue ingestion
+// ---------------------------------------------------------------------------
+
+// Match #123 PR/issue references and short 7-40 char hex SHAs
+const SHA_RE = /\b([0-9a-f]{7,40})\b/gi;
+const PR_REF_RE = /#(\d+)/g;
+
+function ingestIssue(
+  graph: EngramGraph,
+  issue: GitHubIssue,
+  counts: {
+    episodesCreated: number;
+    episodesSkipped: number;
+    entitiesCreated: number;
+    entitiesResolved: number;
+    edgesCreated: number;
+    edgesSuperseded: number;
+  },
+): void {
+  const content = [
+    `Issue #${issue.number}: ${issue.title}`,
+    `URL: ${issue.html_url}`,
+    `State: ${issue.state}`,
+    `Author: ${issue.user?.login ?? "unknown"}`,
+    `Created: ${issue.created_at}`,
+    "",
+    issue.body ?? "",
+  ]
+    .join("\n")
+    .trim();
+
+  const episode = addEpisode(graph, {
+    source_type: "github_issue",
+    source_ref: issue.html_url,
+    content,
+    actor: issue.user?.login ?? undefined,
+    timestamp: issue.created_at,
+    extractor_version: ENGINE_VERSION,
+    metadata: {
+      number: issue.number,
+      title: issue.title,
+      state: issue.state,
+      html_url: issue.html_url,
+    },
+  });
+
+  counts.episodesCreated++;
+
+  const episodeId = episode.id;
+  const evidence: EvidenceInput[] = [
+    { episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 },
+  ];
+
+  // Create issue entity for references edges
+  const issueEntity = addEntity(
+    graph,
+    {
+      canonical_name: issue.html_url,
+      entity_type: "issue",
+      summary: issue.title,
+    },
+    evidence,
+  );
+  counts.entitiesCreated++;
+
+  const body = issue.body ?? "";
+
+  // Create references edges for mentioned commit SHAs
+  const shaMatches = [...body.matchAll(SHA_RE)];
+  for (const match of shaMatches) {
+    const sha = match[1];
+    if (!sha) continue;
+
+    const mentioned = graph.db
+      .query<{ id: string }, [string, string]>(
+        "SELECT id FROM entities WHERE canonical_name = ? AND entity_type = ? LIMIT 1",
+      )
+      .get(sha, "commit");
+
+    if (!mentioned) continue;
+
+    const existing = graph.db
+      .query<{ id: string }, [string, string, string, string]>(
+        `SELECT id FROM edges
+         WHERE source_id = ? AND target_id = ? AND relation_type = ?
+           AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
+      )
+      .get(issueEntity.id, mentioned.id, "references", "observed");
+
+    if (!existing) {
+      addEdge(
+        graph,
+        {
+          source_id: issueEntity.id,
+          target_id: mentioned.id,
+          relation_type: "references",
+          edge_kind: "observed",
+          fact: `Issue #${issue.number} references commit ${sha}`,
+          valid_from: issue.created_at,
+          confidence: 0.9,
+        },
+        evidence,
+      );
+      counts.edgesCreated++;
+    }
+  }
+
+  // Create references edges for mentioned #N (PR/issue refs)
+  const prMatches = [...body.matchAll(PR_REF_RE)];
+  for (const match of prMatches) {
+    const refNum = match[1];
+    if (!refNum) continue;
+
+    // Look for an entity whose canonical_name ends with /pull/<N> or /issues/<N>
+    const mentioned = graph.db
+      .query<{ id: string }, [string, string]>(
+        `SELECT id FROM entities WHERE (canonical_name LIKE ? OR canonical_name LIKE ?)
+         AND entity_type IN ('issue', 'pull_request') LIMIT 1`,
+      )
+      .get(`%/pull/${refNum}`, `%/issues/${refNum}`);
+
+    if (!mentioned) continue;
+
+    const existing = graph.db
+      .query<{ id: string }, [string, string, string, string]>(
+        `SELECT id FROM edges
+         WHERE source_id = ? AND target_id = ? AND relation_type = ?
+           AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
+      )
+      .get(issueEntity.id, mentioned.id, "references", "observed");
+
+    if (!existing) {
+      addEdge(
+        graph,
+        {
+          source_id: issueEntity.id,
+          target_id: mentioned.id,
+          relation_type: "references",
+          edge_kind: "observed",
+          fact: `Issue #${issue.number} references #${refNum}`,
+          valid_from: issue.created_at,
+          confidence: 0.9,
+        },
+        evidence,
+      );
+      counts.edgesCreated++;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHubAdapter
+// ---------------------------------------------------------------------------
+
+export class GitHubAdapter implements EnrichmentAdapter {
+  name = "github";
+  kind = "enrichment";
+
+  /**
+   * Optionally inject a custom fetch function (useful for testing).
+   * Defaults to the global fetch.
+   */
+  private fetchFn: FetchFn;
+
+  constructor(fetchFn?: FetchFn) {
+    this.fetchFn = fetchFn ?? fetch;
+  }
+
+  async enrich(graph: EngramGraph, opts: EnrichOpts): Promise<IngestResult> {
+    const repo = opts.repo;
+    if (!repo) {
+      throw new Error("GitHubAdapter: opts.repo is required (owner/repo)");
+    }
+    validateRepo(repo);
+
+    const endpoint = opts.endpoint ?? "https://api.github.com";
+    const token = opts.token;
+
+    const run = createIngestionRun(graph, repo);
+    const runId = run.id;
+
+    const counts = {
+      episodesCreated: 0,
+      episodesSkipped: 0,
+      entitiesCreated: 0,
+      entitiesResolved: 0,
+      edgesCreated: 0,
+      edgesSuperseded: 0,
+    };
+
+    try {
+      const lastNumber = getLastCursor(graph, repo);
+      let latestNumber = lastNumber;
+
+      // --- Fetch and ingest PRs ---
+      const prs = await fetchAllPages<GitHubPR>(
+        this.fetchFn,
+        endpoint,
+        `/repos/${repo}/pulls?state=closed`,
+        token,
+        opts.since,
+      );
+
+      for (const pr of prs) {
+        if (pr.number <= lastNumber) {
+          counts.episodesSkipped++;
+          continue;
+        }
+
+        ingestPR(graph, pr, counts);
+
+        if (pr.number > latestNumber) {
+          latestNumber = pr.number;
+        }
+      }
+
+      // --- Fetch and ingest Issues (skip those that are PRs) ---
+      const issues = await fetchAllPages<GitHubIssue>(
+        this.fetchFn,
+        endpoint,
+        `/repos/${repo}/issues?state=all`,
+        token,
+        opts.since,
+      );
+
+      for (const issue of issues) {
+        // Skip items that are actually PRs (GitHub issues API returns PRs too)
+        if (issue.pull_request !== undefined) continue;
+
+        if (issue.number <= lastNumber) {
+          counts.episodesSkipped++;
+          continue;
+        }
+
+        ingestIssue(graph, issue, counts);
+
+        if (issue.number > latestNumber) {
+          latestNumber = issue.number;
+        }
+      }
+
+      const cursor = latestNumber > 0 ? String(latestNumber) : null;
+      completeIngestionRun(graph, runId, cursor, {
+        episodes: counts.episodesCreated,
+        entities: counts.entitiesCreated,
+        edges: counts.edgesCreated,
+      });
+
+      return { ...counts, runId };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      failIngestionRun(graph, runId, msg);
+      throw err;
+    }
+  }
+}

--- a/packages/engram-core/src/ingest/git-parse.ts
+++ b/packages/engram-core/src/ingest/git-parse.ts
@@ -1,0 +1,152 @@
+/**
+ * git-parse.ts — helpers for parsing git log output.
+ */
+
+export interface CommitRecord {
+  sha: string;
+  authorEmail: string;
+  authorName: string;
+  timestampUnix: number;
+  subject: string;
+  body: string;
+  files: string[];
+}
+
+const COMMIT_SEPARATOR = "---COMMIT-END---";
+
+/**
+ * Parses the output of:
+ *   git log --format="%H%n%ae%n%an%n%at%n%s%n%b%n---COMMIT-END---" --name-only
+ *
+ * The actual format git produces (observed):
+ *   <sha>
+ *   <author_email>
+ *   <author_name>
+ *   <unix_timestamp>
+ *   <subject>
+ *   <optional body lines>
+ *   ---COMMIT-END---
+ *   <blank line>
+ *   <file1>
+ *   <file2>
+ *   ...
+ *   <sha of next commit>
+ *   ...
+ *
+ * So file names appear AFTER the separator, before the next commit's sha.
+ * Strategy: collect header blocks (sha...separator) and then grab the file
+ * lines that follow each separator before the next sha line.
+ */
+export function parseGitLog(raw: string): CommitRecord[] {
+  const commits: CommitRecord[] = [];
+  if (!raw.trim()) return commits;
+
+  const lines = raw.split("\n");
+
+  // State machine:
+  // We accumulate lines into a "header block" until we hit the separator,
+  // then accumulate lines as "files" until the next 40-char hex sha.
+
+  interface ParsedHeader {
+    sha: string;
+    authorEmail: string;
+    authorName: string;
+    timestampUnix: number;
+    subject: string;
+    body: string;
+  }
+
+  const SHA_RE = /^[0-9a-f]{40}$/i;
+
+  const pendingHeaders: ParsedHeader[] = [];
+  let currentHeaderLines: string[] = [];
+  let inFiles = false;
+  let currentFiles: string[] = [];
+
+  const flushFiles = () => {
+    const header = pendingHeaders[pendingHeaders.length - 1];
+    if (header) {
+      commits.push({
+        ...header,
+        files: currentFiles.filter((f) => f.length > 0),
+      });
+      pendingHeaders.pop();
+    }
+    currentFiles = [];
+    inFiles = false;
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trimEnd();
+
+    if (trimmed === COMMIT_SEPARATOR) {
+      // Parse the accumulated header lines
+      if (currentHeaderLines.length >= 5) {
+        const sha = currentHeaderLines[0]?.trim() ?? "";
+        const authorEmail = currentHeaderLines[1]?.trim() ?? "";
+        const authorName = currentHeaderLines[2]?.trim() ?? "";
+        const timestampUnix = Number.parseInt(
+          currentHeaderLines[3]?.trim() ?? "0",
+          10,
+        );
+        const subject = currentHeaderLines[4]?.trim() ?? "";
+        const bodyLines = currentHeaderLines.slice(5);
+        const body = bodyLines.join("\n").trim();
+
+        if (sha && authorEmail && authorName && !Number.isNaN(timestampUnix)) {
+          // If we were collecting files for a previous commit, flush it first
+          if (inFiles) {
+            flushFiles();
+          }
+          pendingHeaders.push({
+            sha,
+            authorEmail,
+            authorName,
+            timestampUnix,
+            subject,
+            body,
+          });
+          inFiles = true;
+          currentFiles = [];
+        }
+      }
+      currentHeaderLines = [];
+      continue;
+    }
+
+    if (inFiles) {
+      // Check if this line is the start of a new commit (40-char hex sha)
+      if (SHA_RE.test(trimmed)) {
+        // Flush current commit's files
+        flushFiles();
+        // Start new header block
+        currentHeaderLines = [trimmed];
+        continue;
+      }
+      // Otherwise it's a file path (skip blank lines)
+      if (trimmed.length > 0) {
+        currentFiles.push(trimmed);
+      }
+    } else {
+      // Accumulating header lines
+      currentHeaderLines.push(trimmed);
+    }
+  }
+
+  // Flush any remaining
+  if (inFiles && pendingHeaders.length > 0) {
+    flushFiles();
+  }
+
+  return commits;
+}
+
+/**
+ * Recency-weighted score for an author contribution.
+ * weight = exp(-λ * days_ago), λ = ln(2)/90 (90-day half-life)
+ */
+export function recencyWeight(commitUnixSecs: number, nowMs: number): number {
+  const LAMBDA = Math.LN2 / 90; // half-life = 90 days
+  const daysAgo = (nowMs / 1000 - commitUnixSecs) / 86400;
+  return Math.exp(-LAMBDA * Math.max(0, daysAgo));
+}

--- a/packages/engram-core/src/ingest/git.ts
+++ b/packages/engram-core/src/ingest/git.ts
@@ -5,16 +5,16 @@
  * Requires no external API tokens — git commands only.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { ulid } from "ulid";
 import type { EngramGraph } from "../format/index.js";
+import { ENGINE_VERSION } from "../format/version.js";
 import { resolveEntity } from "../graph/aliases.js";
 import { addEdge } from "../graph/edges.js";
 import { addEntity, type EvidenceInput } from "../graph/entities.js";
 import { addEpisode } from "../graph/episodes.js";
-import { ENGINE_VERSION } from "../index.js";
 import { supersedeEdge } from "../temporal/supersession.js";
 import { parseGitLog, recencyWeight } from "./git-parse.js";
 
@@ -172,6 +172,33 @@ function getLastCursor(graph: EngramGraph, sourceScope: string): string | null {
 // Git log execution
 // ---------------------------------------------------------------------------
 
+function validatePathFilter(pathFilter: string[]): string[] {
+  const validated: string[] = [];
+  for (const p of pathFilter) {
+    // Reject absolute paths
+    if (path.isAbsolute(p)) {
+      throw new Error(
+        `ingestGitRepo: path_filter entry must be a relative path, got: ${p}`,
+      );
+    }
+    // Reject path traversal
+    const normalized = path.normalize(p);
+    if (normalized.startsWith("..")) {
+      throw new Error(
+        `ingestGitRepo: path_filter entry must not traverse parent directories, got: ${p}`,
+      );
+    }
+    // Reject pathspec magic (starts with ':')
+    if (p.startsWith(":")) {
+      throw new Error(
+        `ingestGitRepo: path_filter entry must not use pathspec magic, got: ${p}`,
+      );
+    }
+    validated.push(normalized);
+  }
+  return validated;
+}
+
 function runGitLog(
   repoPath: string,
   opts: GitIngestOpts,
@@ -200,26 +227,22 @@ function runGitLog(
   }
 
   if (opts.path_filter && opts.path_filter.length > 0) {
+    const validated = validatePathFilter(opts.path_filter);
     args.push("--");
-    for (const p of opts.path_filter) {
-      // Prevent directory traversal / shell injection
-      const sanitized = path.normalize(p).replace(/^(\.\.[/\\])+/, "");
-      args.push(sanitized);
+    for (const p of validated) {
+      args.push(p);
     }
   }
 
   try {
-    const result = execSync(
-      `git ${args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")}`,
-      {
-        maxBuffer: 100 * 1024 * 1024, // 100 MB
-        encoding: "utf8",
-      },
-    );
+    const result = execFileSync("git", args, {
+      maxBuffer: 100 * 1024 * 1024, // 100 MB
+      encoding: "utf8",
+    });
     return result;
   } catch (err: unknown) {
     if (err instanceof Error && "stdout" in err) {
-      // execSync throws on non-zero exit but may still have output
+      // execFileSync throws on non-zero exit but may still have output
       return (err as { stdout: string }).stdout ?? "";
     }
     throw err;
@@ -314,8 +337,17 @@ export async function ingestGitRepo(
   const validatedPath = validateRepoPath(repoPath);
   const threshold = opts.cochange_threshold ?? 3;
 
+  if (threshold < 1) {
+    throw new Error(
+      `ingestGitRepo: cochange_threshold must be >= 1, got: ${threshold}`,
+    );
+  }
+
+  // Build source_scope that includes significant opts for cursor scoping
+  const sourceScope = `${validatedPath}::branch=${opts.branch ?? "HEAD"}`;
+
   // Create ingestion run record
-  const run = createIngestionRun(graph, validatedPath);
+  const run = createIngestionRun(graph, sourceScope);
   const runId = run.id;
 
   const counts = {
@@ -329,14 +361,14 @@ export async function ingestGitRepo(
 
   try {
     // Get last cursor for idempotency
-    const lastCursor = getLastCursor(graph, validatedPath);
+    const lastCursor = getLastCursor(graph, sourceScope);
 
     // Run git log
     const rawLog = runGitLog(validatedPath, opts, lastCursor);
     const commits = parseGitLog(rawLog);
 
     if (commits.length === 0) {
-      completeIngestionRun(graph, runId, lastCursor, {
+      completeIngestionRun(graph, runId, lastCursor ?? null, {
         episodes: 0,
         entities: 0,
         edges: 0,

--- a/packages/engram-core/src/ingest/git.ts
+++ b/packages/engram-core/src/ingest/git.ts
@@ -1,0 +1,697 @@
+/**
+ * git.ts — Git VCS ingestion: the money command engine.
+ *
+ * Walks git log and extracts entities + edges into an EngramGraph.
+ * Requires no external API tokens — git commands only.
+ */
+
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ulid } from "ulid";
+import type { EngramGraph } from "../format/index.js";
+import { resolveEntity } from "../graph/aliases.js";
+import { addEdge } from "../graph/edges.js";
+import { addEntity, type EvidenceInput } from "../graph/entities.js";
+import { addEpisode } from "../graph/episodes.js";
+import { ENGINE_VERSION } from "../index.js";
+import { supersedeEdge } from "../temporal/supersession.js";
+import { parseGitLog, recencyWeight } from "./git-parse.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface GitIngestOpts {
+  /** ISO8601 date or relative like "6 months ago" */
+  since?: string;
+  /** Branch or ref to walk (default: HEAD) */
+  branch?: string;
+  /** Only include commits touching these paths */
+  path_filter?: string[];
+  /** Min shared commits for co-change edge (default 3) */
+  cochange_threshold?: number;
+}
+
+export interface IngestResult {
+  episodesCreated: number;
+  episodesSkipped: number;
+  entitiesCreated: number;
+  entitiesResolved: number;
+  edgesCreated: number;
+  edgesSuperseded: number;
+  runId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface IngestionRun {
+  id: string;
+  source_type: string;
+  source_scope: string;
+  started_at: string;
+  completed_at: string | null;
+  cursor: string | null;
+  extractor_version: string;
+  episodes_created: number;
+  entities_created: number;
+  edges_created: number;
+  status: string;
+  error: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Security: path validation
+// ---------------------------------------------------------------------------
+
+function validateRepoPath(repoPath: string): string {
+  const resolved = path.resolve(repoPath);
+
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`ingestGitRepo: path does not exist: ${resolved}`);
+  }
+
+  const stat = fs.statSync(resolved);
+  if (!stat.isDirectory()) {
+    throw new Error(`ingestGitRepo: path is not a directory: ${resolved}`);
+  }
+
+  const gitDir = path.join(resolved, ".git");
+  if (!fs.existsSync(gitDir)) {
+    throw new Error(
+      `ingestGitRepo: not a git repository (no .git found): ${resolved}`,
+    );
+  }
+
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// ingestion_runs helpers
+// ---------------------------------------------------------------------------
+
+function createIngestionRun(
+  graph: EngramGraph,
+  sourceScope: string,
+): IngestionRun {
+  const id = ulid();
+  const now = new Date().toISOString();
+
+  graph.db
+    .prepare<
+      void,
+      [string, string, string, string, string, number, number, number, string]
+    >(
+      `INSERT INTO ingestion_runs
+         (id, source_type, source_scope, started_at, extractor_version,
+          episodes_created, entities_created, edges_created, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      id,
+      "git_commit",
+      sourceScope,
+      now,
+      ENGINE_VERSION,
+      0,
+      0,
+      0,
+      "running",
+    );
+
+  return graph.db
+    .query<IngestionRun, [string]>("SELECT * FROM ingestion_runs WHERE id = ?")
+    .get(id) as IngestionRun;
+}
+
+function completeIngestionRun(
+  graph: EngramGraph,
+  runId: string,
+  cursor: string | null,
+  counts: { episodes: number; entities: number; edges: number },
+): void {
+  const now = new Date().toISOString();
+  graph.db
+    .prepare<void, [string, string | null, number, number, number, string]>(
+      `UPDATE ingestion_runs
+       SET completed_at = ?, cursor = ?, episodes_created = ?,
+           entities_created = ?, edges_created = ?, status = 'completed'
+       WHERE id = ?`,
+    )
+    .run(now, cursor, counts.episodes, counts.entities, counts.edges, runId);
+}
+
+function failIngestionRun(
+  graph: EngramGraph,
+  runId: string,
+  error: string,
+): void {
+  const now = new Date().toISOString();
+  graph.db
+    .prepare<void, [string, string, string]>(
+      `UPDATE ingestion_runs SET completed_at = ?, status = 'failed', error = ? WHERE id = ?`,
+    )
+    .run(now, error, runId);
+}
+
+function getLastCursor(graph: EngramGraph, sourceScope: string): string | null {
+  const row = graph.db
+    .query<{ cursor: string | null }, [string]>(
+      `SELECT cursor FROM ingestion_runs
+       WHERE source_type = 'git_commit' AND source_scope = ? AND status = 'completed'
+       ORDER BY completed_at DESC LIMIT 1`,
+    )
+    .get(sourceScope);
+
+  return row?.cursor ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Git log execution
+// ---------------------------------------------------------------------------
+
+function runGitLog(
+  repoPath: string,
+  opts: GitIngestOpts,
+  afterSha: string | null,
+): string {
+  const format = "%H%n%ae%n%an%n%at%n%s%n%b%n---COMMIT-END---";
+
+  const args: string[] = [
+    "-C",
+    repoPath,
+    "log",
+    `--format=${format}`,
+    "--name-only",
+  ];
+
+  if (opts.since) {
+    args.push(`--since=${opts.since}`);
+  }
+
+  const branch = opts.branch ?? "HEAD";
+
+  if (afterSha) {
+    args.push(`${afterSha}..${branch}`);
+  } else {
+    args.push(branch);
+  }
+
+  if (opts.path_filter && opts.path_filter.length > 0) {
+    args.push("--");
+    for (const p of opts.path_filter) {
+      // Prevent directory traversal / shell injection
+      const sanitized = path.normalize(p).replace(/^(\.\.[/\\])+/, "");
+      args.push(sanitized);
+    }
+  }
+
+  try {
+    const result = execSync(
+      `git ${args.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ")}`,
+      {
+        maxBuffer: 100 * 1024 * 1024, // 100 MB
+        encoding: "utf8",
+      },
+    );
+    return result;
+  } catch (err: unknown) {
+    if (err instanceof Error && "stdout" in err) {
+      // execSync throws on non-zero exit but may still have output
+      return (err as { stdout: string }).stdout ?? "";
+    }
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entity helpers
+// ---------------------------------------------------------------------------
+
+const EXTRACTOR = "git-ingest";
+
+function getOrCreatePerson(
+  graph: EngramGraph,
+  email: string,
+  name: string,
+  episodeId: string,
+  counts: { entitiesCreated: number; entitiesResolved: number },
+): string {
+  // Try canonical name (email) first, then name
+  const existing =
+    resolveEntity(graph, email, "person") ??
+    resolveEntity(graph, name, "person");
+
+  if (existing) {
+    counts.entitiesResolved++;
+    return existing.id;
+  }
+
+  const entity = addEntity(
+    graph,
+    {
+      canonical_name: email,
+      entity_type: "person",
+      summary: name !== email ? name : undefined,
+    },
+    [{ episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 }],
+  );
+
+  counts.entitiesCreated++;
+  return entity.id;
+}
+
+function getOrCreateModule(
+  graph: EngramGraph,
+  filePath: string,
+  episodeId: string,
+  counts: { entitiesCreated: number; entitiesResolved: number },
+): string {
+  const existing = resolveEntity(graph, filePath, "module");
+
+  if (existing) {
+    counts.entitiesResolved++;
+    return existing.id;
+  }
+
+  const entity = addEntity(
+    graph,
+    {
+      canonical_name: filePath,
+      entity_type: "module",
+    },
+    [{ episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 }],
+  );
+
+  counts.entitiesCreated++;
+  return entity.id;
+}
+
+// ---------------------------------------------------------------------------
+// Main ingestion function
+// ---------------------------------------------------------------------------
+
+/**
+ * Ingests git commit history into an EngramGraph.
+ *
+ * Extracts:
+ * - Person entities (authors by email)
+ * - Module entities (changed files)
+ * - Observed edges: authored_by (commit episode → author)
+ * - Observed edges: modified (file → commit episode context)
+ * - Inferred edges: co_changes_with (files changed together ≥ threshold)
+ * - Inferred edges: likely_owner_of (recency-weighted most frequent author)
+ *
+ * Idempotent via ingestion_runs cursors and episode dedup.
+ */
+export async function ingestGitRepo(
+  graph: EngramGraph,
+  repoPath: string,
+  opts: GitIngestOpts = {},
+): Promise<IngestResult> {
+  const validatedPath = validateRepoPath(repoPath);
+  const threshold = opts.cochange_threshold ?? 3;
+
+  // Create ingestion run record
+  const run = createIngestionRun(graph, validatedPath);
+  const runId = run.id;
+
+  const counts = {
+    episodesCreated: 0,
+    episodesSkipped: 0,
+    entitiesCreated: 0,
+    entitiesResolved: 0,
+    edgesCreated: 0,
+    edgesSuperseded: 0,
+  };
+
+  try {
+    // Get last cursor for idempotency
+    const lastCursor = getLastCursor(graph, validatedPath);
+
+    // Run git log
+    const rawLog = runGitLog(validatedPath, opts, lastCursor);
+    const commits = parseGitLog(rawLog);
+
+    if (commits.length === 0) {
+      completeIngestionRun(graph, runId, lastCursor, {
+        episodes: 0,
+        entities: 0,
+        edges: 0,
+      });
+      return { ...counts, runId };
+    }
+
+    // Track co-change data: Map<fileA_fileB_sorted_key, count>
+    // Key format: "fileA|||fileB" (sorted alphabetically)
+    const cochangeMap = new Map<string, number>();
+
+    // Track file → [(authorEmail, timestamp)] for likely_owner computation
+    const fileAuthorMap = new Map<
+      string,
+      Array<{ email: string; ts: number }>
+    >();
+
+    // Track entityIds for files and authors (cached across commits)
+    const fileEntityCache = new Map<string, string>(); // filePath → entity_id
+    const authorEntityCache = new Map<string, string>(); // email → entity_id
+
+    // For co-change: we need entity IDs. Collect file→entityId after processing all commits.
+    // Track which commits touched which files (for co-change counting)
+    const commitFiles = new Map<string, string[]>(); // sha → [filePaths]
+
+    // Map episode IDs per commit SHA (for evidence links)
+    const episodeIds = new Map<string, string>(); // sha → episode_id
+
+    const nowMs = Date.now();
+    let latestSha: string | null = null;
+
+    // -------------------------------------------------------------------
+    // Pass 1: create episodes, person entities, file entities, observed edges
+    // -------------------------------------------------------------------
+    for (const commit of commits) {
+      if (!latestSha) latestSha = commit.sha;
+
+      const timestamp = new Date(commit.timestampUnix * 1000).toISOString();
+
+      // Create episode (idempotent via source_ref dedup)
+      const episodeBefore = graph.db
+        .query<{ id: string }, [string, string]>(
+          "SELECT id FROM episodes WHERE source_type = ? AND source_ref = ?",
+        )
+        .get("git_commit", commit.sha);
+
+      let episodeId: string;
+      if (episodeBefore) {
+        episodeId = episodeBefore.id;
+        counts.episodesSkipped++;
+      } else {
+        const content = [
+          `commit ${commit.sha}`,
+          `Author: ${commit.authorName} <${commit.authorEmail}>`,
+          `Date: ${timestamp}`,
+          "",
+          commit.subject,
+          commit.body ? `\n${commit.body}` : "",
+          "",
+          commit.files.length > 0 ? `Files:\n${commit.files.join("\n")}` : "",
+        ]
+          .join("\n")
+          .trim();
+
+        const episode = addEpisode(graph, {
+          source_type: "git_commit",
+          source_ref: commit.sha,
+          content,
+          actor: commit.authorEmail,
+          timestamp,
+          extractor_version: ENGINE_VERSION,
+          metadata: {
+            sha: commit.sha,
+            author_name: commit.authorName,
+            author_email: commit.authorEmail,
+            subject: commit.subject,
+            files: commit.files,
+          },
+        });
+
+        episodeId = episode.id;
+        counts.episodesCreated++;
+      }
+
+      episodeIds.set(commit.sha, episodeId);
+      commitFiles.set(commit.sha, commit.files);
+
+      const evidence: EvidenceInput[] = [
+        { episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 },
+      ];
+
+      // Get or create author entity
+      let authorId = authorEntityCache.get(commit.authorEmail);
+      if (!authorId) {
+        authorId = getOrCreatePerson(
+          graph,
+          commit.authorEmail,
+          commit.authorName,
+          episodeId,
+          counts,
+        );
+        authorEntityCache.set(commit.authorEmail, authorId);
+      } else {
+        counts.entitiesResolved++;
+      }
+
+      // Process each changed file
+      for (const filePath of commit.files) {
+        let fileId = fileEntityCache.get(filePath);
+        if (!fileId) {
+          fileId = getOrCreateModule(graph, filePath, episodeId, counts);
+          fileEntityCache.set(filePath, fileId);
+        } else {
+          counts.entitiesResolved++;
+        }
+
+        // Observed edge: file modified_by author (via commit)
+        // Use file→author direction for "authored_by"
+        const existingAuthoredBy = graph.db
+          .query<{ id: string }, [string, string, string, string]>(
+            `SELECT id FROM edges
+             WHERE source_id = ? AND target_id = ? AND relation_type = ?
+               AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
+          )
+          .get(fileId, authorId, "authored_by", "observed");
+
+        if (!existingAuthoredBy) {
+          addEdge(
+            graph,
+            {
+              source_id: fileId,
+              target_id: authorId,
+              relation_type: "authored_by",
+              edge_kind: "observed",
+              fact: `${filePath} was authored/modified by ${commit.authorEmail} in commit ${commit.sha.slice(0, 8)}`,
+              valid_from: timestamp,
+              confidence: 1.0,
+            },
+            evidence,
+          );
+          counts.edgesCreated++;
+        }
+
+        // Track for likely_owner computation
+        if (!fileAuthorMap.has(filePath)) {
+          fileAuthorMap.set(filePath, []);
+        }
+        fileAuthorMap
+          .get(filePath)
+          ?.push({ email: commit.authorEmail, ts: commit.timestampUnix });
+      }
+
+      // Co-change tracking: count pairwise file co-occurrences
+      const files = commit.files;
+      if (files.length >= 2) {
+        for (let i = 0; i < files.length; i++) {
+          for (let j = i + 1; j < files.length; j++) {
+            const [a, b] = [files[i], files[j]].sort() as [string, string];
+            const key = `${a}|||${b}`;
+            cochangeMap.set(key, (cochangeMap.get(key) ?? 0) + 1);
+          }
+        }
+      }
+    }
+
+    // -------------------------------------------------------------------
+    // Pass 2: co_changes_with edges (inferred)
+    // -------------------------------------------------------------------
+    for (const [key, count] of cochangeMap) {
+      if (count < threshold) continue;
+
+      const [fileA, fileB] = key.split("|||") as [string, string];
+      const entityA = fileEntityCache.get(fileA);
+      const entityB = fileEntityCache.get(fileB);
+
+      if (!entityA || !entityB) continue;
+
+      // Find a representative episode for evidence (use most recent commit touching both)
+      // We just use the first available episode id for these files
+      let evidenceEpisodeId: string | null = null;
+      for (const [sha, files] of commitFiles) {
+        if (files.includes(fileA) && files.includes(fileB)) {
+          evidenceEpisodeId = episodeIds.get(sha) ?? null;
+          if (evidenceEpisodeId) break;
+        }
+      }
+
+      if (!evidenceEpisodeId) continue;
+
+      const evidence: EvidenceInput[] = [
+        {
+          episode_id: evidenceEpisodeId,
+          extractor: EXTRACTOR,
+          confidence: 0.8,
+        },
+      ];
+
+      // Check for existing co_changes_with edge (either direction)
+      const existingAB = graph.db
+        .query<{ id: string }, [string, string, string, string]>(
+          `SELECT id FROM edges
+           WHERE source_id = ? AND target_id = ? AND relation_type = ?
+             AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
+        )
+        .get(entityA, entityB, "co_changes_with", "inferred");
+
+      const existingBA = graph.db
+        .query<{ id: string }, [string, string, string, string]>(
+          `SELECT id FROM edges
+           WHERE source_id = ? AND target_id = ? AND relation_type = ?
+             AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
+        )
+        .get(entityB, entityA, "co_changes_with", "inferred");
+
+      if (!existingAB && !existingBA) {
+        addEdge(
+          graph,
+          {
+            source_id: entityA,
+            target_id: entityB,
+            relation_type: "co_changes_with",
+            edge_kind: "inferred",
+            fact: `${fileA} and ${fileB} co-change frequently (${count} shared commits)`,
+            weight: Math.min(count / 10, 1.0),
+            confidence: 0.8,
+          },
+          evidence,
+        );
+        counts.edgesCreated++;
+      }
+    }
+
+    // -------------------------------------------------------------------
+    // Pass 3: likely_owner_of edges (inferred, recency-weighted)
+    // -------------------------------------------------------------------
+    for (const [filePath, authorEntries] of fileAuthorMap) {
+      const fileId = fileEntityCache.get(filePath);
+      if (!fileId) continue;
+
+      // Sum recency-weighted scores per author
+      const authorScores = new Map<string, number>();
+      for (const { email, ts } of authorEntries) {
+        const w = recencyWeight(ts, nowMs);
+        authorScores.set(email, (authorScores.get(email) ?? 0) + w);
+      }
+
+      // Find top author
+      let topEmail: string | null = null;
+      let topScore = -1;
+      for (const [email, score] of authorScores) {
+        if (score > topScore) {
+          topScore = score;
+          topEmail = email;
+        }
+      }
+
+      if (!topEmail) continue;
+
+      const ownerId = authorEntityCache.get(topEmail);
+      if (!ownerId) continue;
+
+      // Find a representative episode
+      let evidenceEpisodeId: string | null = null;
+      for (const [sha, files] of commitFiles) {
+        const ep = episodeIds.get(sha);
+        if (ep && files.includes(filePath)) {
+          // Try to find the commit by this author
+          const commit = commits.find(
+            (c) => c.sha === sha && c.authorEmail === topEmail,
+          );
+          if (commit) {
+            evidenceEpisodeId = ep;
+            break;
+          }
+        }
+      }
+      // Fallback: any episode touching this file
+      if (!evidenceEpisodeId) {
+        for (const [sha, files] of commitFiles) {
+          if (files.includes(filePath)) {
+            evidenceEpisodeId = episodeIds.get(sha) ?? null;
+            if (evidenceEpisodeId) break;
+          }
+        }
+      }
+
+      if (!evidenceEpisodeId) continue;
+
+      const evidence: EvidenceInput[] = [
+        {
+          episode_id: evidenceEpisodeId,
+          extractor: EXTRACTOR,
+          confidence: topScore,
+        },
+      ];
+
+      // Check for existing likely_owner_of edge for this file
+      const existing = graph.db
+        .query<{ id: string; target_id: string }, [string, string, string]>(
+          `SELECT id, target_id FROM edges
+           WHERE source_id = ? AND relation_type = ? AND edge_kind = ?
+             AND invalidated_at IS NULL LIMIT 1`,
+        )
+        .get(fileId, "likely_owner_of", "inferred");
+
+      if (existing) {
+        if (existing.target_id !== ownerId) {
+          // Owner changed — supersede
+          supersedeEdge(
+            graph,
+            existing.id,
+            {
+              source_id: fileId,
+              target_id: ownerId,
+              relation_type: "likely_owner_of",
+              edge_kind: "inferred",
+              fact: `${filePath} is likely owned by ${topEmail} (recency-weighted score: ${topScore.toFixed(3)})`,
+              confidence: Math.min(topScore, 1.0),
+            },
+            evidence,
+          );
+          counts.edgesSuperseded++;
+          counts.edgesCreated++;
+        }
+        // else same owner — skip
+      } else {
+        addEdge(
+          graph,
+          {
+            source_id: fileId,
+            target_id: ownerId,
+            relation_type: "likely_owner_of",
+            edge_kind: "inferred",
+            fact: `${filePath} is likely owned by ${topEmail} (recency-weighted score: ${topScore.toFixed(3)})`,
+            confidence: Math.min(topScore, 1.0),
+          },
+          evidence,
+        );
+        counts.edgesCreated++;
+      }
+    }
+
+    // -------------------------------------------------------------------
+    // Finalize
+    // -------------------------------------------------------------------
+    completeIngestionRun(graph, runId, latestSha, {
+      episodes: counts.episodesCreated,
+      entities: counts.entitiesCreated,
+      edges: counts.edgesCreated,
+    });
+
+    return { ...counts, runId };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    failIngestionRun(graph, runId, msg);
+    throw err;
+  }
+}

--- a/packages/engram-core/src/temporal/history.ts
+++ b/packages/engram-core/src/temporal/history.ts
@@ -1,0 +1,29 @@
+/**
+ * history.ts — getFactHistory: chronological edge history between two entities.
+ */
+
+import type { EngramGraph } from "../format/index.js";
+import type { Edge } from "../graph/edges.js";
+
+/**
+ * Returns ALL edges between source_id and target_id (active and invalidated),
+ * ordered by valid_from ASC NULLS FIRST, then created_at ASC.
+ *
+ * This gives a full temporal history of the relationship between two entities.
+ */
+export function getFactHistory(
+  graph: EngramGraph,
+  source_id: string,
+  target_id: string,
+): Edge[] {
+  return graph.db
+    .query<Edge, [string, string]>(
+      `SELECT * FROM edges
+       WHERE source_id = ? AND target_id = ?
+       ORDER BY
+         CASE WHEN valid_from IS NULL THEN 0 ELSE 1 END ASC,
+         valid_from ASC,
+         created_at ASC`,
+    )
+    .all(source_id, target_id);
+}

--- a/packages/engram-core/src/temporal/index.ts
+++ b/packages/engram-core/src/temporal/index.ts
@@ -1,0 +1,6 @@
+/**
+ * temporal/index.ts — re-exports for the temporal engine module.
+ */
+
+export { getFactHistory } from "./history.js";
+export { checkActiveEdgeConflict, supersedeEdge } from "./supersession.js";

--- a/packages/engram-core/src/temporal/supersession.ts
+++ b/packages/engram-core/src/temporal/supersession.ts
@@ -1,0 +1,148 @@
+/**
+ * supersession.ts — supersedeEdge and active-edge conflict detection.
+ */
+
+import type { EngramGraph } from "../format/index.js";
+import type { Edge, EdgeInput } from "../graph/edges.js";
+import { addEdge } from "../graph/edges.js";
+import type { EvidenceInput } from "../graph/entities.js";
+import { EdgeNotFoundError } from "../graph/errors.js";
+
+/**
+ * Checks whether a new edge would overlap with any existing active edge that
+ * shares the same (source_id, target_id, relation_type, edge_kind).
+ *
+ * Two validity windows overlap when they are not disjoint:
+ *   NOT (e.valid_until <= new.valid_from  OR  new.valid_until <= e.valid_from)
+ * NULLs are treated as ±∞:
+ *   - NULL valid_from  = -∞ (edge has no known start — it could overlap anything)
+ *   - NULL valid_until = +∞ (edge is still current — it overlaps everything after valid_from)
+ *
+ * Returns the first conflicting edge, or null if none found.
+ */
+export function checkActiveEdgeConflict(
+  graph: EngramGraph,
+  source_id: string,
+  target_id: string,
+  relation_type: string,
+  edge_kind: string,
+  valid_from: string | null,
+  valid_until: string | null,
+): Edge | null {
+  // We look for active edges where the windows overlap.
+  // Overlap = NOT (e ends before new starts  OR  new ends before e starts)
+  //
+  // "e ends before new starts" means:
+  //   e.valid_until IS NOT NULL AND e.valid_until <= new.valid_from
+  //   (if e.valid_until IS NULL it extends to +∞ so it never ends before anything)
+  //
+  // "new ends before e starts" means:
+  //   new.valid_until IS NOT NULL AND new.valid_until <= e.valid_from
+  //   (if new.valid_until IS NULL it extends to +∞ so it never ends before anything)
+  //
+  // Because SQLite only supports positional params we build the SQL dynamically.
+  const conditions: string[] = [
+    "source_id = ?",
+    "target_id = ?",
+    "relation_type = ?",
+    "edge_kind = ?",
+    "invalidated_at IS NULL",
+  ];
+  const params: unknown[] = [source_id, target_id, relation_type, edge_kind];
+
+  // Build "e ends before new starts" clause
+  let eEndsBeforeNew: string;
+  if (valid_from === null) {
+    // new starts at -∞ → nothing can end before -∞
+    eEndsBeforeNew = "0";
+  } else {
+    eEndsBeforeNew = `(e.valid_until IS NOT NULL AND e.valid_until <= ?)`;
+    params.push(valid_from);
+  }
+
+  // Build "new ends before e starts" clause
+  let newEndsBeforeE: string;
+  if (valid_until === null) {
+    // new extends to +∞ → it never ends before anything
+    newEndsBeforeE = "0";
+  } else {
+    newEndsBeforeE = `(e.valid_from IS NOT NULL AND ? <= e.valid_from)`;
+    params.push(valid_until);
+  }
+
+  const noOverlap = `(${eEndsBeforeNew} OR ${newEndsBeforeE})`;
+  conditions.push(`NOT ${noOverlap}`);
+
+  const sql = `SELECT * FROM edges e WHERE ${conditions.join(" AND ")} LIMIT 1`;
+  return graph.db.query<Edge, unknown[]>(sql).get(...params) ?? null;
+}
+
+/**
+ * Atomically supersedes an existing edge with a new one.
+ *
+ * Steps (all inside one SQLite transaction):
+ * 1. Fetch old edge — throws EdgeNotFoundError if not found.
+ * 2. Verify old edge is active (invalidated_at IS NULL) — throws if already superseded.
+ * 3. Insert new edge (with evidence).
+ * 4. Set old edge: invalidated_at = now, superseded_by = new_id, valid_until = new.valid_from ?? now.
+ *
+ * Returns { old: updatedOldEdge, new: newEdge }.
+ */
+export function supersedeEdge(
+  graph: EngramGraph,
+  old_edge_id: string,
+  new_edge: EdgeInput,
+  evidence: EvidenceInput[],
+): { old: Edge; new: Edge } {
+  const oldEdge = graph.db
+    .query<Edge, [string]>("SELECT * FROM edges WHERE id = ?")
+    .get(old_edge_id);
+
+  if (!oldEdge) {
+    throw new EdgeNotFoundError(old_edge_id);
+  }
+
+  if (oldEdge.invalidated_at !== null) {
+    throw new Error(
+      `supersedeEdge: edge ${old_edge_id} is already superseded (invalidated_at = ${oldEdge.invalidated_at})`,
+    );
+  }
+
+  const now = new Date().toISOString();
+  // Use a container so the transaction closure can assign and we can read it after.
+  const result: { newEdge: Edge | null } = { newEdge: null };
+
+  graph.db.transaction(() => {
+    // Insert the new edge within the transaction
+    result.newEdge = addEdge(graph, new_edge, evidence);
+
+    // The old edge's valid_until becomes the new edge's valid_from (or now if unset)
+    const closingValidUntil = new_edge.valid_from ?? now;
+
+    graph.db
+      .prepare<void, [string, string, string, string]>(
+        `UPDATE edges
+         SET invalidated_at = ?,
+             superseded_by  = ?,
+             valid_until    = ?
+         WHERE id = ?`,
+      )
+      .run(now, result.newEdge.id, closingValidUntil, old_edge_id);
+  })();
+
+  if (!result.newEdge) {
+    throw new Error("supersedeEdge: new edge was not created");
+  }
+
+  const updatedOldEdge = graph.db
+    .query<Edge, [string]>("SELECT * FROM edges WHERE id = ?")
+    .get(old_edge_id);
+
+  if (!updatedOldEdge) {
+    throw new Error(
+      `supersedeEdge: failed to retrieve old edge ${old_edge_id} after update`,
+    );
+  }
+
+  return { old: updatedOldEdge, new: result.newEdge };
+}

--- a/packages/engram-core/src/temporal/supersession.ts
+++ b/packages/engram-core/src/temporal/supersession.ts
@@ -94,25 +94,31 @@ export function supersedeEdge(
   new_edge: EdgeInput,
   evidence: EvidenceInput[],
 ): { old: Edge; new: Edge } {
-  const oldEdge = graph.db
-    .query<Edge, [string]>("SELECT * FROM edges WHERE id = ?")
-    .get(old_edge_id);
-
-  if (!oldEdge) {
-    throw new EdgeNotFoundError(old_edge_id);
-  }
-
-  if (oldEdge.invalidated_at !== null) {
-    throw new Error(
-      `supersedeEdge: edge ${old_edge_id} is already superseded (invalidated_at = ${oldEdge.invalidated_at})`,
-    );
-  }
-
   const now = new Date().toISOString();
   // Use a container so the transaction closure can assign and we can read it after.
-  const result: { newEdge: Edge | null } = { newEdge: null };
+  const result: { newEdge: Edge | null; oldEdge: Edge | null } = {
+    newEdge: null,
+    oldEdge: null,
+  };
 
   graph.db.transaction(() => {
+    // Fetch old edge inside transaction to prevent TOCTOU race
+    const oldEdge = graph.db
+      .query<Edge, [string]>("SELECT * FROM edges WHERE id = ?")
+      .get(old_edge_id);
+
+    if (!oldEdge) {
+      throw new EdgeNotFoundError(old_edge_id);
+    }
+
+    if (oldEdge.invalidated_at !== null) {
+      throw new Error(
+        `supersedeEdge: edge ${old_edge_id} is already superseded (invalidated_at = ${oldEdge.invalidated_at})`,
+      );
+    }
+
+    result.oldEdge = oldEdge;
+
     // Insert the new edge within the transaction
     result.newEdge = addEdge(graph, new_edge, evidence);
 
@@ -125,9 +131,22 @@ export function supersedeEdge(
          SET invalidated_at = ?,
              superseded_by  = ?,
              valid_until    = ?
-         WHERE id = ?`,
+         WHERE id = ? AND invalidated_at IS NULL`,
       )
       .run(now, result.newEdge.id, closingValidUntil, old_edge_id);
+
+    // Verify the update actually succeeded by checking the row
+    const verifyRow = graph.db
+      .query<{ invalidated_at: string | null }, [string]>(
+        "SELECT invalidated_at FROM edges WHERE id = ?",
+      )
+      .get(old_edge_id);
+
+    if (!verifyRow || verifyRow.invalidated_at === null) {
+      throw new Error(
+        `supersedeEdge: failed to invalidate edge ${old_edge_id} — it may have been concurrently superseded`,
+      );
+    }
   })();
 
   if (!result.newEdge) {

--- a/packages/engram-core/test/ingest/git.test.ts
+++ b/packages/engram-core/test/ingest/git.test.ts
@@ -1,0 +1,308 @@
+/**
+ * git.test.ts — integration tests for git VCS ingestion.
+ *
+ * Uses the engram repo itself as the test fixture (real git history).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { EngramGraph } from "../../src/index.js";
+import { closeGraph, createGraph } from "../../src/index.js";
+import { ingestGitRepo } from "../../src/ingest/git.js";
+import { parseGitLog, recencyWeight } from "../../src/ingest/git-parse.js";
+
+// Path to the engram repo root (two levels up from packages/engram-core)
+const ENGRAM_REPO = path.resolve(import.meta.dir, "../../../../");
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests for git-parse helpers
+// ---------------------------------------------------------------------------
+
+describe("parseGitLog", () => {
+  test("parses an empty string", () => {
+    expect(parseGitLog("")).toEqual([]);
+    expect(parseGitLog("   \n  ")).toEqual([]);
+  });
+
+  test("parses a single commit with files", () => {
+    const raw = [
+      "abc1234567890abc1234567890abc1234567890ab",
+      "author@example.com",
+      "Author Name",
+      "1700000000",
+      "feat: add something",
+      "",
+      "---COMMIT-END---",
+      "src/foo.ts",
+      "src/bar.ts",
+      "",
+    ].join("\n");
+
+    const commits = parseGitLog(raw);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]?.sha).toBe("abc1234567890abc1234567890abc1234567890ab");
+    expect(commits[0]?.authorEmail).toBe("author@example.com");
+    expect(commits[0]?.authorName).toBe("Author Name");
+    expect(commits[0]?.timestampUnix).toBe(1700000000);
+    expect(commits[0]?.subject).toBe("feat: add something");
+    expect(commits[0]?.files).toContain("src/foo.ts");
+    expect(commits[0]?.files).toContain("src/bar.ts");
+  });
+
+  test("parses a commit with body text", () => {
+    const raw = [
+      "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      "dev@example.com",
+      "Dev User",
+      "1700000000",
+      "fix: something broken",
+      "This is the body.",
+      "More body text.",
+      "",
+      "---COMMIT-END---",
+      "README.md",
+      "",
+    ].join("\n");
+
+    const commits = parseGitLog(raw);
+    expect(commits).toHaveLength(1);
+    expect(commits[0]?.body).toContain("This is the body.");
+    expect(commits[0]?.files).toContain("README.md");
+  });
+
+  test("parses multiple commits", () => {
+    const raw = [
+      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "a@example.com",
+      "Alice",
+      "1700000001",
+      "first commit",
+      "",
+      "---COMMIT-END---",
+      "a.ts",
+      "",
+      "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "b@example.com",
+      "Bob",
+      "1700000002",
+      "second commit",
+      "",
+      "---COMMIT-END---",
+      "b.ts",
+      "",
+    ].join("\n");
+
+    const commits = parseGitLog(raw);
+    expect(commits).toHaveLength(2);
+    expect(commits[0]?.sha).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(commits[1]?.sha).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+  });
+});
+
+describe("recencyWeight", () => {
+  test("weight is 1.0 for a commit made right now", () => {
+    const now = Date.now();
+    const w = recencyWeight(now / 1000, now);
+    expect(w).toBeCloseTo(1.0, 5);
+  });
+
+  test("weight is ~0.5 for a commit 90 days ago (half-life)", () => {
+    const now = Date.now();
+    const ninetyDaysAgo = now - 90 * 24 * 60 * 60 * 1000;
+    const w = recencyWeight(ninetyDaysAgo / 1000, now);
+    expect(w).toBeCloseTo(0.5, 2);
+  });
+
+  test("older commits have lower weight", () => {
+    const now = Date.now();
+    const recent = recencyWeight(now / 1000 - 86400, now); // 1 day ago
+    const old = recencyWeight(now / 1000 - 86400 * 365, now); // 1 year ago
+    expect(recent).toBeGreaterThan(old);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: ingest engram repo
+// ---------------------------------------------------------------------------
+
+describe("ingestGitRepo — engram repo", () => {
+  test("ingestGitRepo returns a valid IngestResult", async () => {
+    const result = await ingestGitRepo(graph, ENGRAM_REPO, {
+      since: "1 year ago",
+    });
+
+    expect(result.runId).toBeDefined();
+    expect(result.episodesCreated).toBeGreaterThanOrEqual(0);
+    expect(result.episodesSkipped).toBeGreaterThanOrEqual(0);
+    expect(result.entitiesCreated).toBeGreaterThanOrEqual(0);
+    expect(result.edgesCreated).toBeGreaterThanOrEqual(0);
+  });
+
+  test("creates person entities for commit authors", async () => {
+    await ingestGitRepo(graph, ENGRAM_REPO, { since: "1 year ago" });
+
+    const persons = graph.db
+      .query<{ canonical_name: string }, []>(
+        "SELECT canonical_name FROM entities WHERE entity_type = 'person'",
+      )
+      .all();
+
+    // The repo should have at least one author
+    expect(persons.length).toBeGreaterThan(0);
+    // canonical_name for persons is their email
+    expect(persons.every((p) => p.canonical_name.includes("@"))).toBe(true);
+  });
+
+  test("creates module entities for changed files", async () => {
+    await ingestGitRepo(graph, ENGRAM_REPO, { since: "1 year ago" });
+
+    const modules = graph.db
+      .query<{ count: number }, []>(
+        "SELECT COUNT(*) AS count FROM entities WHERE entity_type = 'module'",
+      )
+      .get();
+
+    expect(modules?.count).toBeGreaterThan(0);
+  });
+
+  test("creates observed authored_by edges", async () => {
+    await ingestGitRepo(graph, ENGRAM_REPO, { since: "1 year ago" });
+
+    const edges = graph.db
+      .query<{ count: number }, []>(
+        `SELECT COUNT(*) AS count FROM edges
+         WHERE relation_type = 'authored_by' AND edge_kind = 'observed' AND invalidated_at IS NULL`,
+      )
+      .get();
+
+    expect(edges?.count).toBeGreaterThan(0);
+  });
+
+  test("creates ingestion_runs row with status=completed", async () => {
+    const result = await ingestGitRepo(graph, ENGRAM_REPO, {
+      since: "1 year ago",
+    });
+
+    const run = graph.db
+      .query<{ status: string; cursor: string | null }, [string]>(
+        "SELECT status, cursor FROM ingestion_runs WHERE id = ?",
+      )
+      .get(result.runId);
+
+    expect(run?.status).toBe("completed");
+  });
+
+  test("idempotency: second run skips already-ingested episodes", async () => {
+    const first = await ingestGitRepo(graph, ENGRAM_REPO, {
+      since: "1 year ago",
+    });
+
+    // Second run over same range — all episodes should be skipped
+    const second = await ingestGitRepo(graph, ENGRAM_REPO, {
+      since: "1 year ago",
+    });
+
+    // Second run should have 0 new episodes created (all skipped via cursor)
+    // The cursor points to the latest SHA, so git log returns empty
+    expect(second.episodesCreated).toBe(0);
+    expect(second.runId).not.toBe(first.runId);
+  });
+
+  test("creates inferred likely_owner_of edges when files have commits", async () => {
+    await ingestGitRepo(graph, ENGRAM_REPO, { since: "1 year ago" });
+
+    const ownerEdges = graph.db
+      .query<{ count: number }, []>(
+        `SELECT COUNT(*) AS count FROM edges
+         WHERE relation_type = 'likely_owner_of' AND edge_kind = 'inferred'
+           AND invalidated_at IS NULL`,
+      )
+      .get();
+
+    // May be 0 if repo is too small — just verify no error and count >= 0
+    expect(ownerEdges?.count).toBeGreaterThanOrEqual(0);
+  });
+
+  test("all edges have at least one evidence link", async () => {
+    await ingestGitRepo(graph, ENGRAM_REPO, { since: "1 year ago" });
+
+    // Find any active edge without evidence
+    const orphaned = graph.db
+      .query<{ id: string }, []>(
+        `SELECT e.id FROM edges e
+         WHERE e.invalidated_at IS NULL
+           AND NOT EXISTS (SELECT 1 FROM edge_evidence ee WHERE ee.edge_id = e.id)`,
+      )
+      .all();
+
+    expect(orphaned).toHaveLength(0);
+  });
+
+  test("all entities have at least one evidence link", async () => {
+    await ingestGitRepo(graph, ENGRAM_REPO, { since: "1 year ago" });
+
+    const orphaned = graph.db
+      .query<{ id: string }, []>(
+        `SELECT en.id FROM entities en
+         WHERE NOT EXISTS (SELECT 1 FROM entity_evidence ev WHERE ev.entity_id = en.id)`,
+      )
+      .all();
+
+    expect(orphaned).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe("ingestGitRepo — error cases", () => {
+  test("throws on non-existent path", async () => {
+    await expect(
+      ingestGitRepo(graph, "/tmp/this-path-does-not-exist-engram-test"),
+    ).rejects.toThrow();
+  });
+
+  test("throws on non-git directory", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-test-"));
+    try {
+      await expect(ingestGitRepo(graph, tmpDir)).rejects.toThrow();
+    } finally {
+      fs.rmdirSync(tmpDir);
+    }
+  });
+
+  test("sets status=failed on ingestion_runs when error occurs", async () => {
+    try {
+      await ingestGitRepo(graph, "/tmp/nonexistent-repo-path-engram");
+    } catch {
+      // Expected
+    }
+
+    // Check if any failed run was recorded
+    const failedRun = graph.db
+      .query<{ id: string; status: string }, []>(
+        "SELECT id, status FROM ingestion_runs WHERE status = 'failed' LIMIT 1",
+      )
+      .get();
+
+    // If the error happened before DB write, that's fine too
+    // Just verify no "running" runs are left dangling from successful error handling
+    // (The run may not exist if validation fails before DB insert — that's OK)
+    if (failedRun) {
+      expect(failedRun.status).toBe("failed");
+    }
+  });
+});

--- a/packages/engram-core/test/ingest/github.test.ts
+++ b/packages/engram-core/test/ingest/github.test.ts
@@ -1,0 +1,430 @@
+/**
+ * github.test.ts — Tests for the GitHubAdapter with mocked fetch.
+ *
+ * All tests use mock fetch — no real GitHub API calls are made.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { closeGraph, createGraph, type EngramGraph } from "../../src/index.js";
+import { GitHubAdapter } from "../../src/ingest/adapters/github.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+function makeFetch(responses: Record<string, unknown>): typeof fetch {
+  return async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    // Find matching response by URL substring
+    for (const [key, body] of Object.entries(responses)) {
+      if (url.includes(key)) {
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    // Default empty array (simulates no more pages)
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+const TEST_REPO = "owner/test-repo";
+const TEST_TOKEN = "test-token-never-stored";
+
+// ---------------------------------------------------------------------------
+// PR enrichment tests
+// ---------------------------------------------------------------------------
+
+describe("GitHubAdapter — PR enrichment", () => {
+  test("creates episodes for fetched PRs", async () => {
+    const fakePRs = [
+      {
+        number: 1,
+        html_url: "https://github.com/owner/test-repo/pull/1",
+        title: "Add feature X",
+        body: "This PR adds feature X.",
+        state: "closed",
+        user: { login: "alice" },
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-02T00:00:00Z",
+        requested_reviewers: [],
+        assignees: [],
+      },
+    ];
+
+    const adapter = new GitHubAdapter(makeFetch({ "/pulls": fakePRs }));
+    const result = await adapter.enrich(graph, {
+      token: TEST_TOKEN,
+      repo: TEST_REPO,
+    });
+
+    expect(result.episodesCreated).toBe(1);
+    expect(result.runId).toBeTruthy();
+
+    // Verify episode in DB
+    const episode = graph.db
+      .query<{ source_type: string; source_ref: string }, [string]>(
+        "SELECT source_type, source_ref FROM episodes WHERE source_ref = ?",
+      )
+      .get("https://github.com/owner/test-repo/pull/1");
+
+    expect(episode).toBeTruthy();
+    expect(episode?.source_type).toBe("github_pr");
+  });
+
+  test("creates reviewed_by edge for PR reviewer", async () => {
+    const fakePRs = [
+      {
+        number: 2,
+        html_url: "https://github.com/owner/test-repo/pull/2",
+        title: "Refactor Y",
+        body: "Refactoring Y module.",
+        state: "closed",
+        user: { login: "bob" },
+        created_at: "2024-02-01T00:00:00Z",
+        updated_at: "2024-02-02T00:00:00Z",
+        requested_reviewers: [{ login: "carol" }],
+        assignees: [],
+      },
+    ];
+
+    const adapter = new GitHubAdapter(makeFetch({ "/pulls": fakePRs }));
+    await adapter.enrich(graph, { token: TEST_TOKEN, repo: TEST_REPO });
+
+    // Verify reviewed_by edge exists
+    const edge = graph.db
+      .query<{ relation_type: string; edge_kind: string }, [string, string]>(
+        `SELECT e.relation_type, e.edge_kind FROM edges e
+         JOIN entities src ON src.id = e.source_id
+         JOIN entities tgt ON tgt.id = e.target_id
+         WHERE src.canonical_name = ? AND tgt.canonical_name = ?
+           AND e.invalidated_at IS NULL`,
+      )
+      .get("carol", "bob");
+
+    expect(edge).toBeTruthy();
+    expect(edge?.relation_type).toBe("reviewed_by");
+    expect(edge?.edge_kind).toBe("observed");
+  });
+
+  test("creates person entities for PR author and reviewers", async () => {
+    const fakePRs = [
+      {
+        number: 3,
+        html_url: "https://github.com/owner/test-repo/pull/3",
+        title: "Fix bug Z",
+        body: null,
+        state: "closed",
+        user: { login: "dave" },
+        created_at: "2024-03-01T00:00:00Z",
+        updated_at: "2024-03-02T00:00:00Z",
+        requested_reviewers: [{ login: "eve" }],
+        assignees: [],
+      },
+    ];
+
+    const adapter = new GitHubAdapter(makeFetch({ "/pulls": fakePRs }));
+    const result = await adapter.enrich(graph, {
+      token: TEST_TOKEN,
+      repo: TEST_REPO,
+    });
+
+    const dave = graph.db
+      .query<{ canonical_name: string }, [string]>(
+        "SELECT canonical_name FROM entities WHERE canonical_name = ? AND entity_type = 'person'",
+      )
+      .get("dave");
+    const eve = graph.db
+      .query<{ canonical_name: string }, [string]>(
+        "SELECT canonical_name FROM entities WHERE canonical_name = ? AND entity_type = 'person'",
+      )
+      .get("eve");
+
+    expect(dave).toBeTruthy();
+    expect(eve).toBeTruthy();
+    expect(result.entitiesCreated).toBeGreaterThan(0);
+  });
+
+  test("does not create reviewed_by edge for self-review", async () => {
+    const fakePRs = [
+      {
+        number: 4,
+        html_url: "https://github.com/owner/test-repo/pull/4",
+        title: "Self review PR",
+        body: null,
+        state: "closed",
+        user: { login: "frank" },
+        created_at: "2024-04-01T00:00:00Z",
+        updated_at: "2024-04-02T00:00:00Z",
+        requested_reviewers: [{ login: "frank" }], // same as author
+        assignees: [],
+      },
+    ];
+
+    const adapter = new GitHubAdapter(makeFetch({ "/pulls": fakePRs }));
+    await adapter.enrich(graph, { token: TEST_TOKEN, repo: TEST_REPO });
+
+    const edges = graph.db
+      .query<{ id: string }, []>(
+        `SELECT id FROM edges WHERE relation_type = 'reviewed_by' AND invalidated_at IS NULL`,
+      )
+      .all();
+
+    expect(edges.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue enrichment tests
+// ---------------------------------------------------------------------------
+
+describe("GitHubAdapter — Issue enrichment", () => {
+  test("creates episodes for fetched issues", async () => {
+    const fakeIssues = [
+      {
+        number: 10,
+        html_url: "https://github.com/owner/test-repo/issues/10",
+        title: "Bug report",
+        body: "Something is broken.",
+        state: "open",
+        user: { login: "alice" },
+        created_at: "2024-05-01T00:00:00Z",
+        updated_at: "2024-05-02T00:00:00Z",
+      },
+    ];
+
+    const adapter = new GitHubAdapter(makeFetch({ "/issues": fakeIssues }));
+    const result = await adapter.enrich(graph, {
+      token: TEST_TOKEN,
+      repo: TEST_REPO,
+    });
+
+    expect(result.episodesCreated).toBe(1);
+
+    const episode = graph.db
+      .query<{ source_type: string }, [string]>(
+        "SELECT source_type FROM episodes WHERE source_ref = ?",
+      )
+      .get("https://github.com/owner/test-repo/issues/10");
+
+    expect(episode?.source_type).toBe("github_issue");
+  });
+
+  test("skips issues that are actually PRs (pull_request field present)", async () => {
+    const fakeIssues = [
+      {
+        number: 11,
+        html_url: "https://github.com/owner/test-repo/pull/11",
+        title: "PR as issue",
+        body: "This comes from /issues endpoint but is a PR.",
+        state: "closed",
+        user: { login: "bob" },
+        created_at: "2024-05-03T00:00:00Z",
+        updated_at: "2024-05-04T00:00:00Z",
+        pull_request: { url: "https://api.github.com/..." },
+      },
+    ];
+
+    const adapter = new GitHubAdapter(makeFetch({ "/issues": fakeIssues }));
+    const result = await adapter.enrich(graph, {
+      token: TEST_TOKEN,
+      repo: TEST_REPO,
+    });
+
+    // Should have skipped the PR-as-issue
+    expect(result.episodesCreated).toBe(0);
+  });
+
+  test("creates issue entity with references edge to mentioned PR entity", async () => {
+    // First create a PR entity so the reference can be resolved
+    const fakePRs = [
+      {
+        number: 5,
+        html_url: "https://github.com/owner/test-repo/pull/5",
+        title: "PR being referenced",
+        body: null,
+        state: "closed",
+        user: { login: "carol" },
+        created_at: "2024-06-01T00:00:00Z",
+        updated_at: "2024-06-02T00:00:00Z",
+        requested_reviewers: [],
+        assignees: [],
+      },
+    ];
+
+    const fakeIssues = [
+      {
+        number: 12,
+        html_url: "https://github.com/owner/test-repo/issues/12",
+        title: "Issue referencing PR",
+        body: "This is fixed by #5.",
+        state: "open",
+        user: { login: "dave" },
+        created_at: "2024-06-03T00:00:00Z",
+        updated_at: "2024-06-04T00:00:00Z",
+      },
+    ];
+
+    const adapter = new GitHubAdapter(
+      makeFetch({ "/pulls": fakePRs, "/issues": fakeIssues }),
+    );
+    await adapter.enrich(graph, { token: TEST_TOKEN, repo: TEST_REPO });
+
+    // The issue entity should exist
+    const issueEntity = graph.db
+      .query<{ id: string }, [string]>(
+        "SELECT id FROM entities WHERE canonical_name = ? AND entity_type = 'issue'",
+      )
+      .get("https://github.com/owner/test-repo/issues/12");
+
+    expect(issueEntity).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency tests
+// ---------------------------------------------------------------------------
+
+describe("GitHubAdapter — Idempotency", () => {
+  test("second run skips already-processed items via cursor", async () => {
+    const fakePRs = [
+      {
+        number: 20,
+        html_url: "https://github.com/owner/test-repo/pull/20",
+        title: "First PR",
+        body: "Content.",
+        state: "closed",
+        user: { login: "alice" },
+        created_at: "2024-07-01T00:00:00Z",
+        updated_at: "2024-07-02T00:00:00Z",
+        requested_reviewers: [],
+        assignees: [],
+      },
+    ];
+
+    const adapter = new GitHubAdapter(makeFetch({ "/pulls": fakePRs }));
+
+    // First run
+    const first = await adapter.enrich(graph, {
+      token: TEST_TOKEN,
+      repo: TEST_REPO,
+    });
+    expect(first.episodesCreated).toBe(1);
+
+    // Second run with same data — cursor should skip PR #20
+    const second = await adapter.enrich(graph, {
+      token: TEST_TOKEN,
+      repo: TEST_REPO,
+    });
+    expect(second.episodesCreated).toBe(0);
+    expect(second.episodesSkipped).toBe(1);
+  });
+
+  test("second run picks up new items beyond cursor", async () => {
+    const firstBatch = [
+      {
+        number: 30,
+        html_url: "https://github.com/owner/test-repo/pull/30",
+        title: "Older PR",
+        body: null,
+        state: "closed",
+        user: { login: "bob" },
+        created_at: "2024-08-01T00:00:00Z",
+        updated_at: "2024-08-02T00:00:00Z",
+        requested_reviewers: [],
+        assignees: [],
+      },
+    ];
+
+    const secondBatch = [
+      ...firstBatch,
+      {
+        number: 31,
+        html_url: "https://github.com/owner/test-repo/pull/31",
+        title: "Newer PR",
+        body: null,
+        state: "closed",
+        user: { login: "carol" },
+        created_at: "2024-08-03T00:00:00Z",
+        updated_at: "2024-08-04T00:00:00Z",
+        requested_reviewers: [],
+        assignees: [],
+      },
+    ];
+
+    const adapterFirst = new GitHubAdapter(makeFetch({ "/pulls": firstBatch }));
+    await adapterFirst.enrich(graph, { token: TEST_TOKEN, repo: TEST_REPO });
+
+    const adapterSecond = new GitHubAdapter(
+      makeFetch({ "/pulls": secondBatch }),
+    );
+    const second = await adapterSecond.enrich(graph, {
+      token: TEST_TOKEN,
+      repo: TEST_REPO,
+    });
+
+    expect(second.episodesCreated).toBe(1); // only PR #31 is new
+    expect(second.episodesSkipped).toBe(1); // PR #30 skipped
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation tests
+// ---------------------------------------------------------------------------
+
+describe("GitHubAdapter — Validation", () => {
+  test("throws if repo is missing", async () => {
+    const adapter = new GitHubAdapter(makeFetch({}));
+    await expect(adapter.enrich(graph, { token: TEST_TOKEN })).rejects.toThrow(
+      "opts.repo is required",
+    );
+  });
+
+  test("throws if repo format is invalid", async () => {
+    const adapter = new GitHubAdapter(makeFetch({}));
+    await expect(
+      adapter.enrich(graph, { token: TEST_TOKEN, repo: "not-valid" }),
+    ).rejects.toThrow("owner/repo");
+  });
+
+  test("uses custom endpoint (GitHub Enterprise)", async () => {
+    const urls: string[] = [];
+    const capturingFetch: typeof fetch = async (
+      input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) => {
+      urls.push(typeof input === "string" ? input : input.toString());
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const adapter = new GitHubAdapter(capturingFetch);
+    await adapter.enrich(graph, {
+      token: TEST_TOKEN,
+      repo: TEST_REPO,
+      endpoint: "https://github.example.com/api/v3",
+    });
+
+    expect(
+      urls.some((u) => u.startsWith("https://github.example.com/api/v3")),
+    ).toBe(true);
+  });
+});

--- a/packages/engram-core/test/temporal/temporal.test.ts
+++ b/packages/engram-core/test/temporal/temporal.test.ts
@@ -1,0 +1,579 @@
+/**
+ * temporal.test.ts — tests for the temporal engine: validity windows, supersession,
+ * history, and temporal findEdges filters.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Edge, EngramGraph } from "../../src/index.js";
+import {
+  addEdge,
+  addEntity,
+  addEpisode,
+  checkActiveEdgeConflict,
+  closeGraph,
+  createGraph,
+  findEdges,
+  getEdge,
+  getFactHistory,
+  supersedeEdge,
+} from "../../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+function makeEpisode() {
+  return addEpisode(graph, {
+    source_type: "manual",
+    source_ref: `ref-${Math.random()}`,
+    content: "test episode",
+    timestamp: new Date().toISOString(),
+  });
+}
+
+function makeEntity(name: string) {
+  const ep = makeEpisode();
+  return addEntity(graph, { canonical_name: name, entity_type: "module" }, [
+    { episode_id: ep.id, extractor: "test" },
+  ]);
+}
+
+function makeEdge(
+  sourceId: string,
+  targetId: string,
+  opts: {
+    valid_from?: string | null;
+    valid_until?: string | null;
+    relation_type?: string;
+    edge_kind?: string;
+  } = {},
+): Edge {
+  const ep = makeEpisode();
+  return addEdge(
+    graph,
+    {
+      source_id: sourceId,
+      target_id: targetId,
+      relation_type: opts.relation_type ?? "depends_on",
+      edge_kind: opts.edge_kind ?? "observed",
+      fact: "A depends on B",
+      valid_from: opts.valid_from === null ? undefined : opts.valid_from,
+      valid_until: opts.valid_until === null ? undefined : opts.valid_until,
+    },
+    [{ episode_id: ep.id, extractor: "test" }],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// supersedeEdge
+// ---------------------------------------------------------------------------
+
+describe("supersedeEdge", () => {
+  test("atomically invalidates old edge and creates new edge", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const old = makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+    });
+    const ep = makeEpisode();
+
+    const result = supersedeEdge(
+      graph,
+      old.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "A still depends on B (updated)",
+        valid_from: "2024-06-01T00:00:00Z",
+      },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    // Old edge should be invalidated
+    expect(result.old.invalidated_at).not.toBeNull();
+    expect(result.old.superseded_by).toBe(result.new.id);
+    // Old valid_until should equal new valid_from (no gap)
+    expect(result.old.valid_until).toBe("2024-06-01T00:00:00Z");
+
+    // New edge should be active
+    expect(result.new.invalidated_at).toBeNull();
+    expect(result.new.valid_from).toBe("2024-06-01T00:00:00Z");
+  });
+
+  test("old valid_until = now when new edge has no valid_from", () => {
+    const before = new Date().toISOString();
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const old = makeEdge(src.id, tgt.id);
+    const ep = makeEpisode();
+
+    const result = supersedeEdge(
+      graph,
+      old.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "updated fact",
+      },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    const after = new Date().toISOString();
+    const validUntil = result.old.valid_until;
+    expect(validUntil).not.toBeNull();
+    // valid_until should be between before and after (i.e. "now")
+    expect(validUntil != null && validUntil >= before).toBe(true);
+    expect(validUntil != null && validUntil <= after).toBe(true);
+  });
+
+  test("throws EdgeNotFoundError for unknown edge", () => {
+    const ep = makeEpisode();
+    expect(() =>
+      supersedeEdge(
+        graph,
+        "nonexistent-id",
+        {
+          source_id: "a",
+          target_id: "b",
+          relation_type: "r",
+          edge_kind: "observed",
+          fact: "f",
+        },
+        [{ episode_id: ep.id, extractor: "test" }],
+      ),
+    ).toThrow("edge not found");
+  });
+
+  test("throws when edge is already superseded", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const old = makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+    });
+    const ep1 = makeEpisode();
+
+    const _first = supersedeEdge(
+      graph,
+      old.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "second version",
+        valid_from: "2024-06-01T00:00:00Z",
+      },
+      [{ episode_id: ep1.id, extractor: "test" }],
+    );
+
+    const ep2 = makeEpisode();
+    expect(() =>
+      supersedeEdge(
+        graph,
+        old.id,
+        {
+          source_id: src.id,
+          target_id: tgt.id,
+          relation_type: "depends_on",
+          edge_kind: "observed",
+          fact: "third version",
+          valid_from: "2024-09-01T00:00:00Z",
+        },
+        [{ episode_id: ep2.id, extractor: "test" }],
+      ),
+    ).toThrow("already superseded");
+  });
+
+  test("supersession chain: old → mid → new", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const v1 = makeEdge(src.id, tgt.id, { valid_from: "2024-01-01T00:00:00Z" });
+    const ep2 = makeEpisode();
+
+    const r1 = supersedeEdge(
+      graph,
+      v1.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "v2",
+        valid_from: "2024-06-01T00:00:00Z",
+      },
+      [{ episode_id: ep2.id, extractor: "test" }],
+    );
+
+    const ep3 = makeEpisode();
+    const r2 = supersedeEdge(
+      graph,
+      r1.new.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "v3",
+        valid_from: "2025-01-01T00:00:00Z",
+      },
+      [{ episode_id: ep3.id, extractor: "test" }],
+    );
+
+    // v1 superseded by v2
+    const fetchedV1 = getEdge(graph, v1.id);
+    expect(fetchedV1?.superseded_by).toBe(r1.new.id);
+    expect(fetchedV1?.valid_until).toBe("2024-06-01T00:00:00Z");
+
+    // v2 superseded by v3
+    const fetchedV2 = getEdge(graph, r1.new.id);
+    expect(fetchedV2?.superseded_by).toBe(r2.new.id);
+    expect(fetchedV2?.valid_until).toBe("2025-01-01T00:00:00Z");
+
+    // v3 still active
+    expect(r2.new.invalidated_at).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkActiveEdgeConflict
+// ---------------------------------------------------------------------------
+
+describe("checkActiveEdgeConflict", () => {
+  test("detects conflict with open-ended active edge (NULL valid_until)", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    makeEdge(src.id, tgt.id, { valid_from: "2024-01-01T00:00:00Z" }); // valid_until = NULL
+
+    const conflict = checkActiveEdgeConflict(
+      graph,
+      src.id,
+      tgt.id,
+      "depends_on",
+      "observed",
+      "2024-06-01T00:00:00Z",
+      null,
+    );
+
+    expect(conflict).not.toBeNull();
+  });
+
+  test("no conflict when windows are adjacent (no overlap)", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2024-06-01T00:00:00Z",
+    });
+
+    const conflict = checkActiveEdgeConflict(
+      graph,
+      src.id,
+      tgt.id,
+      "depends_on",
+      "observed",
+      "2024-06-01T00:00:00Z", // starts exactly when old one ends — half-open so no overlap
+      null,
+    );
+
+    expect(conflict).toBeNull();
+  });
+
+  test("no conflict when windows are fully disjoint", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2024-03-01T00:00:00Z",
+    });
+
+    const conflict = checkActiveEdgeConflict(
+      graph,
+      src.id,
+      tgt.id,
+      "depends_on",
+      "observed",
+      "2024-06-01T00:00:00Z",
+      "2024-09-01T00:00:00Z",
+    );
+
+    expect(conflict).toBeNull();
+  });
+
+  test("no conflict with different relation_type", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+      relation_type: "imports",
+    });
+
+    const conflict = checkActiveEdgeConflict(
+      graph,
+      src.id,
+      tgt.id,
+      "depends_on",
+      "observed",
+      "2024-01-01T00:00:00Z",
+      null,
+    );
+
+    expect(conflict).toBeNull();
+  });
+
+  test("does not detect conflict for invalidated edges", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const old = makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+    });
+    const ep = makeEpisode();
+
+    supersedeEdge(
+      graph,
+      old.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "new version",
+        valid_from: "2024-06-01T00:00:00Z",
+      },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    // The old (now-invalidated) edge should not cause a conflict
+    const conflict = checkActiveEdgeConflict(
+      graph,
+      src.id,
+      tgt.id,
+      "depends_on",
+      "observed",
+      "2024-01-01T00:00:00Z",
+      "2024-05-01T00:00:00Z",
+    );
+
+    // The active edge (v2, valid from 2024-06-01) should not overlap with 2024-01 to 2024-05
+    expect(conflict).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFactHistory
+// ---------------------------------------------------------------------------
+
+describe("getFactHistory", () => {
+  test("returns all edges (active + invalidated) in chronological order", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const v1 = makeEdge(src.id, tgt.id, { valid_from: "2024-01-01T00:00:00Z" });
+    const ep2 = makeEpisode();
+
+    const r1 = supersedeEdge(
+      graph,
+      v1.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "v2",
+        valid_from: "2024-06-01T00:00:00Z",
+      },
+      [{ episode_id: ep2.id, extractor: "test" }],
+    );
+
+    const history = getFactHistory(graph, src.id, tgt.id);
+
+    expect(history.length).toBe(2);
+    // v1 comes first (earlier valid_from)
+    expect(history[0].id).toBe(v1.id);
+    expect(history[1].id).toBe(r1.new.id);
+  });
+
+  test("returns empty array when no edges exist", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const history = getFactHistory(graph, src.id, tgt.id);
+    expect(history).toEqual([]);
+  });
+
+  test("history includes only edges between the requested pair", () => {
+    const a = makeEntity("A");
+    const b = makeEntity("B");
+    const c = makeEntity("C");
+
+    makeEdge(a.id, b.id, { valid_from: "2024-01-01T00:00:00Z" });
+    makeEdge(a.id, c.id, { valid_from: "2024-03-01T00:00:00Z" });
+
+    const history = getFactHistory(graph, a.id, b.id);
+    expect(history.length).toBe(1);
+    expect(history[0].target_id).toBe(b.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findEdges — valid_at and include_invalidated filters
+// ---------------------------------------------------------------------------
+
+describe("findEdges temporal filters", () => {
+  test("valid_at returns only edges valid at that timestamp", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2024-06-01T00:00:00Z",
+    });
+    makeEdge(src.id, tgt.id, {
+      valid_from: "2024-06-01T00:00:00Z",
+      valid_until: "2025-01-01T00:00:00Z",
+      relation_type: "imports",
+    });
+
+    const janEdges = findEdges(graph, {
+      source_id: src.id,
+      valid_at: "2024-03-01T00:00:00Z",
+      include_invalidated: true,
+    });
+    expect(janEdges.length).toBe(1);
+    expect(janEdges[0].relation_type).toBe("depends_on");
+
+    const julyEdges = findEdges(graph, {
+      source_id: src.id,
+      valid_at: "2024-07-01T00:00:00Z",
+      include_invalidated: true,
+    });
+    expect(julyEdges.length).toBe(1);
+    expect(julyEdges[0].relation_type).toBe("imports");
+  });
+
+  test("valid_at with NULL valid_from (open start) includes the edge", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    makeEdge(src.id, tgt.id); // NULL valid_from, NULL valid_until
+
+    const edges = findEdges(graph, {
+      source_id: src.id,
+      valid_at: "2020-01-01T00:00:00Z",
+      include_invalidated: true,
+    });
+    expect(edges.length).toBe(1);
+  });
+
+  test("valid_at with NULL valid_until (still current) includes the edge", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    makeEdge(src.id, tgt.id, { valid_from: "2024-01-01T00:00:00Z" }); // valid_until = NULL
+
+    const edges = findEdges(graph, {
+      source_id: src.id,
+      valid_at: "2030-01-01T00:00:00Z",
+      include_invalidated: true,
+    });
+    expect(edges.length).toBe(1);
+  });
+
+  test("valid_at excludes edge whose valid_until equals the timestamp (half-open)", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2024-06-01T00:00:00Z",
+    });
+
+    // Exactly at valid_until → NOT valid (half-open [valid_from, valid_until))
+    const edges = findEdges(graph, {
+      source_id: src.id,
+      valid_at: "2024-06-01T00:00:00Z",
+      include_invalidated: true,
+    });
+    expect(edges.length).toBe(0);
+  });
+
+  test("include_invalidated: false (default) excludes invalidated edges", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const old = makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+    });
+    const ep = makeEpisode();
+
+    supersedeEdge(
+      graph,
+      old.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "new",
+        valid_from: "2024-06-01T00:00:00Z",
+      },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    const activeEdges = findEdges(graph, { source_id: src.id });
+    expect(activeEdges.length).toBe(1);
+    expect(activeEdges[0].invalidated_at).toBeNull();
+  });
+
+  test("include_invalidated: true returns all edges including invalidated", () => {
+    const src = makeEntity("A");
+    const tgt = makeEntity("B");
+
+    const old = makeEdge(src.id, tgt.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+    });
+    const ep = makeEpisode();
+
+    supersedeEdge(
+      graph,
+      old.id,
+      {
+        source_id: src.id,
+        target_id: tgt.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "new",
+        valid_from: "2024-06-01T00:00:00Z",
+      },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    const allEdges = findEdges(graph, {
+      source_id: src.id,
+      include_invalidated: true,
+    });
+    expect(allEdges.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- `EnrichmentAdapter` interface: `name`, `kind`, `enrich(graph, opts)` — extensible for future adapters (Gerrit, Jira, etc.)
- `GitHubAdapter` enriches the git-ingested graph with PR discussions and issue data via GitHub REST API
- PRs: episodes + `reviewed_by` edges; Issues: episodes + `references` edges
- Idempotent via `ingestion_runs` cursor; episode dedup via `source_ref = PR/issue URL`
- Token never stored — passed only at call time via `EnrichOpts.token`
- Injectable `fetchFn` for testable implementation (no real API calls in tests)

## Acceptance Criteria

- [x] `EnrichmentAdapter` interface defined
- [x] `GitHubAdapter` fetches PRs and issues
- [x] Episodes from PR/issue content; person entities for authors/reviewers
- [x] `reviewed_by` edges (reviewer → author), `references` edges (issue → mentioned items)
- [x] `EnrichOpts`: `since`, `token`, `endpoint`
- [x] Idempotent cursor in `ingestion_runs`
- [x] `IngestResult` returned

## Test plan

- [x] `bun test` — 117 tests pass (all mocked, no real API calls)
- [x] `bun run build` — succeeds
- [x] `bun run lint` — clean

> **Note:** Stacked on `feat/git-ingest-issue-5` (PR #20). Merge order: #15 → #17 → #18 → #19 → #20 → this PR.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)