### PR TITLE
feat: CLI — core commands

### DIFF
--- a/packages/engram-cli/src/cli.ts
+++ b/packages/engram-cli/src/cli.ts
@@ -2,6 +2,17 @@
 
 import { Command } from "commander";
 import { ENGINE_VERSION } from "engram-core";
+import { registerAdd } from "./commands/add.js";
+import { registerDecay } from "./commands/decay.js";
+import { registerExport } from "./commands/export.js";
+import { registerHistory } from "./commands/history.js";
+import { registerIngest } from "./commands/ingest.js";
+import { registerInit } from "./commands/init.js";
+import { registerMaintenance } from "./commands/maintenance.js";
+import { registerSearch } from "./commands/search.js";
+import { registerShow } from "./commands/show.js";
+import { registerStats } from "./commands/stats.js";
+import { registerVerify } from "./commands/verify.js";
 
 const program = new Command()
   .name("engram")
@@ -9,5 +20,17 @@ const program = new Command()
     "A local-first temporal knowledge graph engine for developer memory",
   )
   .version(ENGINE_VERSION);
+
+registerInit(program);
+registerAdd(program);
+registerSearch(program);
+registerShow(program);
+registerHistory(program);
+registerDecay(program);
+registerStats(program);
+registerIngest(program);
+registerExport(program);
+registerVerify(program);
+registerMaintenance(program);
 
 program.parse();

--- a/packages/engram-cli/src/commands/add.ts
+++ b/packages/engram-cli/src/commands/add.ts
@@ -1,0 +1,78 @@
+/**
+ * add.ts — `engram add` command.
+ *
+ * Adds a manual note or file as an episode (source_type='manual').
+ * No entity extraction — raw episode creation only.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import { addEpisode, closeGraph, openGraph } from "engram-core";
+
+interface AddOpts {
+  file?: string;
+  db: string;
+}
+
+export function registerAdd(program: Command): void {
+  program
+    .command("add [content]")
+    .description("Add a manual note or file as evidence")
+    .option("--file <path>", "read content from a file instead of the argument")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((content: string | undefined, opts: AddOpts) => {
+      const dbPath = path.resolve(opts.db);
+
+      let episodeContent: string;
+
+      if (opts.file) {
+        const filePath = path.resolve(opts.file);
+        if (!fs.existsSync(filePath)) {
+          console.error(`Error: file not found: ${filePath}`);
+          process.exit(1);
+        }
+        try {
+          episodeContent = fs.readFileSync(filePath, "utf-8");
+        } catch (err) {
+          console.error(
+            `Error reading file: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.exit(1);
+        }
+      } else if (content) {
+        episodeContent = content;
+      } else {
+        console.error("Error: provide <content> or --file <path>");
+        process.exit(1);
+      }
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      try {
+        const episode = addEpisode(graph, {
+          source_type: "manual",
+          content: episodeContent,
+          timestamp: new Date().toISOString(),
+        });
+        console.log(`Added episode ${episode.id}`);
+      } catch (err) {
+        console.error(
+          `Error adding episode: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+}

--- a/packages/engram-cli/src/commands/decay.ts
+++ b/packages/engram-cli/src/commands/decay.ts
@@ -1,0 +1,93 @@
+/**
+ * decay.ts — `engram decay` command.
+ *
+ * Runs the decay detection report and prints results.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { DecayReport, EngramGraph } from "engram-core";
+import { closeGraph, getDecayReport, openGraph } from "engram-core";
+
+interface DecayOpts {
+  staleDays: string;
+  dormantDays: string;
+  db: string;
+}
+
+export function registerDecay(program: Command): void {
+  program
+    .command("decay")
+    .description("Show knowledge decay report")
+    .option("--stale-days <n>", "days without evidence to mark as stale", "180")
+    .option("--dormant-days <n>", "days of owner inactivity to flag", "90")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((opts: DecayOpts) => {
+      const dbPath = path.resolve(opts.db);
+      const staleDays = parseInt(opts.staleDays, 10);
+      const dormantDays = parseInt(opts.dormantDays, 10);
+
+      if (Number.isNaN(staleDays) || staleDays < 1) {
+        console.error("Error: --stale-days must be a positive integer");
+        process.exit(1);
+      }
+      if (Number.isNaN(dormantDays) || dormantDays < 1) {
+        console.error("Error: --dormant-days must be a positive integer");
+        process.exit(1);
+      }
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      let report: DecayReport;
+      try {
+        report = getDecayReport(graph, {
+          stale_days: staleDays,
+          dormant_days: dormantDays,
+        });
+        closeGraph(graph);
+      } catch (err) {
+        console.error(
+          `Decay report failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+        return;
+      }
+
+      console.log(`Decay Report — ${report.generated_at}`);
+      console.log(
+        `Entities: ${report.total_entities}  Edges: ${report.total_edges}`,
+      );
+      console.log("");
+      console.log("Summary:");
+      console.log(`  stale_evidence:     ${report.summary.stale_evidence}`);
+      console.log(`  contradicted:       ${report.summary.contradicted}`);
+      console.log(`  concentrated_risk:  ${report.summary.concentrated_risk}`);
+      console.log(`  dormant_owner:      ${report.summary.dormant_owner}`);
+      console.log(`  orphaned:           ${report.summary.orphaned}`);
+
+      if (report.decay_items.length === 0) {
+        console.log("\nNo decay items found.");
+        return;
+      }
+
+      console.log(`\nDecay Items (${report.decay_items.length}):`);
+      for (const item of report.decay_items) {
+        console.log(
+          `  [${item.severity.toUpperCase()}] [${item.decay_category}] ${item.name}`,
+        );
+        console.log(`    ${item.details}`);
+        if (item.last_evidence_at) {
+          console.log(`    last evidence: ${item.last_evidence_at}`);
+        }
+      }
+    });
+}

--- a/packages/engram-cli/src/commands/export.ts
+++ b/packages/engram-cli/src/commands/export.ts
@@ -1,0 +1,126 @@
+/**
+ * export.ts — `engram export` command.
+ *
+ * Exports the graph as deterministic JSONL (one object per line, sorted by ID)
+ * or as markdown summaries.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import { closeGraph, findEdges, findEntities, openGraph } from "engram-core";
+
+interface ExportOpts {
+  format: string;
+  db: string;
+}
+
+interface EpisodeRow {
+  id: string;
+  source_type: string;
+  source_ref: string | null;
+  content: string;
+  actor: string | null;
+  status: string;
+  timestamp: string;
+  ingested_at: string;
+}
+
+export function registerExport(program: Command): void {
+  program
+    .command("export")
+    .description("Export the knowledge graph to JSONL or markdown")
+    .option("--format <fmt>", "output format: jsonl or md", "jsonl")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((opts: ExportOpts) => {
+      const dbPath = path.resolve(opts.db);
+
+      if (opts.format !== "jsonl" && opts.format !== "md") {
+        console.error("Error: --format must be 'jsonl' or 'md'");
+        process.exit(1);
+      }
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      try {
+        const entities = findEntities(graph).sort((a, b) =>
+          a.id.localeCompare(b.id),
+        );
+        const edges = findEdges(graph, { include_invalidated: true }).sort(
+          (a, b) => a.id.localeCompare(b.id),
+        );
+        const episodes = graph.db
+          .query<EpisodeRow, []>("SELECT * FROM episodes ORDER BY id ASC")
+          .all();
+
+        if (opts.format === "jsonl") {
+          for (const entity of entities) {
+            console.log(JSON.stringify({ _type: "entity", ...entity }));
+          }
+          for (const edge of edges) {
+            console.log(JSON.stringify({ _type: "edge", ...edge }));
+          }
+          for (const episode of episodes) {
+            console.log(JSON.stringify({ _type: "episode", ...episode }));
+          }
+        } else {
+          // Markdown format
+          console.log("# Engram Export\n");
+          console.log(`Generated: ${new Date().toISOString()}\n`);
+
+          console.log(`## Entities (${entities.length})\n`);
+          for (const entity of entities) {
+            console.log(`### ${entity.canonical_name}`);
+            console.log(`- **id**: ${entity.id}`);
+            console.log(`- **type**: ${entity.entity_type}`);
+            console.log(`- **status**: ${entity.status}`);
+            if (entity.summary) {
+              console.log(`- **summary**: ${entity.summary}`);
+            }
+            console.log("");
+          }
+
+          console.log(`## Edges (${edges.length})\n`);
+          for (const edge of edges) {
+            const status = edge.invalidated_at ? " *(superseded)*" : "";
+            console.log(`- [${edge.edge_kind}] ${edge.fact}${status}`);
+            console.log(`  - id: ${edge.id}`);
+            console.log(`  - relation: ${edge.relation_type}`);
+          }
+
+          console.log(`\n## Episodes (${episodes.length})\n`);
+          for (const ep of episodes) {
+            console.log(`### ${ep.id}`);
+            console.log(
+              `- **source**: ${ep.source_type}${ep.source_ref ? ` (${ep.source_ref})` : ""}`,
+            );
+            console.log(`- **timestamp**: ${ep.timestamp}`);
+            if (ep.actor) {
+              console.log(`- **actor**: ${ep.actor}`);
+            }
+            const snippet =
+              ep.content.length > 200
+                ? `${ep.content.slice(0, 200)}…`
+                : ep.content;
+            console.log(`\n${snippet}\n`);
+          }
+        }
+      } catch (err) {
+        console.error(
+          `Export failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+}

--- a/packages/engram-cli/src/commands/export.ts
+++ b/packages/engram-cli/src/commands/export.ts
@@ -74,7 +74,6 @@ export function registerExport(program: Command): void {
         } else {
           // Markdown format
           console.log("# Engram Export\n");
-          console.log(`Generated: ${new Date().toISOString()}\n`);
 
           console.log(`## Entities (${entities.length})\n`);
           for (const entity of entities) {

--- a/packages/engram-cli/src/commands/history.ts
+++ b/packages/engram-cli/src/commands/history.ts
@@ -1,0 +1,129 @@
+/**
+ * history.ts — `engram history` command.
+ *
+ * Shows the temporal evolution of facts for an entity or between two entities.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import {
+  closeGraph,
+  findEdges,
+  getEntity,
+  getFactHistory,
+  openGraph,
+  resolveEntity,
+} from "engram-core";
+
+interface HistoryOpts {
+  db: string;
+}
+
+function resolveEntityByNameOrId(
+  graph: ReturnType<typeof openGraph>,
+  nameOrId: string,
+) {
+  return getEntity(graph, nameOrId) ?? resolveEntity(graph, nameOrId);
+}
+
+export function registerHistory(program: Command): void {
+  program
+    .command("history <entity1> [entity2]")
+    .description(
+      "Show temporal fact evolution for an entity or between two entities",
+    )
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action(
+      (
+        entity1Arg: string,
+        entity2Arg: string | undefined,
+        opts: HistoryOpts,
+      ) => {
+        const dbPath = path.resolve(opts.db);
+
+        let graph: EngramGraph | undefined;
+        try {
+          graph = openGraph(dbPath);
+        } catch (err) {
+          console.error(
+            `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.exit(1);
+        }
+
+        try {
+          const entity1 = resolveEntityByNameOrId(graph, entity1Arg);
+          if (!entity1) {
+            console.error(`Entity not found: ${entity1Arg}`);
+            closeGraph(graph);
+            process.exit(1);
+          }
+
+          if (entity2Arg) {
+            // Show history between two entities
+            const entity2 = resolveEntityByNameOrId(graph, entity2Arg);
+            if (!entity2) {
+              console.error(`Entity not found: ${entity2Arg}`);
+              closeGraph(graph);
+              process.exit(1);
+            }
+
+            const edges = getFactHistory(graph, entity1.id, entity2.id);
+            console.log(
+              `History: ${entity1.canonical_name} → ${entity2.canonical_name}`,
+            );
+            console.log(`${edges.length} fact(s)\n`);
+
+            for (const edge of edges) {
+              const status = edge.invalidated_at ? "superseded" : "active";
+              const from = edge.valid_from ?? "unknown";
+              const until = edge.valid_until ?? "present";
+              console.log(`[${status}] ${edge.fact}`);
+              console.log(`  kind:  ${edge.edge_kind}`);
+              console.log(`  valid: ${from} — ${until}`);
+              console.log(`  id:    ${edge.id}`);
+              if (edge.superseded_by) {
+                console.log(`  superseded_by: ${edge.superseded_by}`);
+              }
+            }
+          } else {
+            // Show all edges for entity1 with temporal info
+            const outEdges = findEdges(graph, {
+              source_id: entity1.id,
+              include_invalidated: true,
+            });
+            const inEdges = findEdges(graph, {
+              target_id: entity1.id,
+              include_invalidated: true,
+            });
+            const allEdges = [...outEdges, ...inEdges].sort((a, b) =>
+              a.created_at.localeCompare(b.created_at),
+            );
+
+            console.log(`History: ${entity1.canonical_name}`);
+            console.log(`${allEdges.length} fact(s)\n`);
+
+            for (const edge of allEdges) {
+              const status = edge.invalidated_at ? "superseded" : "active";
+              const from = edge.valid_from ?? "unknown";
+              const until = edge.valid_until ?? "present";
+              console.log(`[${status}] ${edge.fact}`);
+              console.log(
+                `  kind:  ${edge.edge_kind}  relation: ${edge.relation_type}`,
+              );
+              console.log(`  valid: ${from} — ${until}`);
+            }
+          }
+        } catch (err) {
+          console.error(
+            `Error: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          closeGraph(graph);
+          process.exit(1);
+        }
+
+        closeGraph(graph);
+      },
+    );
+}

--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -1,0 +1,176 @@
+/**
+ * ingest.ts — `engram ingest` command group.
+ *
+ * Subcommands:
+ *   - ingest git [<path>] [--since] [--branch]
+ *   - ingest md <glob>
+ *   - ingest enrich github [--token] [--repo]
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import {
+  closeGraph,
+  GitHubAdapter,
+  ingestGitRepo,
+  ingestMarkdown,
+  openGraph,
+} from "engram-core";
+
+interface IngestGitOpts {
+  since?: string;
+  branch?: string;
+  db: string;
+}
+
+interface IngestMdOpts {
+  db: string;
+}
+
+interface IngestEnrichGithubOpts {
+  token?: string;
+  repo?: string;
+  db: string;
+}
+
+export function registerIngest(program: Command): void {
+  const ingest = program
+    .command("ingest")
+    .description("Ingest data into the knowledge graph");
+
+  // ingest git
+  ingest
+    .command("git [repoPath]")
+    .description("Ingest a git repository (VCS layer)")
+    .option(
+      "--since <date>",
+      "only ingest commits since this date (ISO8601 or relative)",
+    )
+    .option("--branch <branch>", "branch or ref to walk (default: HEAD)")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action(async (repoPath: string | undefined, opts: IngestGitOpts) => {
+      const dbPath = path.resolve(opts.db);
+      const resolvedRepo = path.resolve(repoPath ?? ".");
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      console.log(`Ingesting git repo: ${resolvedRepo}`);
+      try {
+        const result = await ingestGitRepo(graph, resolvedRepo, {
+          since: opts.since,
+          branch: opts.branch,
+        });
+        console.log("Git ingestion complete:");
+        console.log(`  Episodes created:  ${result.episodesCreated}`);
+        console.log(`  Episodes skipped:  ${result.episodesSkipped}`);
+        console.log(`  Entities created:  ${result.entitiesCreated}`);
+        console.log(`  Edges created:     ${result.edgesCreated}`);
+        console.log(`  Edges superseded:  ${result.edgesSuperseded}`);
+      } catch (err) {
+        console.error(
+          `Git ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+
+  // ingest md
+  ingest
+    .command("md <glob>")
+    .description("Ingest markdown files matching a glob pattern")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action(async (glob: string, opts: IngestMdOpts) => {
+      const dbPath = path.resolve(opts.db);
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      console.log(`Ingesting markdown: ${glob}`);
+      try {
+        const result = await ingestMarkdown(graph, glob);
+        console.log("Markdown ingestion complete:");
+        console.log(`  Episodes created: ${result.episodesCreated}`);
+        console.log(`  Episodes skipped: ${result.episodesSkipped}`);
+      } catch (err) {
+        console.error(
+          `Markdown ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+
+  // ingest enrich github
+  const enrich = ingest
+    .command("enrich")
+    .description("Enrich the graph with data from external sources");
+
+  enrich
+    .command("github")
+    .description("Enrich with GitHub PRs and issues")
+    .option("--token <token>", "GitHub API token (or set GITHUB_TOKEN env var)")
+    .option("--repo <owner/repo>", "repository in owner/repo format")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action(async (opts: IngestEnrichGithubOpts) => {
+      const dbPath = path.resolve(opts.db);
+      const token = opts.token ?? process.env.GITHUB_TOKEN;
+
+      if (!token) {
+        console.error(
+          "Error: GitHub token required. Use --token or set GITHUB_TOKEN env var.",
+        );
+        process.exit(1);
+      }
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      const adapter = new GitHubAdapter();
+      console.log(`Enriching from GitHub${opts.repo ? ` (${opts.repo})` : ""}`);
+
+      try {
+        const result = await adapter.enrich(graph, { token, repo: opts.repo });
+        console.log("GitHub enrichment complete:");
+        console.log(`  Episodes created: ${result.episodesCreated}`);
+        console.log(`  Episodes skipped: ${result.episodesSkipped}`);
+        console.log(`  Entities created: ${result.entitiesCreated}`);
+        console.log(`  Edges created:    ${result.edgesCreated}`);
+      } catch (err) {
+        console.error(
+          `GitHub enrichment failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+}

--- a/packages/engram-cli/src/commands/init.ts
+++ b/packages/engram-cli/src/commands/init.ts
@@ -1,0 +1,65 @@
+/**
+ * init.ts — `engram init` command.
+ *
+ * Creates a new .engram database at the given path.
+ * Optionally runs git ingestion immediately after creation.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import { closeGraph, createGraph, ingestGitRepo } from "engram-core";
+
+interface InitOpts {
+  fromGit?: string;
+  db: string;
+}
+
+export function registerInit(program: Command): void {
+  program
+    .command("init")
+    .description("Create a new .engram knowledge graph database")
+    .option("--from-git <path>", "also ingest a git repository after creating")
+    .option("--db <path>", "path for the .engram file", ".engram")
+    .action(async (opts: InitOpts) => {
+      const dbPath = path.resolve(opts.db);
+
+      if (fs.existsSync(dbPath)) {
+        console.error(`Error: .engram file already exists at ${dbPath}`);
+        process.exit(1);
+      }
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = createGraph(dbPath);
+        console.log(`Created ${dbPath}`);
+      } catch (err) {
+        console.error(
+          `Error creating graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      if (opts.fromGit) {
+        const repoPath = path.resolve(opts.fromGit);
+        console.log(`Ingesting git repository: ${repoPath}`);
+        try {
+          const result = await ingestGitRepo(graph, repoPath);
+          console.log(`Git ingestion complete:`);
+          console.log(`  Episodes created:  ${result.episodesCreated}`);
+          console.log(`  Episodes skipped:  ${result.episodesSkipped}`);
+          console.log(`  Entities created:  ${result.entitiesCreated}`);
+          console.log(`  Edges created:     ${result.edgesCreated}`);
+        } catch (err) {
+          console.error(
+            `Git ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          closeGraph(graph);
+          process.exit(1);
+        }
+      }
+
+      closeGraph(graph);
+    });
+}

--- a/packages/engram-cli/src/commands/maintenance.ts
+++ b/packages/engram-cli/src/commands/maintenance.ts
@@ -1,0 +1,65 @@
+/**
+ * maintenance.ts — `engram rebuild-index` and `engram serve` commands.
+ *
+ * rebuild-index: rebuilds FTS5 indexes for entities, edges, episodes.
+ * serve:         placeholder — MCP server not yet implemented.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import { closeGraph, openGraph } from "engram-core";
+
+interface MaintenanceOpts {
+  db: string;
+}
+
+export function registerMaintenance(program: Command): void {
+  // rebuild-index
+  program
+    .command("rebuild-index")
+    .description("Rebuild FTS5 indexes for entities, edges, and episodes")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((opts: MaintenanceOpts) => {
+      const dbPath = path.resolve(opts.db);
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      try {
+        graph.db.run(
+          "INSERT INTO entities_fts(entities_fts) VALUES('rebuild')",
+        );
+        graph.db.run("INSERT INTO edges_fts(edges_fts) VALUES('rebuild')");
+        graph.db.run(
+          "INSERT INTO episodes_fts(episodes_fts) VALUES('rebuild')",
+        );
+        console.log("FTS indexes rebuilt successfully.");
+      } catch (err) {
+        console.error(
+          `Rebuild failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+
+  // serve
+  program
+    .command("serve")
+    .description("Start the MCP server (stdio transport)")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((_opts: MaintenanceOpts) => {
+      console.log("MCP server not yet implemented.");
+      console.log("Use the engram-mcp package when available.");
+    });
+}

--- a/packages/engram-cli/src/commands/search.ts
+++ b/packages/engram-cli/src/commands/search.ts
@@ -1,0 +1,83 @@
+/**
+ * search.ts — `engram search` command.
+ *
+ * Full-text search across entities, edges, and episodes.
+ * Outputs text or JSON format.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph, SearchResult } from "engram-core";
+import { closeGraph, openGraph, search } from "engram-core";
+
+interface SearchOpts {
+  limit: string;
+  validAt?: string;
+  format: string;
+  db: string;
+}
+
+export function registerSearch(program: Command): void {
+  program
+    .command("search <query>")
+    .description("Search the knowledge graph")
+    .option("--limit <n>", "maximum results to return", "20")
+    .option("--valid-at <iso>", "filter edges valid at this ISO8601 timestamp")
+    .option("--format <fmt>", "output format: text or json", "text")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((query: string, opts: SearchOpts) => {
+      const dbPath = path.resolve(opts.db);
+      const limit = parseInt(opts.limit, 10);
+
+      if (Number.isNaN(limit) || limit < 1) {
+        console.error("Error: --limit must be a positive integer");
+        process.exit(1);
+      }
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      let results: SearchResult[];
+      try {
+        results = search(graph, query, {
+          limit,
+          valid_at: opts.validAt,
+        });
+        closeGraph(graph);
+      } catch (err) {
+        console.error(
+          `Search failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+        return;
+      }
+
+      if (opts.format === "json") {
+        console.log(JSON.stringify(results, null, 2));
+        return;
+      }
+
+      if (results.length === 0) {
+        console.log("No results found.");
+        return;
+      }
+
+      for (const r of results) {
+        const score = r.score.toFixed(3);
+        const kind = r.edge_kind ? ` [${r.edge_kind}]` : "";
+        console.log(`[${r.type}${kind}] (${score}) ${r.content}`);
+        console.log(`  id: ${r.id}`);
+        if (r.provenance.length > 0) {
+          console.log(`  evidence: ${r.provenance.length} episode(s)`);
+        }
+      }
+    });
+}

--- a/packages/engram-cli/src/commands/search.ts
+++ b/packages/engram-cli/src/commands/search.ts
@@ -34,6 +34,11 @@ export function registerSearch(program: Command): void {
         process.exit(1);
       }
 
+      if (opts.format !== "text" && opts.format !== "json") {
+        console.error("Error: --format must be 'text' or 'json'");
+        process.exit(1);
+      }
+
       let graph: EngramGraph | undefined;
       try {
         graph = openGraph(dbPath);

--- a/packages/engram-cli/src/commands/show.ts
+++ b/packages/engram-cli/src/commands/show.ts
@@ -68,7 +68,12 @@ export function registerShow(program: Command): void {
         // Edges — target
         const inEdges = findEdges(graph, { target_id: entity.id });
 
-        const allEdges = [...outEdges, ...inEdges];
+        // Dedup edges by ID (outEdges and inEdges may overlap)
+        const edgeMap = new Map<string, (typeof outEdges)[0]>();
+        for (const edge of [...outEdges, ...inEdges]) {
+          if (!edgeMap.has(edge.id)) edgeMap.set(edge.id, edge);
+        }
+        const allEdges = Array.from(edgeMap.values());
 
         if (allEdges.length > 0) {
           // Group by relation_type

--- a/packages/engram-cli/src/commands/show.ts
+++ b/packages/engram-cli/src/commands/show.ts
@@ -1,0 +1,107 @@
+/**
+ * show.ts — `engram show` command.
+ *
+ * Displays entity details with edges grouped by relation_type and evidence count.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import {
+  closeGraph,
+  findEdges,
+  getEntity,
+  getEvidenceForEntity,
+  openGraph,
+  resolveEntity,
+} from "engram-core";
+
+interface ShowOpts {
+  db: string;
+}
+
+export function registerShow(program: Command): void {
+  program
+    .command("show <entity>")
+    .description("Show entity details, edges, and evidence")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((entityArg: string, opts: ShowOpts) => {
+      const dbPath = path.resolve(opts.db);
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      try {
+        // Try by ID first, then by name/alias
+        let entity = getEntity(graph, entityArg);
+        if (!entity) {
+          entity = resolveEntity(graph, entityArg);
+        }
+
+        if (!entity) {
+          console.error(`Entity not found: ${entityArg}`);
+          closeGraph(graph);
+          process.exit(1);
+        }
+
+        console.log(`${entity.canonical_name}`);
+        console.log(`  id:     ${entity.id}`);
+        console.log(`  type:   ${entity.entity_type}`);
+        console.log(`  status: ${entity.status}`);
+        if (entity.summary) {
+          console.log(`  summary: ${entity.summary}`);
+        }
+        console.log(`  created: ${entity.created_at}`);
+
+        const evidence = getEvidenceForEntity(graph, entity.id);
+        console.log(`  evidence: ${evidence.length} episode(s)`);
+
+        // Edges — source
+        const outEdges = findEdges(graph, { source_id: entity.id });
+        // Edges — target
+        const inEdges = findEdges(graph, { target_id: entity.id });
+
+        const allEdges = [...outEdges, ...inEdges];
+
+        if (allEdges.length > 0) {
+          // Group by relation_type
+          const grouped = new Map<string, typeof allEdges>();
+          for (const edge of allEdges) {
+            const group = grouped.get(edge.relation_type) ?? [];
+            group.push(edge);
+            grouped.set(edge.relation_type, group);
+          }
+
+          console.log("\nEdges:");
+          for (const [relType, edges] of grouped) {
+            console.log(`  [${relType}] (${edges.length})`);
+            for (const edge of edges.slice(0, 5)) {
+              const direction = edge.source_id === entity.id ? "->" : "<-";
+              const status = edge.invalidated_at ? " [invalidated]" : "";
+              console.log(`    ${direction} ${edge.fact}${status}`);
+            }
+            if (edges.length > 5) {
+              console.log(`    ... and ${edges.length - 5} more`);
+            }
+          }
+        } else {
+          console.log("\nNo edges.");
+        }
+      } catch (err) {
+        console.error(
+          `Error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+}

--- a/packages/engram-cli/src/commands/stats.ts
+++ b/packages/engram-cli/src/commands/stats.ts
@@ -1,0 +1,88 @@
+/**
+ * stats.ts — `engram stats` command.
+ *
+ * Shows counts of entities, edges, and episodes in the graph.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import { closeGraph, openGraph } from "engram-core";
+
+interface StatsOpts {
+  db: string;
+}
+
+interface CountRow {
+  count: number;
+}
+
+export function registerStats(program: Command): void {
+  program
+    .command("stats")
+    .description("Show graph statistics (entity, edge, episode counts)")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((opts: StatsOpts) => {
+      const dbPath = path.resolve(opts.db);
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      try {
+        const entities =
+          graph.db
+            .query<CountRow, []>(
+              "SELECT COUNT(*) as count FROM entities WHERE status = 'active'",
+            )
+            .get()?.count ?? 0;
+
+        const edges =
+          graph.db
+            .query<CountRow, []>(
+              "SELECT COUNT(*) as count FROM edges WHERE invalidated_at IS NULL",
+            )
+            .get()?.count ?? 0;
+
+        const episodes =
+          graph.db
+            .query<CountRow, []>(
+              "SELECT COUNT(*) as count FROM episodes WHERE status = 'active'",
+            )
+            .get()?.count ?? 0;
+
+        const aliases =
+          graph.db
+            .query<CountRow, []>("SELECT COUNT(*) as count FROM entity_aliases")
+            .get()?.count ?? 0;
+
+        const invalidatedEdges =
+          graph.db
+            .query<CountRow, []>(
+              "SELECT COUNT(*) as count FROM edges WHERE invalidated_at IS NOT NULL",
+            )
+            .get()?.count ?? 0;
+
+        console.log(`Graph: ${dbPath}`);
+        console.log(`  Entities (active):   ${entities}`);
+        console.log(`  Edges (active):      ${edges}`);
+        console.log(`  Edges (invalidated): ${invalidatedEdges}`);
+        console.log(`  Episodes (active):   ${episodes}`);
+        console.log(`  Aliases:             ${aliases}`);
+      } catch (err) {
+        console.error(
+          `Error reading stats: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+}

--- a/packages/engram-cli/src/commands/verify.ts
+++ b/packages/engram-cli/src/commands/verify.ts
@@ -1,0 +1,133 @@
+/**
+ * verify.ts — `engram verify` command.
+ *
+ * Validates .engram integrity by checking evidence invariants.
+ * Exit 0 = clean, Exit 2 = integrity issues found.
+ */
+
+import * as path from "node:path";
+import type { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import { closeGraph, openGraph } from "engram-core";
+
+interface VerifyOpts {
+  db: string;
+}
+
+interface IdRow {
+  id: string;
+  name: string;
+}
+
+export function registerVerify(program: Command): void {
+  program
+    .command("verify")
+    .description("Validate .engram integrity (evidence invariants)")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action((opts: VerifyOpts) => {
+      const dbPath = path.resolve(opts.db);
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      const violations: string[] = [];
+
+      try {
+        // Check entities without evidence
+        const orphanedEntities = graph.db
+          .query<IdRow, []>(`
+            SELECT e.id, e.canonical_name AS name
+            FROM entities e
+            WHERE e.status = 'active'
+              AND NOT EXISTS (
+                SELECT 1 FROM entity_evidence ee WHERE ee.entity_id = e.id
+              )
+          `)
+          .all();
+
+        for (const entity of orphanedEntities) {
+          violations.push(
+            `Entity ${entity.id} (${entity.name}) has no evidence links`,
+          );
+        }
+
+        // Check edges without evidence
+        const orphanedEdges = graph.db
+          .query<{ id: string; fact: string }, []>(`
+            SELECT ed.id, ed.fact
+            FROM edges ed
+            WHERE ed.invalidated_at IS NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM edge_evidence ee WHERE ee.edge_id = ed.id
+              )
+          `)
+          .all();
+
+        for (const edge of orphanedEdges) {
+          violations.push(
+            `Edge ${edge.id} ("${edge.fact}") has no evidence links`,
+          );
+        }
+
+        // Check for entity_evidence pointing to missing episodes
+        const danglingEntityEvidence = graph.db
+          .query<{ entity_id: string; episode_id: string }, []>(`
+            SELECT ee.entity_id, ee.episode_id
+            FROM entity_evidence ee
+            WHERE NOT EXISTS (
+              SELECT 1 FROM episodes ep WHERE ep.id = ee.episode_id
+            )
+          `)
+          .all();
+
+        for (const ev of danglingEntityEvidence) {
+          violations.push(
+            `entity_evidence for entity ${ev.entity_id} references missing episode ${ev.episode_id}`,
+          );
+        }
+
+        // Check for edge_evidence pointing to missing episodes
+        const danglingEdgeEvidence = graph.db
+          .query<{ edge_id: string; episode_id: string }, []>(`
+            SELECT ee.edge_id, ee.episode_id
+            FROM edge_evidence ee
+            WHERE NOT EXISTS (
+              SELECT 1 FROM episodes ep WHERE ep.id = ee.episode_id
+            )
+          `)
+          .all();
+
+        for (const ev of danglingEdgeEvidence) {
+          violations.push(
+            `edge_evidence for edge ${ev.edge_id} references missing episode ${ev.episode_id}`,
+          );
+        }
+      } catch (err) {
+        console.error(
+          `Verify failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+
+      if (violations.length === 0) {
+        console.log("Graph integrity OK — no violations found.");
+        return;
+      }
+
+      console.error(`Found ${violations.length} integrity violation(s):`);
+      for (const v of violations) {
+        console.error(`  - ${v}`);
+      }
+      process.exit(2);
+    });
+}

--- a/packages/engram-cli/test/commands/cli.test.ts
+++ b/packages/engram-cli/test/commands/cli.test.ts
@@ -261,11 +261,11 @@ describe("engram decay", () => {
 });
 
 describe("engram error handling", () => {
-  it("openGraph throws a descriptive error for a non-engram file", () => {
+  it("openGraph throws a descriptive error for a non-engram file", async () => {
     // CLI commands call openGraph and catch + print the error.
     // Here we verify that openGraph produces a descriptive error, which is
     // what the CLI would log to console.error before exiting.
-    const { openGraph } = require("engram-core");
+    const { openGraph } = await import("engram-core");
     const { tmpDir, dbPath } = tmpDb();
     try {
       fs.writeFileSync(dbPath, "not a valid engram database\n");
@@ -277,6 +277,16 @@ describe("engram error handling", () => {
       }
       // Should throw something (either SQLite error or EngramFormatError)
       expect(caught).not.toBeNull();
+      // Should have a descriptive message mentioning format_version, "not a valid .engram file",
+      // "missing", or a SQLite-level error indicating the file is not a valid database
+      const msg = caught?.message ?? "";
+      const isDescriptive =
+        msg.includes("format_version") ||
+        msg.includes("not a valid .engram file") ||
+        msg.includes("missing") ||
+        msg.includes("not a database") ||
+        msg.includes("database");
+      expect(isDescriptive).toBe(true);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/packages/engram-cli/test/commands/cli.test.ts
+++ b/packages/engram-cli/test/commands/cli.test.ts
@@ -1,0 +1,284 @@
+/**
+ * cli.test.ts — CLI command registration and basic output tests.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { addEpisode, createGraph } from "engram-core";
+import { registerAdd } from "../../src/commands/add.js";
+import { registerDecay } from "../../src/commands/decay.js";
+import { registerExport } from "../../src/commands/export.js";
+import { registerHistory } from "../../src/commands/history.js";
+import { registerIngest } from "../../src/commands/ingest.js";
+import { registerInit } from "../../src/commands/init.js";
+import { registerMaintenance } from "../../src/commands/maintenance.js";
+import { registerSearch } from "../../src/commands/search.js";
+import { registerShow } from "../../src/commands/show.js";
+import { registerStats } from "../../src/commands/stats.js";
+import { registerVerify } from "../../src/commands/verify.js";
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  registerInit(program);
+  registerAdd(program);
+  registerSearch(program);
+  registerShow(program);
+  registerHistory(program);
+  registerDecay(program);
+  registerStats(program);
+  registerIngest(program);
+  registerExport(program);
+  registerVerify(program);
+  registerMaintenance(program);
+  return program;
+}
+
+function tmpDb(): { tmpDir: string; dbPath: string } {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-cli-test-"));
+  const dbPath = path.join(tmpDir, "test.engram");
+  return { tmpDir, dbPath };
+}
+
+describe("CLI command registration", () => {
+  it("registers all expected top-level commands", () => {
+    const program = makeProgram();
+    const names = program.commands.map((c) => c.name());
+    expect(names).toContain("init");
+    expect(names).toContain("add");
+    expect(names).toContain("search");
+    expect(names).toContain("show");
+    expect(names).toContain("history");
+    expect(names).toContain("decay");
+    expect(names).toContain("stats");
+    expect(names).toContain("ingest");
+    expect(names).toContain("export");
+    expect(names).toContain("verify");
+    expect(names).toContain("rebuild-index");
+    expect(names).toContain("serve");
+  });
+
+  it("registers ingest subcommands", () => {
+    const program = makeProgram();
+    const ingest = program.commands.find((c) => c.name() === "ingest");
+    expect(ingest).toBeDefined();
+    if (!ingest) return;
+    const subNames = ingest.commands.map((c) => c.name());
+    expect(subNames).toContain("git");
+    expect(subNames).toContain("md");
+    expect(subNames).toContain("enrich");
+  });
+
+  it("registers ingest enrich subcommands", () => {
+    const program = makeProgram();
+    const ingest = program.commands.find((c) => c.name() === "ingest");
+    if (!ingest) return;
+    const enrich = ingest.commands.find((c) => c.name() === "enrich");
+    expect(enrich).toBeDefined();
+    if (!enrich) return;
+    const subNames = enrich.commands.map((c) => c.name());
+    expect(subNames).toContain("github");
+  });
+});
+
+describe("engram stats", () => {
+  it("prints graph statistics without error", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync(["node", "engram", "stats", "--db", dbPath]);
+      } finally {
+        console.log = origLog;
+      }
+      const output = logs.join("\n");
+      expect(output).toContain("Entities");
+      expect(output).toContain("Edges");
+      expect(output).toContain("Episodes");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram search", () => {
+  it("outputs text (no JSON) by default on empty graph", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "search",
+          "test",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      expect(logs.join("\n")).toContain("No results");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("outputs JSON array when --format json is set", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "search",
+          "test",
+          "--format",
+          "json",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const parsed = JSON.parse(logs.join("\n"));
+      expect(Array.isArray(parsed)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram verify", () => {
+  it("reports OK on a clean graph", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync(["node", "engram", "verify", "--db", dbPath]);
+      } finally {
+        console.log = origLog;
+      }
+      expect(logs.join("\n")).toContain("OK");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram export", () => {
+  it("JSONL export produces valid JSON lines with _type field", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      const graph = createGraph(dbPath);
+      addEpisode(graph, {
+        source_type: "manual",
+        content: "test content for export",
+        timestamp: new Date().toISOString(),
+      });
+      graph.db.close();
+
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "export",
+          "--format",
+          "jsonl",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+
+      for (const line of logs) {
+        if (line.trim()) {
+          const parsed = JSON.parse(line);
+          expect(parsed).toHaveProperty("_type");
+          expect(["entity", "edge", "episode"]).toContain(parsed._type);
+        }
+      }
+
+      const hasEpisode = logs.some((l) => {
+        try {
+          return JSON.parse(l)._type === "episode";
+        } catch {
+          return false;
+        }
+      });
+      expect(hasEpisode).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram decay", () => {
+  it("prints decay report summary", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync(["node", "engram", "decay", "--db", dbPath]);
+      } finally {
+        console.log = origLog;
+      }
+      const output = logs.join("\n");
+      expect(output).toContain("Decay Report");
+      expect(output).toContain("Summary");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram error handling", () => {
+  it("openGraph throws a descriptive error for a non-engram file", () => {
+    // CLI commands call openGraph and catch + print the error.
+    // Here we verify that openGraph produces a descriptive error, which is
+    // what the CLI would log to console.error before exiting.
+    const { openGraph } = require("engram-core");
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      fs.writeFileSync(dbPath, "not a valid engram database\n");
+      let caught: Error | null = null;
+      try {
+        openGraph(dbPath);
+      } catch (err) {
+        caught = err as Error;
+      }
+      // Should throw something (either SQLite error or EngramFormatError)
+      expect(caught).not.toBeNull();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/engram-core/package.json
+++ b/packages/engram-core/package.json
@@ -5,6 +5,12 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "bun build src/index.ts --outdir dist --target node",
     "test": "bun test"


### PR DESCRIPTION
## Summary

Full CLI command surface over `engram-core`. The CLI is intentionally thin — all logic lives in the library.

**Core commands:** `init`, `add`, `search`, `show`, `history`, `decay`, `stats`  
**Ingest commands:** `ingest git`, `ingest md`, `ingest enrich github`  
**Maintenance:** `export`, `verify`, `rebuild-index`, `serve` (placeholder)

## Acceptance Criteria

- [x] `engram init [--from-git <path>]`
- [x] `engram add <content> [--file <path>]`
- [x] `engram search <query>` with `--limit`, `--valid-at`, `--format json|text`
- [x] `engram show <entity>` — edges grouped by relation_type, evidence count
- [x] `engram history <entity1> [<entity2>]`
- [x] `engram decay [--stale-days N] [--dormant-days N]`
- [x] `engram stats` — entity/edge/episode/alias counts
- [x] `engram ingest git|md|enrich github`
- [x] `engram export [--format jsonl|md]` — sorted by ID for determinism
- [x] `engram verify` — evidence invariant check (exit 0 clean, 2 violations)
- [x] `engram rebuild-index` — FTS5 rebuild
- [x] Human-readable errors, no stack traces
- [x] Exit codes: 0 success, 1 error, 2 verify failures
- [x] Default DB: `.engram` in CWD; `--db <path>` override on all commands

## Test plan

- [x] `bun test` — 223 tests pass (213 core + 10 CLI)
- [x] `bun run build` — all 4 packages build cleanly
- [x] `bun run lint` — 66 files checked, clean

> **Note:** Stacked on `feat/decay-detection-issue-10` (PR #25).

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)