### PR TITLE
feat: graph traversal and temporal queries

### DIFF
--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -55,13 +55,18 @@ export { ingestMarkdown } from "./ingest/markdown.js";
 export type { TextIngestOpts } from "./ingest/text.js";
 export { ingestText } from "./ingest/text.js";
 export type {
+  PathResult,
   ScoreComponents,
   SearchOpts,
   SearchResult,
+  SubGraph,
+  TraversalOpts,
 } from "./retrieval/index.js";
-export { search } from "./retrieval/index.js";
+export { getNeighbors, getPath, search } from "./retrieval/index.js";
+export type { TemporalSnapshot } from "./temporal/index.js";
 export {
   checkActiveEdgeConflict,
   getFactHistory,
+  getSnapshot,
   supersedeEdge,
 } from "./temporal/index.js";

--- a/packages/engram-core/src/retrieval/index.ts
+++ b/packages/engram-core/src/retrieval/index.ts
@@ -5,3 +5,9 @@
 export type { ScoreComponents } from "./scoring.js";
 export type { SearchOpts, SearchResult } from "./search.js";
 export { search } from "./search.js";
+export type {
+  PathResult,
+  SubGraph,
+  TraversalOpts,
+} from "./traversal.js";
+export { getNeighbors, getPath } from "./traversal.js";

--- a/packages/engram-core/src/retrieval/traversal.ts
+++ b/packages/engram-core/src/retrieval/traversal.ts
@@ -144,6 +144,7 @@ export function getPath(
   }
 
   const MAX_DEPTH = 10;
+  const maxHops = Math.min(opts.depth ?? MAX_DEPTH, MAX_DEPTH);
 
   // BFS state: track parent entity and edge used to reach each entity
   const visited = new Set<string>([from_id]);
@@ -151,7 +152,7 @@ export function getPath(
 
   let frontier: string[] = [from_id];
 
-  for (let hop = 0; hop < MAX_DEPTH; hop++) {
+  for (let hop = 0; hop < maxHops; hop++) {
     if (frontier.length === 0) break;
 
     const nextFrontier: string[] = [];
@@ -204,7 +205,10 @@ function reconstructPath(
   let current = to_id;
   while (current !== from_id) {
     const p = parent.get(current);
-    if (!p) break;
+    if (!p) {
+      // Incomplete path — return not-found instead of partial result
+      return { found: false, entities: [], edges: [], length: 0 };
+    }
     pathEdges.unshift(p.edge);
     pathEntityIds.unshift(p.entityId);
     current = p.entityId;

--- a/packages/engram-core/src/retrieval/traversal.ts
+++ b/packages/engram-core/src/retrieval/traversal.ts
@@ -1,0 +1,231 @@
+/**
+ * traversal.ts — graph traversal (BFS neighbors and shortest path).
+ */
+
+import type { EngramGraph } from "../format/index.js";
+import type { Edge, Entity } from "../graph/index.js";
+import { EntityNotFoundError, findEdges, getEntity } from "../graph/index.js";
+
+export interface SubGraph {
+  entities: Entity[];
+  edges: Edge[];
+}
+
+export interface TraversalOpts {
+  /** Max hops. Default 1. */
+  depth?: number;
+  /** Filter by edge_kind values. */
+  edge_kinds?: string[];
+  /** Only follow edges valid at this ISO8601 timestamp. */
+  valid_at?: string;
+  /** Direction of traversal. Default 'both'. */
+  direction?: "outbound" | "inbound" | "both";
+}
+
+export interface PathResult {
+  found: boolean;
+  entities: Entity[];
+  edges: Edge[];
+  length: number;
+}
+
+/**
+ * Collect edges from an entity respecting direction and options.
+ */
+function collectEdges(
+  graph: EngramGraph,
+  entity_id: string,
+  opts: TraversalOpts,
+): Edge[] {
+  const direction = opts.direction ?? "both";
+  const results: Edge[] = [];
+
+  const baseQuery = {
+    active_only: true as const,
+    valid_at: opts.valid_at,
+  };
+
+  if (direction === "outbound" || direction === "both") {
+    results.push(...findEdges(graph, { ...baseQuery, source_id: entity_id }));
+  }
+
+  if (direction === "inbound" || direction === "both") {
+    results.push(...findEdges(graph, { ...baseQuery, target_id: entity_id }));
+  }
+
+  if (opts.edge_kinds && opts.edge_kinds.length > 0) {
+    return results.filter((e) => opts.edge_kinds?.includes(e.edge_kind));
+  }
+
+  return results;
+}
+
+/**
+ * BFS from entity_id up to opts.depth hops (default 1).
+ * Returns deduplicated SubGraph of entities and edges.
+ */
+export function getNeighbors(
+  graph: EngramGraph,
+  entity_id: string,
+  opts: TraversalOpts = {},
+): SubGraph {
+  const start = getEntity(graph, entity_id);
+  if (!start) {
+    throw new EntityNotFoundError(entity_id);
+  }
+
+  const maxDepth = opts.depth ?? 1;
+  const visitedEntities = new Map<string, Entity>();
+  const visitedEdges = new Map<string, Edge>();
+
+  visitedEntities.set(start.id, start);
+
+  let frontier: string[] = [entity_id];
+
+  for (let hop = 0; hop < maxDepth; hop++) {
+    if (frontier.length === 0) break;
+
+    const nextFrontier: string[] = [];
+
+    for (const eid of frontier) {
+      const edges = collectEdges(graph, eid, opts);
+
+      for (const edge of edges) {
+        if (!visitedEdges.has(edge.id)) {
+          visitedEdges.set(edge.id, edge);
+        }
+
+        // Determine the neighbor entity ID
+        const neighborId =
+          edge.source_id === eid ? edge.target_id : edge.source_id;
+
+        if (!visitedEntities.has(neighborId)) {
+          const neighbor = getEntity(graph, neighborId);
+          if (neighbor) {
+            visitedEntities.set(neighborId, neighbor);
+            nextFrontier.push(neighborId);
+          }
+        }
+      }
+    }
+
+    frontier = nextFrontier;
+  }
+
+  return {
+    entities: Array.from(visitedEntities.values()),
+    edges: Array.from(visitedEdges.values()),
+  };
+}
+
+/**
+ * BFS shortest path between from_id and to_id.
+ * Max depth 10 to prevent unbounded traversal.
+ */
+export function getPath(
+  graph: EngramGraph,
+  from_id: string,
+  to_id: string,
+  opts: TraversalOpts = {},
+): PathResult {
+  const startEntity = getEntity(graph, from_id);
+  if (!startEntity) {
+    throw new EntityNotFoundError(from_id);
+  }
+
+  const endEntity = getEntity(graph, to_id);
+  if (!endEntity) {
+    throw new EntityNotFoundError(to_id);
+  }
+
+  // Trivial case
+  if (from_id === to_id) {
+    return { found: true, entities: [startEntity], edges: [], length: 0 };
+  }
+
+  const MAX_DEPTH = 10;
+
+  // BFS state: track parent entity and edge used to reach each entity
+  const visited = new Set<string>([from_id]);
+  const parent = new Map<string, { entityId: string; edge: Edge }>();
+
+  let frontier: string[] = [from_id];
+
+  for (let hop = 0; hop < MAX_DEPTH; hop++) {
+    if (frontier.length === 0) break;
+
+    const nextFrontier: string[] = [];
+
+    for (const eid of frontier) {
+      const edges = collectEdges(graph, eid, opts);
+
+      for (const edge of edges) {
+        const neighborId =
+          edge.source_id === eid ? edge.target_id : edge.source_id;
+
+        if (visited.has(neighborId)) continue;
+
+        visited.add(neighborId);
+        parent.set(neighborId, { entityId: eid, edge });
+
+        if (neighborId === to_id) {
+          // Reconstruct path
+          return reconstructPath(
+            graph,
+            from_id,
+            to_id,
+            parent,
+            startEntity,
+            endEntity,
+          );
+        }
+
+        nextFrontier.push(neighborId);
+      }
+    }
+
+    frontier = nextFrontier;
+  }
+
+  return { found: false, entities: [], edges: [], length: 0 };
+}
+
+function reconstructPath(
+  graph: EngramGraph,
+  from_id: string,
+  to_id: string,
+  parent: Map<string, { entityId: string; edge: Edge }>,
+  startEntity: Entity,
+  endEntity: Entity,
+): PathResult {
+  const pathEdges: Edge[] = [];
+  const pathEntityIds: string[] = [to_id];
+
+  let current = to_id;
+  while (current !== from_id) {
+    const p = parent.get(current);
+    if (!p) break;
+    pathEdges.unshift(p.edge);
+    pathEntityIds.unshift(p.entityId);
+    current = p.entityId;
+  }
+
+  const pathEntities: Entity[] = [];
+  for (const id of pathEntityIds) {
+    if (id === from_id) {
+      pathEntities.push(startEntity);
+    } else if (id === to_id) {
+      pathEntities.push(endEntity);
+    } else {
+      const e = getEntity(graph, id);
+      if (e) pathEntities.push(e);
+    }
+  }
+
+  return {
+    found: true,
+    entities: pathEntities,
+    edges: pathEdges,
+    length: pathEdges.length,
+  };
+}

--- a/packages/engram-core/src/temporal/index.ts
+++ b/packages/engram-core/src/temporal/index.ts
@@ -3,4 +3,6 @@
  */
 
 export { getFactHistory } from "./history.js";
+export type { TemporalSnapshot } from "./snapshot.js";
+export { getSnapshot } from "./snapshot.js";
 export { checkActiveEdgeConflict, supersedeEdge } from "./supersession.js";

--- a/packages/engram-core/src/temporal/snapshot.ts
+++ b/packages/engram-core/src/temporal/snapshot.ts
@@ -1,0 +1,27 @@
+/**
+ * snapshot.ts — temporal graph snapshots.
+ */
+
+import type { EngramGraph } from "../format/index.js";
+import type { Edge, Entity } from "../graph/index.js";
+import { findEdges, findEntities } from "../graph/index.js";
+
+export interface TemporalSnapshot {
+  /** The queried timestamp. */
+  at: string;
+  entities: Entity[];
+  /** Only edges valid at `at`. */
+  edges: Edge[];
+}
+
+/**
+ * Returns the graph state at the given ISO8601 UTC timestamp.
+ * Entities: all active entities (entities have no validity windows in v0.1).
+ * Edges: only edges valid at the given point in time.
+ */
+export function getSnapshot(graph: EngramGraph, at: string): TemporalSnapshot {
+  const entities = findEntities(graph, { status: "active" });
+  const edges = findEdges(graph, { valid_at: at, include_invalidated: false });
+
+  return { at, entities, edges };
+}

--- a/packages/engram-core/test/retrieval/traversal.test.ts
+++ b/packages/engram-core/test/retrieval/traversal.test.ts
@@ -1,0 +1,460 @@
+/**
+ * traversal.test.ts — tests for graph traversal and temporal snapshots.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EngramGraph } from "../../src/index.js";
+import {
+  addEdge,
+  addEntity,
+  addEpisode,
+  closeGraph,
+  createGraph,
+  EntityNotFoundError,
+  getNeighbors,
+  getPath,
+  getSnapshot,
+} from "../../src/index.js";
+
+let graph: EngramGraph;
+
+// Shared evidence for tests.
+const makeEvidence = (episodeId: string) => [
+  { episode_id: episodeId, extractor: "test", confidence: 1.0 },
+];
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function seedEpisode() {
+  return addEpisode(graph, {
+    source_type: "manual",
+    source_ref: `ref-${Date.now()}-${Math.random()}`,
+    content: "test episode",
+    timestamp: "2024-01-01T00:00:00Z",
+  });
+}
+
+function seedEntity(name: string, episodeId: string) {
+  return addEntity(
+    graph,
+    { canonical_name: name, entity_type: "module" },
+    makeEvidence(episodeId),
+  );
+}
+
+function seedEdge(
+  sourceId: string,
+  targetId: string,
+  episodeId: string,
+  opts: {
+    relation_type?: string;
+    edge_kind?: string;
+    valid_from?: string;
+    valid_until?: string;
+  } = {},
+) {
+  return addEdge(
+    graph,
+    {
+      source_id: sourceId,
+      target_id: targetId,
+      relation_type: opts.relation_type ?? "depends_on",
+      edge_kind: opts.edge_kind ?? "observed",
+      fact: `${sourceId} depends on ${targetId}`,
+      valid_from: opts.valid_from,
+      valid_until: opts.valid_until,
+    },
+    makeEvidence(episodeId),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// getNeighbors
+// ---------------------------------------------------------------------------
+
+describe("getNeighbors", () => {
+  test("throws EntityNotFoundError for unknown entity", () => {
+    expect(() => getNeighbors(graph, "nonexistent")).toThrow(
+      EntityNotFoundError,
+    );
+  });
+
+  test("returns only start entity when no edges", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+
+    const result = getNeighbors(graph, a.id);
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].id).toBe(a.id);
+    expect(result.edges).toHaveLength(0);
+  });
+
+  test("returns direct neighbors at depth 1 (default)", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+
+    const e1 = seedEdge(a.id, b.id, ep.id);
+    const e2 = seedEdge(a.id, c.id, ep.id);
+
+    const result = getNeighbors(graph, a.id);
+
+    const entityIds = result.entities.map((e) => e.id).sort();
+    expect(entityIds).toEqual([a.id, b.id, c.id].sort());
+
+    const edgeIds = result.edges.map((e) => e.id).sort();
+    expect(edgeIds).toEqual([e1.id, e2.id].sort());
+  });
+
+  test("depth 2 includes transitive neighbors", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+
+    seedEdge(a.id, b.id, ep.id);
+    seedEdge(b.id, c.id, ep.id);
+
+    const result = getNeighbors(graph, a.id, { depth: 2 });
+
+    const entityIds = result.entities.map((e) => e.id).sort();
+    expect(entityIds).toEqual([a.id, b.id, c.id].sort());
+    expect(result.edges).toHaveLength(2);
+  });
+
+  test("depth 1 does not include transitive neighbors", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+
+    seedEdge(a.id, b.id, ep.id);
+    seedEdge(b.id, c.id, ep.id);
+
+    const result = getNeighbors(graph, a.id, { depth: 1 });
+
+    const entityIds = result.entities.map((e) => e.id);
+    expect(entityIds).not.toContain(c.id);
+    expect(result.edges).toHaveLength(1);
+  });
+
+  test("direction outbound filters inbound edges", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+
+    const outEdge = seedEdge(a.id, b.id, ep.id); // outbound from a
+    seedEdge(c.id, a.id, ep.id); // inbound to a
+
+    const result = getNeighbors(graph, a.id, { direction: "outbound" });
+
+    const edgeIds = result.edges.map((e) => e.id);
+    expect(edgeIds).toContain(outEdge.id);
+    expect(edgeIds).toHaveLength(1);
+
+    const entityIds = result.entities.map((e) => e.id);
+    expect(entityIds).toContain(b.id);
+    expect(entityIds).not.toContain(c.id);
+  });
+
+  test("direction inbound filters outbound edges", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+
+    seedEdge(a.id, b.id, ep.id); // outbound from a
+    const inEdge = seedEdge(c.id, a.id, ep.id); // inbound to a
+
+    const result = getNeighbors(graph, a.id, { direction: "inbound" });
+
+    const edgeIds = result.edges.map((e) => e.id);
+    expect(edgeIds).toContain(inEdge.id);
+    expect(edgeIds).toHaveLength(1);
+  });
+
+  test("edge_kinds filter excludes non-matching edges", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+
+    const obsEdge = seedEdge(a.id, b.id, ep.id, { edge_kind: "observed" });
+    seedEdge(a.id, c.id, ep.id, { edge_kind: "inferred" });
+
+    const result = getNeighbors(graph, a.id, { edge_kinds: ["observed"] });
+
+    const edgeIds = result.edges.map((e) => e.id);
+    expect(edgeIds).toEqual([obsEdge.id]);
+
+    const entityIds = result.entities.map((e) => e.id);
+    expect(entityIds).toContain(b.id);
+    expect(entityIds).not.toContain(c.id);
+  });
+
+  test("valid_at filters out edges outside validity window", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    // Edge valid 2024-01 only
+    seedEdge(a.id, b.id, ep.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2024-02-01T00:00:00Z",
+    });
+
+    // Query at 2025 — edge should not be included
+    const result = getNeighbors(graph, a.id, {
+      valid_at: "2025-01-01T00:00:00Z",
+    });
+
+    expect(result.edges).toHaveLength(0);
+    expect(result.entities).toHaveLength(1); // only start
+  });
+
+  test("deduplicates entities and edges when multiple paths exist", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+
+    // A -> B and A -> C -> B (at depth 2, B appears via two paths)
+    seedEdge(a.id, b.id, ep.id);
+    seedEdge(a.id, c.id, ep.id);
+    seedEdge(c.id, b.id, ep.id);
+
+    const result = getNeighbors(graph, a.id, { depth: 2 });
+
+    const entityIds = result.entities.map((e) => e.id);
+    const uniqueEntityIds = [...new Set(entityIds)];
+    expect(entityIds).toHaveLength(uniqueEntityIds.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPath
+// ---------------------------------------------------------------------------
+
+describe("getPath", () => {
+  test("throws EntityNotFoundError for unknown from_id", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    expect(() => getPath(graph, "nonexistent", a.id)).toThrow(
+      EntityNotFoundError,
+    );
+  });
+
+  test("throws EntityNotFoundError for unknown to_id", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    expect(() => getPath(graph, a.id, "nonexistent")).toThrow(
+      EntityNotFoundError,
+    );
+  });
+
+  test("trivial path: from and to are the same entity", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+
+    const result = getPath(graph, a.id, a.id);
+
+    expect(result.found).toBe(true);
+    expect(result.entities).toHaveLength(1);
+    expect(result.edges).toHaveLength(0);
+    expect(result.length).toBe(0);
+  });
+
+  test("returns not found when no path exists", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    // No edges between a and b
+    const result = getPath(graph, a.id, b.id);
+
+    expect(result.found).toBe(false);
+    expect(result.entities).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+    expect(result.length).toBe(0);
+  });
+
+  test("finds direct path (1 hop)", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    const edge = seedEdge(a.id, b.id, ep.id);
+
+    const result = getPath(graph, a.id, b.id);
+
+    expect(result.found).toBe(true);
+    expect(result.length).toBe(1);
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].id).toBe(edge.id);
+    expect(result.entities.map((e) => e.id)).toEqual([a.id, b.id]);
+  });
+
+  test("finds multi-hop path", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+
+    seedEdge(a.id, b.id, ep.id);
+    seedEdge(b.id, c.id, ep.id);
+
+    const result = getPath(graph, a.id, c.id);
+
+    expect(result.found).toBe(true);
+    expect(result.length).toBe(2);
+    expect(result.entities).toHaveLength(3);
+    expect(result.entities[0].id).toBe(a.id);
+    expect(result.entities[result.entities.length - 1].id).toBe(c.id);
+  });
+
+  test("returns shortest path when multiple routes exist", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+    const d = seedEntity("D", ep.id);
+
+    // Short path: A -> D (1 hop)
+    seedEdge(a.id, d.id, ep.id);
+    // Long path: A -> B -> C -> D (3 hops)
+    seedEdge(a.id, b.id, ep.id);
+    seedEdge(b.id, c.id, ep.id);
+    seedEdge(c.id, d.id, ep.id);
+
+    const result = getPath(graph, a.id, d.id);
+
+    expect(result.found).toBe(true);
+    expect(result.length).toBe(1);
+  });
+
+  test("traverses inbound edges when direction is both", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    // Edge goes B -> A (inbound to A)
+    const edge = seedEdge(b.id, a.id, ep.id);
+
+    // BFS from A should still reach B via the inbound edge
+    const result = getPath(graph, a.id, b.id);
+
+    expect(result.found).toBe(true);
+    expect(result.edges[0].id).toBe(edge.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSnapshot
+// ---------------------------------------------------------------------------
+
+describe("getSnapshot", () => {
+  test("returns all active entities", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    const snap = getSnapshot(graph, "2025-01-01T00:00:00Z");
+
+    const ids = snap.entities.map((e) => e.id).sort();
+    expect(ids).toEqual([a.id, b.id].sort());
+  });
+
+  test("includes edges valid at the given timestamp", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    const edge = seedEdge(a.id, b.id, ep.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2026-01-01T00:00:00Z",
+    });
+
+    const snap = getSnapshot(graph, "2025-01-01T00:00:00Z");
+
+    expect(snap.at).toBe("2025-01-01T00:00:00Z");
+    const edgeIds = snap.edges.map((e) => e.id);
+    expect(edgeIds).toContain(edge.id);
+  });
+
+  test("excludes edges not valid at the given timestamp", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    seedEdge(a.id, b.id, ep.id, {
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2024-06-01T00:00:00Z",
+    });
+
+    const snap = getSnapshot(graph, "2025-01-01T00:00:00Z");
+
+    expect(snap.edges).toHaveLength(0);
+  });
+
+  test("includes edges with null validity bounds (always current)", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    const edge = seedEdge(a.id, b.id, ep.id); // no valid_from or valid_until
+
+    const snap = getSnapshot(graph, "2025-01-01T00:00:00Z");
+
+    const edgeIds = snap.edges.map((e) => e.id);
+    expect(edgeIds).toContain(edge.id);
+  });
+
+  test("excludes invalidated edges", () => {
+    const ep = seedEpisode();
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+
+    const edge = addEdge(
+      graph,
+      {
+        source_id: a.id,
+        target_id: b.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "A depends on B",
+      },
+      makeEvidence(ep.id),
+    );
+
+    // Manually invalidate the edge
+    graph.db
+      .query("UPDATE edges SET invalidated_at = ? WHERE id = ?")
+      .run("2024-06-01T00:00:00Z", edge.id);
+
+    const snap = getSnapshot(graph, "2025-01-01T00:00:00Z");
+
+    const edgeIds = snap.edges.map((e) => e.id);
+    expect(edgeIds).not.toContain(edge.id);
+  });
+
+  test("returns snapshot at queried timestamp", () => {
+    const ep = seedEpisode();
+    seedEntity("A", ep.id);
+
+    const snap = getSnapshot(graph, "2023-06-15T12:00:00Z");
+    expect(snap.at).toBe("2023-06-15T12:00:00Z");
+  });
+});


### PR DESCRIPTION
## Summary

- `getNeighbors(graph, entity_id, opts?)` — BFS subgraph up to N hops, with `edge_kind`, `valid_at`, `direction` filters
- `getPath(graph, from_id, to_id, opts?)` — BFS shortest path between entities (max depth 10)
- `getSnapshot(graph, at)` — `TemporalSnapshot`: all active entities + edges valid at the given ISO8601 timestamp

## Acceptance Criteria

- [x] `getNeighbors` — 1-hop and multi-hop traversal
- [x] `getPath` — shortest path (BFS with visited set)
- [x] `getSnapshot` — graph state at any timestamp
- [x] Snapshot respects validity windows
- [x] Traversal respects `edge_kind` and temporal filters
- [x] `SubGraph`, `PathResult`, `TemporalSnapshot` types exported

## Test plan

- [x] `bun test` — 193 tests pass
- [x] `bun run build` — succeeds
- [x] `bun run lint` — clean

> **Note:** Stacked on `feat/retrieval-search-issue-8` (PR #23). Merge order: #15 → ... → #23 → this PR.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)