### PR TITLE
feat: knowledge decay detection

### DIFF
--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -55,6 +55,11 @@ export { ingestMarkdown } from "./ingest/markdown.js";
 export type { TextIngestOpts } from "./ingest/text.js";
 export { ingestText } from "./ingest/text.js";
 export type {
+  DecayCategory,
+  DecayItem,
+  DecayOpts,
+  DecayReport,
+  DecaySeverity,
   PathResult,
   ScoreComponents,
   SearchOpts,
@@ -62,7 +67,12 @@ export type {
   SubGraph,
   TraversalOpts,
 } from "./retrieval/index.js";
-export { getNeighbors, getPath, search } from "./retrieval/index.js";
+export {
+  getDecayReport,
+  getNeighbors,
+  getPath,
+  search,
+} from "./retrieval/index.js";
 export type { TemporalSnapshot } from "./temporal/index.js";
 export {
   checkActiveEdgeConflict,

--- a/packages/engram-core/src/retrieval/decay.ts
+++ b/packages/engram-core/src/retrieval/decay.ts
@@ -168,18 +168,22 @@ function detectContradicted(
   nowMs: number,
 ): DecayItem[] {
   const recentWindowMs = staleDays * 2 * 24 * 60 * 60 * 1000;
+  const recentCutoff = new Date(nowMs - recentWindowMs).toISOString();
 
+  // Only report recently superseded edges (within recentWindowMs)
   const rows = graph.db
-    .query<ContradictedRow, []>(`
+    .query<ContradictedRow, [string]>(`
       SELECT id, fact, invalidated_at
       FROM edges
       WHERE invalidated_at IS NOT NULL AND superseded_by IS NOT NULL
+        AND invalidated_at >= ?
     `)
-    .all();
+    .all(recentCutoff);
 
   return rows.map((row) => {
     const ageMs = nowMs - new Date(row.invalidated_at).getTime();
-    const severity: DecaySeverity = ageMs <= recentWindowMs ? "medium" : "low";
+    const severity: DecaySeverity =
+      ageMs <= recentWindowMs / 2 ? "medium" : "low";
     return {
       type: "edge" as const,
       id: row.id,
@@ -213,18 +217,18 @@ function detectConcentratedRisk(
         en.id,
         en.canonical_name,
         COUNT(DISTINCT ed.id) AS edge_count,
-        COUNT(DISTINCT ep.owner_id) AS owner_count
+        COUNT(DISTINCT COALESCE(NULLIF(ep.owner_id, ''), NULLIF(ep.actor, ''))) AS owner_count
       FROM entities en
       JOIN edges ed ON (ed.source_id = en.id OR ed.target_id = en.id)
         AND ed.invalidated_at IS NULL
       JOIN entity_evidence ee ON ee.entity_id = en.id
       JOIN episodes ep ON ep.id = ee.episode_id
         AND ep.status != 'redacted'
-        AND ep.owner_id IS NOT NULL
+        AND COALESCE(NULLIF(ep.owner_id, ''), NULLIF(ep.actor, '')) IS NOT NULL
       WHERE en.status = 'active'
       GROUP BY en.id
       HAVING COUNT(DISTINCT ed.id) >= ?
-        AND COUNT(DISTINCT ep.owner_id) <= 2
+        AND COUNT(DISTINCT COALESCE(NULLIF(ep.owner_id, ''), NULLIF(ep.actor, ''))) <= 2
     `)
     .all(minEdges);
 
@@ -284,7 +288,7 @@ function detectDormantOwner(
   for (const row of rawRows) {
     const key = `${row.entity_id}::${row.actor}`;
     const tsMs = new Date(row.ts).getTime();
-    const ageMs = nowMs - tsMs;
+    const ageMs = Math.max(0, nowMs - tsMs); // clamp to prevent negative age from future timestamps
     const weight = Math.exp((-ageMs * Math.LN2) / HALF_LIFE_MS);
 
     const existing = actorMap.get(key);

--- a/packages/engram-core/src/retrieval/decay.ts
+++ b/packages/engram-core/src/retrieval/decay.ts
@@ -1,0 +1,441 @@
+/**
+ * decay.ts — Knowledge decay detection for the engram graph.
+ *
+ * Detects five categories of knowledge decay:
+ *   - stale_evidence: entities/edges with no recent supporting evidence
+ *   - contradicted: edges recently superseded by newer facts
+ *   - concentrated_risk: entities with many edges but few distinct owners
+ *   - dormant_owner: entities whose primary contributor has gone quiet
+ *   - orphaned: active entities with no active edges
+ */
+
+import type { EngramGraph } from "../format/index.js";
+
+export type DecayCategory =
+  | "stale_evidence"
+  | "contradicted"
+  | "concentrated_risk"
+  | "dormant_owner"
+  | "orphaned";
+
+export type DecaySeverity = "low" | "medium" | "high" | "critical";
+
+export interface DecayItem {
+  type: "entity" | "edge";
+  id: string;
+  name: string;
+  decay_category: DecayCategory;
+  severity: DecaySeverity;
+  details: string;
+  last_evidence_at: string | null;
+}
+
+export interface DecayReport {
+  generated_at: string;
+  total_entities: number;
+  total_edges: number;
+  decay_items: DecayItem[];
+  summary: {
+    stale_evidence: number;
+    contradicted: number;
+    concentrated_risk: number;
+    dormant_owner: number;
+    orphaned: number;
+  };
+}
+
+export interface DecayOpts {
+  stale_days?: number;
+  dormant_days?: number;
+  min_edges_for_risk?: number;
+}
+
+const SEVERITY_ORDER: Record<DecaySeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+function staleSeverity(ageDays: number, staleDays: number): DecaySeverity {
+  if (ageDays > staleDays * 8) return "critical";
+  if (ageDays > staleDays * 4) return "high";
+  if (ageDays > staleDays * 2) return "medium";
+  return "low";
+}
+
+// ---------------------------------------------------------------------------
+// stale_evidence detection
+// ---------------------------------------------------------------------------
+
+interface StaleRow {
+  id: string;
+  name: string;
+  item_type: string;
+  max_ts: string | null;
+}
+
+function detectStaleEvidence(
+  graph: EngramGraph,
+  staleDays: number,
+  nowMs: number,
+): DecayItem[] {
+  const items: DecayItem[] = [];
+  const staleMs = staleDays * 24 * 60 * 60 * 1000;
+
+  // Entities: find max episode timestamp per entity
+  const entityRows = graph.db
+    .query<StaleRow, []>(`
+      SELECT
+        e.id,
+        e.canonical_name AS name,
+        'entity' AS item_type,
+        MAX(ep.timestamp) AS max_ts
+      FROM entities e
+      LEFT JOIN entity_evidence ee ON ee.entity_id = e.id
+      LEFT JOIN episodes ep ON ep.id = ee.episode_id AND ep.status != 'redacted'
+      WHERE e.status = 'active'
+      GROUP BY e.id
+    `)
+    .all();
+
+  for (const row of entityRows) {
+    if (!row.max_ts) continue;
+    const ageMs = nowMs - new Date(row.max_ts).getTime();
+    if (ageMs > staleMs) {
+      const ageDays = ageMs / (24 * 60 * 60 * 1000);
+      items.push({
+        type: "entity",
+        id: row.id,
+        name: row.name,
+        decay_category: "stale_evidence",
+        severity: staleSeverity(ageDays, staleDays),
+        details: `No evidence updates in ${Math.round(ageDays)} days (threshold: ${staleDays})`,
+        last_evidence_at: row.max_ts,
+      });
+    }
+  }
+
+  // Edges: find max episode timestamp per active edge
+  const edgeRows = graph.db
+    .query<StaleRow, []>(`
+      SELECT
+        ed.id,
+        ed.fact AS name,
+        'edge' AS item_type,
+        MAX(ep.timestamp) AS max_ts
+      FROM edges ed
+      LEFT JOIN edge_evidence eve ON eve.edge_id = ed.id
+      LEFT JOIN episodes ep ON ep.id = eve.episode_id AND ep.status != 'redacted'
+      WHERE ed.invalidated_at IS NULL
+      GROUP BY ed.id
+    `)
+    .all();
+
+  for (const row of edgeRows) {
+    if (!row.max_ts) continue;
+    const ageMs = nowMs - new Date(row.max_ts).getTime();
+    if (ageMs > staleMs) {
+      const ageDays = ageMs / (24 * 60 * 60 * 1000);
+      items.push({
+        type: "edge",
+        id: row.id,
+        name: row.name,
+        decay_category: "stale_evidence",
+        severity: staleSeverity(ageDays, staleDays),
+        details: `No evidence updates in ${Math.round(ageDays)} days (threshold: ${staleDays})`,
+        last_evidence_at: row.max_ts,
+      });
+    }
+  }
+
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// contradicted detection
+// ---------------------------------------------------------------------------
+
+interface ContradictedRow {
+  id: string;
+  fact: string;
+  invalidated_at: string;
+}
+
+function detectContradicted(
+  graph: EngramGraph,
+  staleDays: number,
+  nowMs: number,
+): DecayItem[] {
+  const recentWindowMs = staleDays * 2 * 24 * 60 * 60 * 1000;
+
+  const rows = graph.db
+    .query<ContradictedRow, []>(`
+      SELECT id, fact, invalidated_at
+      FROM edges
+      WHERE invalidated_at IS NOT NULL AND superseded_by IS NOT NULL
+    `)
+    .all();
+
+  return rows.map((row) => {
+    const ageMs = nowMs - new Date(row.invalidated_at).getTime();
+    const severity: DecaySeverity = ageMs <= recentWindowMs ? "medium" : "low";
+    return {
+      type: "edge" as const,
+      id: row.id,
+      name: row.fact,
+      decay_category: "contradicted" as const,
+      severity,
+      details: `Edge was superseded at ${row.invalidated_at}`,
+      last_evidence_at: null,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// concentrated_risk detection
+// ---------------------------------------------------------------------------
+
+interface RiskRow {
+  id: string;
+  canonical_name: string;
+  edge_count: number;
+  owner_count: number;
+}
+
+function detectConcentratedRisk(
+  graph: EngramGraph,
+  minEdges: number,
+): DecayItem[] {
+  const rows = graph.db
+    .query<RiskRow, [number]>(`
+      SELECT
+        en.id,
+        en.canonical_name,
+        COUNT(DISTINCT ed.id) AS edge_count,
+        COUNT(DISTINCT ep.owner_id) AS owner_count
+      FROM entities en
+      JOIN edges ed ON (ed.source_id = en.id OR ed.target_id = en.id)
+        AND ed.invalidated_at IS NULL
+      JOIN entity_evidence ee ON ee.entity_id = en.id
+      JOIN episodes ep ON ep.id = ee.episode_id
+        AND ep.status != 'redacted'
+        AND ep.owner_id IS NOT NULL
+      WHERE en.status = 'active'
+      GROUP BY en.id
+      HAVING COUNT(DISTINCT ed.id) >= ?
+        AND COUNT(DISTINCT ep.owner_id) <= 2
+    `)
+    .all(minEdges);
+
+  return rows.map((row) => ({
+    type: "entity" as const,
+    id: row.id,
+    name: row.canonical_name,
+    decay_category: "concentrated_risk" as const,
+    severity: (row.owner_count <= 1 ? "high" : "medium") as DecaySeverity,
+    details: `${row.edge_count} active edges backed by only ${row.owner_count} distinct owner(s)`,
+    last_evidence_at: null,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// dormant_owner detection
+// ---------------------------------------------------------------------------
+
+interface ActorRow {
+  entity_id: string;
+  canonical_name: string;
+  actor: string;
+  last_ts: string;
+  weight_sum: number;
+}
+
+function detectDormantOwner(
+  graph: EngramGraph,
+  dormantDays: number,
+  nowMs: number,
+): DecayItem[] {
+  const HALF_LIFE_MS = 90 * 24 * 60 * 60 * 1000;
+
+  // Pull all (entity, actor, episode timestamp) combinations
+  const rawRows = graph.db
+    .query<
+      { entity_id: string; canonical_name: string; actor: string; ts: string },
+      []
+    >(`
+      SELECT
+        en.id AS entity_id,
+        en.canonical_name,
+        ep.actor,
+        ep.timestamp AS ts
+      FROM entities en
+      JOIN entity_evidence ee ON ee.entity_id = en.id
+      JOIN episodes ep ON ep.id = ee.episode_id
+        AND ep.status != 'redacted'
+        AND ep.actor IS NOT NULL
+      WHERE en.status = 'active'
+    `)
+    .all();
+
+  // Group by entity + actor and accumulate recency weights
+  const actorMap = new Map<string, ActorRow>();
+
+  for (const row of rawRows) {
+    const key = `${row.entity_id}::${row.actor}`;
+    const tsMs = new Date(row.ts).getTime();
+    const ageMs = nowMs - tsMs;
+    const weight = Math.exp((-ageMs * Math.LN2) / HALF_LIFE_MS);
+
+    const existing = actorMap.get(key);
+    if (existing) {
+      existing.weight_sum += weight;
+      if (row.ts > existing.last_ts) {
+        existing.last_ts = row.ts;
+      }
+    } else {
+      actorMap.set(key, {
+        entity_id: row.entity_id,
+        canonical_name: row.canonical_name,
+        actor: row.actor,
+        last_ts: row.ts,
+        weight_sum: weight,
+      });
+    }
+  }
+
+  // For each entity find top author by weight_sum, then check if dormant
+  const topAuthorByEntity = new Map<string, ActorRow>();
+  for (const row of actorMap.values()) {
+    const existing = topAuthorByEntity.get(row.entity_id);
+    if (!existing || row.weight_sum > existing.weight_sum) {
+      topAuthorByEntity.set(row.entity_id, row);
+    }
+  }
+
+  const dormantMs = dormantDays * 24 * 60 * 60 * 1000;
+  const items: DecayItem[] = [];
+
+  for (const top of topAuthorByEntity.values()) {
+    const inactiveMs = nowMs - new Date(top.last_ts).getTime();
+    if (inactiveMs > dormantMs) {
+      const inactiveDays = Math.round(inactiveMs / (24 * 60 * 60 * 1000));
+      const severity: DecaySeverity =
+        inactiveMs > dormantMs * 2 ? "high" : "medium";
+      items.push({
+        type: "entity",
+        id: top.entity_id,
+        name: top.canonical_name,
+        decay_category: "dormant_owner",
+        severity,
+        details: `Primary contributor '${top.actor}' inactive for ${inactiveDays} days (threshold: ${dormantDays})`,
+        last_evidence_at: top.last_ts,
+      });
+    }
+  }
+
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// orphaned detection
+// ---------------------------------------------------------------------------
+
+interface OrphanRow {
+  id: string;
+  canonical_name: string;
+}
+
+function detectOrphaned(graph: EngramGraph): DecayItem[] {
+  const rows = graph.db
+    .query<OrphanRow, []>(`
+      SELECT en.id, en.canonical_name
+      FROM entities en
+      WHERE en.status = 'active'
+        AND NOT EXISTS (
+          SELECT 1 FROM edges ed
+          WHERE ed.invalidated_at IS NULL
+            AND (ed.source_id = en.id OR ed.target_id = en.id)
+        )
+    `)
+    .all();
+
+  return rows.map((row) => ({
+    type: "entity" as const,
+    id: row.id,
+    name: row.canonical_name,
+    decay_category: "orphaned" as const,
+    severity: "low" as DecaySeverity,
+    details: "Active entity with no active edges",
+    last_evidence_at: null,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all five decay detection passes and return a consolidated DecayReport.
+ * Results are sorted: critical → high → medium → low.
+ */
+export function getDecayReport(
+  graph: EngramGraph,
+  opts?: DecayOpts,
+): DecayReport {
+  const staleDays = opts?.stale_days ?? 180;
+  const dormantDays = opts?.dormant_days ?? 90;
+  const minEdges = opts?.min_edges_for_risk ?? 3;
+  const now = new Date();
+  const nowMs = now.getTime();
+  const generated_at = now.toISOString();
+
+  // Total counts
+  const countEntitiesRow = graph.db
+    .query<{ total_entities: number }, []>(
+      "SELECT COUNT(*) AS total_entities FROM entities WHERE status = 'active'",
+    )
+    .get();
+  const total_entities = countEntitiesRow?.total_entities ?? 0;
+
+  const countEdgesRow = graph.db
+    .query<{ total_edges: number }, []>(
+      "SELECT COUNT(*) AS total_edges FROM edges WHERE invalidated_at IS NULL",
+    )
+    .get();
+  const total_edges = countEdgesRow?.total_edges ?? 0;
+
+  // Run all detectors
+  const staleItems = detectStaleEvidence(graph, staleDays, nowMs);
+  const contradictedItems = detectContradicted(graph, staleDays, nowMs);
+  const riskItems = detectConcentratedRisk(graph, minEdges);
+  const dormantItems = detectDormantOwner(graph, dormantDays, nowMs);
+  const orphanedItems = detectOrphaned(graph);
+
+  const all = [
+    ...staleItems,
+    ...contradictedItems,
+    ...riskItems,
+    ...dormantItems,
+    ...orphanedItems,
+  ];
+
+  // Sort: critical first, then high, medium, low
+  all.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+
+  const summary = {
+    stale_evidence: staleItems.length,
+    contradicted: contradictedItems.length,
+    concentrated_risk: riskItems.length,
+    dormant_owner: dormantItems.length,
+    orphaned: orphanedItems.length,
+  };
+
+  return {
+    generated_at,
+    total_entities,
+    total_edges,
+    decay_items: all,
+    summary,
+  };
+}

--- a/packages/engram-core/src/retrieval/index.ts
+++ b/packages/engram-core/src/retrieval/index.ts
@@ -2,6 +2,14 @@
  * retrieval/index.ts — re-exports for the retrieval module.
  */
 
+export type {
+  DecayCategory,
+  DecayItem,
+  DecayOpts,
+  DecayReport,
+  DecaySeverity,
+} from "./decay.js";
+export { getDecayReport } from "./decay.js";
 export type { ScoreComponents } from "./scoring.js";
 export type { SearchOpts, SearchResult } from "./search.js";
 export { search } from "./search.js";

--- a/packages/engram-core/test/retrieval/decay.test.ts
+++ b/packages/engram-core/test/retrieval/decay.test.ts
@@ -1,0 +1,423 @@
+/**
+ * decay.test.ts — tests for getDecayReport().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EngramGraph } from "../../src/index.js";
+import {
+  addEdge,
+  addEntity,
+  addEpisode,
+  closeGraph,
+  createGraph,
+  getDecayReport,
+  supersedeEdge,
+} from "../../src/index.js";
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvidence(episodeId: string) {
+  return [{ episode_id: episodeId, extractor: "test", confidence: 1.0 }];
+}
+
+function seedEpisode(opts: {
+  timestamp?: string;
+  actor?: string;
+  owner_id?: string;
+  source_ref?: string;
+}) {
+  return addEpisode(graph, {
+    source_type: "manual",
+    source_ref: opts.source_ref ?? `ref-${Date.now()}-${Math.random()}`,
+    content: "test episode",
+    timestamp: opts.timestamp ?? "2024-01-01T00:00:00Z",
+    actor: opts.actor,
+    owner_id: opts.owner_id,
+  });
+}
+
+function seedEntity(name: string, episodeId: string) {
+  return addEntity(
+    graph,
+    { canonical_name: name, entity_type: "module" },
+    makeEvidence(episodeId),
+  );
+}
+
+function seedEdge(
+  sourceId: string,
+  targetId: string,
+  episodeId: string,
+  opts: { relation_type?: string; edge_kind?: string } = {},
+) {
+  return addEdge(
+    graph,
+    {
+      source_id: sourceId,
+      target_id: targetId,
+      relation_type: opts.relation_type ?? "depends_on",
+      edge_kind: opts.edge_kind ?? "observed",
+      fact: `${sourceId} depends on ${targetId}`,
+    },
+    makeEvidence(episodeId),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Basic structure
+// ---------------------------------------------------------------------------
+
+describe("getDecayReport basic structure", () => {
+  test("returns a valid report with no items on an empty graph", () => {
+    const report = getDecayReport(graph);
+    expect(report.generated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(report.total_entities).toBe(0);
+    expect(report.total_edges).toBe(0);
+    expect(report.decay_items).toEqual([]);
+    expect(report.summary).toEqual({
+      stale_evidence: 0,
+      contradicted: 0,
+      concentrated_risk: 0,
+      dormant_owner: 0,
+      orphaned: 0,
+    });
+  });
+
+  test("total_entities and total_edges reflect active graph state", () => {
+    const ep = seedEpisode({ timestamp: new Date().toISOString() });
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    seedEdge(a.id, b.id, ep.id);
+
+    const report = getDecayReport(graph);
+    expect(report.total_entities).toBe(2);
+    expect(report.total_edges).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stale_evidence
+// ---------------------------------------------------------------------------
+
+describe("stale_evidence", () => {
+  test("detects entity with old evidence", () => {
+    // Episode timestamped 2 years ago (730 days) — well past 180-day default
+    const ep = seedEpisode({ timestamp: "2022-01-01T00:00:00Z" });
+    seedEntity("OldEntity", ep.id);
+
+    const report = getDecayReport(graph, { stale_days: 180 });
+    const staleItems = report.decay_items.filter(
+      (i) => i.decay_category === "stale_evidence" && i.name === "OldEntity",
+    );
+    expect(staleItems.length).toBe(1);
+    expect(staleItems[0].type).toBe("entity");
+  });
+
+  test("does not flag entity with recent evidence", () => {
+    const ep = seedEpisode({ timestamp: new Date().toISOString() });
+    seedEntity("FreshEntity", ep.id);
+
+    const report = getDecayReport(graph, { stale_days: 180 });
+    const staleItems = report.decay_items.filter(
+      (i) => i.decay_category === "stale_evidence" && i.name === "FreshEntity",
+    );
+    expect(staleItems.length).toBe(0);
+  });
+
+  test("severity escalates with age", () => {
+    // > 8x stale_days → critical
+    const staleDays = 10;
+    const ep = seedEpisode({ timestamp: "2020-01-01T00:00:00Z" }); // ~6 years ago
+    seedEntity("VeryOld", ep.id);
+
+    const report = getDecayReport(graph, { stale_days: staleDays });
+    const item = report.decay_items.find(
+      (i) => i.decay_category === "stale_evidence" && i.name === "VeryOld",
+    );
+    expect(item?.severity).toBe("critical");
+  });
+
+  test("detects stale edge", () => {
+    const ep = seedEpisode({ timestamp: "2022-01-01T00:00:00Z" });
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    seedEdge(a.id, b.id, ep.id);
+
+    const report = getDecayReport(graph, { stale_days: 180 });
+    const staleEdges = report.decay_items.filter(
+      (i) => i.decay_category === "stale_evidence" && i.type === "edge",
+    );
+    expect(staleEdges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("summary.stale_evidence reflects count", () => {
+    const ep = seedEpisode({ timestamp: "2022-01-01T00:00:00Z" });
+    seedEntity("S1", ep.id);
+    seedEntity("S2", ep.id);
+
+    const report = getDecayReport(graph, { stale_days: 180 });
+    expect(report.summary.stale_evidence).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contradicted
+// ---------------------------------------------------------------------------
+
+describe("contradicted", () => {
+  test("detects superseded edge", () => {
+    const ep = seedEpisode({ timestamp: new Date().toISOString() });
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const edge = seedEdge(a.id, b.id, ep.id);
+
+    supersedeEdge(
+      graph,
+      edge.id,
+      {
+        source_id: a.id,
+        target_id: b.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "A depends on B (updated)",
+      },
+      makeEvidence(ep.id),
+    );
+
+    const report = getDecayReport(graph);
+    const contradicted = report.decay_items.filter(
+      (i) => i.decay_category === "contradicted",
+    );
+    expect(contradicted.length).toBe(1);
+    expect(contradicted[0].type).toBe("edge");
+  });
+
+  test("recently superseded is medium severity", () => {
+    const ep = seedEpisode({ timestamp: new Date().toISOString() });
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const edge = seedEdge(a.id, b.id, ep.id);
+
+    supersedeEdge(
+      graph,
+      edge.id,
+      {
+        source_id: a.id,
+        target_id: b.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "A depends on B v2",
+      },
+      makeEvidence(ep.id),
+    );
+
+    const report = getDecayReport(graph, { stale_days: 180 });
+    const item = report.decay_items.find(
+      (i) => i.decay_category === "contradicted",
+    );
+    expect(item?.severity).toBe("medium");
+  });
+
+  test("summary.contradicted reflects count", () => {
+    const ep = seedEpisode({ timestamp: new Date().toISOString() });
+    const a = seedEntity("A", ep.id);
+    const b = seedEntity("B", ep.id);
+    const edge = seedEdge(a.id, b.id, ep.id);
+
+    supersedeEdge(
+      graph,
+      edge.id,
+      {
+        source_id: a.id,
+        target_id: b.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "A depends on B v2",
+      },
+      makeEvidence(ep.id),
+    );
+
+    const report = getDecayReport(graph);
+    expect(report.summary.contradicted).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// concentrated_risk
+// ---------------------------------------------------------------------------
+
+describe("concentrated_risk", () => {
+  test("flags entity with many edges but single owner", () => {
+    const ep = seedEpisode({
+      timestamp: new Date().toISOString(),
+      owner_id: "owner-alice",
+    });
+    const hub = seedEntity("Hub", ep.id);
+    const b = seedEntity("B", ep.id);
+    const c = seedEntity("C", ep.id);
+    const d = seedEntity("D", ep.id);
+
+    seedEdge(hub.id, b.id, ep.id);
+    seedEdge(hub.id, c.id, ep.id);
+    seedEdge(hub.id, d.id, ep.id);
+
+    const report = getDecayReport(graph, { min_edges_for_risk: 3 });
+    const risk = report.decay_items.filter(
+      (i) => i.decay_category === "concentrated_risk" && i.name === "Hub",
+    );
+    expect(risk.length).toBe(1);
+    expect(risk[0].severity).toBe("high");
+  });
+
+  test("does not flag entity below edge threshold", () => {
+    const ep = seedEpisode({
+      timestamp: new Date().toISOString(),
+      owner_id: "owner-alice",
+    });
+    const hub = seedEntity("SmallHub", ep.id);
+    const b = seedEntity("B2", ep.id);
+    seedEdge(hub.id, b.id, ep.id);
+
+    const report = getDecayReport(graph, { min_edges_for_risk: 3 });
+    const risk = report.decay_items.filter(
+      (i) => i.decay_category === "concentrated_risk" && i.name === "SmallHub",
+    );
+    expect(risk.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// orphaned
+// ---------------------------------------------------------------------------
+
+describe("orphaned", () => {
+  test("flags active entity with no active edges", () => {
+    const ep = seedEpisode({ timestamp: new Date().toISOString() });
+    seedEntity("Loner", ep.id);
+
+    const report = getDecayReport(graph);
+    const orphaned = report.decay_items.filter(
+      (i) => i.decay_category === "orphaned" && i.name === "Loner",
+    );
+    expect(orphaned.length).toBe(1);
+    expect(orphaned[0].severity).toBe("low");
+    expect(orphaned[0].type).toBe("entity");
+  });
+
+  test("does not flag entity that has active edges", () => {
+    const ep = seedEpisode({ timestamp: new Date().toISOString() });
+    const a = seedEntity("Connected", ep.id);
+    const b = seedEntity("B", ep.id);
+    seedEdge(a.id, b.id, ep.id);
+
+    const report = getDecayReport(graph);
+    const orphaned = report.decay_items.filter(
+      (i) => i.decay_category === "orphaned" && i.name === "Connected",
+    );
+    expect(orphaned.length).toBe(0);
+  });
+
+  test("summary.orphaned reflects count", () => {
+    const ep = seedEpisode({ timestamp: new Date().toISOString() });
+    seedEntity("Orphan1", ep.id);
+    seedEntity("Orphan2", ep.id);
+
+    const report = getDecayReport(graph);
+    expect(report.summary.orphaned).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dormant_owner
+// ---------------------------------------------------------------------------
+
+describe("dormant_owner", () => {
+  test("flags entity whose top actor has been inactive", () => {
+    // Episode 200 days old — past 90-day dormant threshold
+    const oldDate = new Date(
+      Date.now() - 200 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const ep = seedEpisode({ timestamp: oldDate, actor: "alice" });
+    seedEntity("AliceModule", ep.id);
+
+    const report = getDecayReport(graph, { dormant_days: 90 });
+    const dormant = report.decay_items.filter(
+      (i) => i.decay_category === "dormant_owner" && i.name === "AliceModule",
+    );
+    expect(dormant.length).toBe(1);
+    expect(dormant[0].details).toContain("alice");
+  });
+
+  test("does not flag entity whose top actor is active", () => {
+    const ep = seedEpisode({
+      timestamp: new Date().toISOString(),
+      actor: "bob",
+    });
+    seedEntity("BobModule", ep.id);
+
+    const report = getDecayReport(graph, { dormant_days: 90 });
+    const dormant = report.decay_items.filter(
+      (i) => i.decay_category === "dormant_owner" && i.name === "BobModule",
+    );
+    expect(dormant.length).toBe(0);
+  });
+
+  test("severity is high when inactive > 2x dormant_days", () => {
+    const veryOld = new Date(
+      Date.now() - 300 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const ep = seedEpisode({ timestamp: veryOld, actor: "carol" });
+    seedEntity("CarolModule", ep.id);
+
+    const report = getDecayReport(graph, { dormant_days: 90 });
+    const item = report.decay_items.find(
+      (i) => i.decay_category === "dormant_owner" && i.name === "CarolModule",
+    );
+    expect(item?.severity).toBe("high");
+  });
+
+  test("summary.dormant_owner reflects count", () => {
+    const oldDate = new Date(
+      Date.now() - 200 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const ep = seedEpisode({ timestamp: oldDate, actor: "dave" });
+    seedEntity("DaveModule", ep.id);
+
+    const report = getDecayReport(graph, { dormant_days: 90 });
+    expect(report.summary.dormant_owner).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sort order
+// ---------------------------------------------------------------------------
+
+describe("sort order", () => {
+  test("decay_items sorted critical before low", () => {
+    const report = getDecayReport(graph);
+    const items = report.decay_items;
+    const order: Record<string, number> = {
+      critical: 0,
+      high: 1,
+      medium: 2,
+      low: 3,
+    };
+    for (let i = 0; i < items.length - 1; i++) {
+      expect(order[items[i].severity]).toBeLessThanOrEqual(
+        order[items[i + 1].severity],
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `getDecayReport(graph, opts?)` — surfaces stale, contradicted, concentrated-risk, dormant-owner, and orphaned knowledge
- Five SQL-driven detection passes; results sorted by severity (critical first)
- Dormant owner uses recency-weighted analysis (exponential decay, 90-day half-life) — same algorithm as git ingestion
- The temporal graph earning its keep: this is what `git-fame` can't produce

## Acceptance Criteria

- [x] `stale_evidence` — entities/edges with no evidence updates in configurable window
- [x] `contradicted` — recently superseded edges
- [x] `concentrated_risk` — high-centrality entities with few distinct owners (bus factor)
- [x] `dormant_owner` — primary contributor inactive beyond threshold
- [x] `orphaned` — active entities with zero active edges
- [x] `DecayItem` includes type, id, name, category, severity, details, last_evidence_at
- [x] `DecayOpts` configurable thresholds
- [x] Sorted by severity

## Test plan

- [x] `bun test` — 213 tests pass
- [x] `bun run build` — succeeds
- [x] `bun run lint` — clean

> **Note:** Stacked on `feat/graph-traversal-issue-9` (PR #24).

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)