### PR TITLE
feat: MCP server — stdio transport with read-heavy tool surface

### DIFF
--- a/packages/engram-mcp/package.json
+++ b/packages/engram-mcp/package.json
@@ -4,6 +4,12 @@
   "description": "MCP server for engram temporal knowledge graph",
   "type": "module",
   "main": "dist/server.js",
+  "exports": {
+    ".": {
+      "bun": "./src/server.ts",
+      "default": "./dist/server.js"
+    }
+  },
   "scripts": {
     "build": "bun build src/server.ts --outdir dist --target node",
     "test": "bun test"

--- a/packages/engram-mcp/src/resources.ts
+++ b/packages/engram-mcp/src/resources.ts
@@ -1,0 +1,66 @@
+/**
+ * resources.ts — MCP resource handlers for engram graph metadata.
+ *
+ * Resources:
+ *   engram://stats  — entity/edge/episode counts
+ *   engram://recent — last 10 episodes by ingested_at
+ */
+
+import type { EngramGraph } from "engram-core";
+
+export const ENGRAM_RESOURCES = [
+  {
+    uri: "engram://stats",
+    name: "engram stats",
+    description: "Entity, edge, and episode counts for the current graph",
+    mimeType: "application/json",
+  },
+  {
+    uri: "engram://recent",
+    name: "engram recent episodes",
+    description: "The 10 most recently ingested episodes",
+    mimeType: "application/json",
+  },
+];
+
+interface StatsRow {
+  entities: number;
+  edges: number;
+  episodes: number;
+}
+
+export function readStats(graph: EngramGraph): StatsRow {
+  const row = graph.db
+    .query<StatsRow, []>(
+      `SELECT
+        (SELECT COUNT(*) FROM entities WHERE status = 'active') AS entities,
+        (SELECT COUNT(*) FROM edges WHERE invalidated_at IS NULL) AS edges,
+        (SELECT COUNT(*) FROM episodes WHERE status = 'active') AS episodes`,
+    )
+    .get();
+
+  return row ?? { entities: 0, edges: 0, episodes: 0 };
+}
+
+interface RecentEpisodeRow {
+  id: string;
+  source_type: string;
+  source_ref: string | null;
+  actor: string | null;
+  timestamp: string;
+  ingested_at: string;
+  content: string;
+}
+
+export function readRecentEpisodes(graph: EngramGraph): RecentEpisodeRow[] {
+  return graph.db
+    .query<RecentEpisodeRow, []>(
+      `SELECT id, source_type, source_ref, actor, timestamp, ingested_at,
+              SUBSTR(content, 1, 200) AS content
+       FROM episodes
+       WHERE status = 'active'
+       ORDER BY ingested_at DESC
+       LIMIT 10`,
+    )
+    .all();
+}

--- a/packages/engram-mcp/src/tools/context.ts
+++ b/packages/engram-mcp/src/tools/context.ts
@@ -8,6 +8,7 @@ import {
   type Edge,
   type EngramGraph,
   type Entity,
+  EntityNotFoundError,
   type Episode,
   getEdge,
   getEntity,
@@ -115,6 +116,8 @@ export function handleGetContext(
     }
   }
 
+  const MAX_FANOUT = 50;
+
   // Step 3: Fan-out 1-hop traversal from top 3 entity search results
   for (const entityId of top3EntityIds) {
     try {
@@ -123,9 +126,12 @@ export function handleGetContext(
         valid_at: input.valid_at,
       });
 
+      let fanoutCount = 0;
       for (const entity of subgraph.entities) {
+        if (fanoutCount >= MAX_FANOUT) break;
         if (!entityScores.has(entity.id)) {
           entityScores.set(entity.id, 0.3);
+          fanoutCount++;
         }
       }
 
@@ -134,8 +140,12 @@ export function handleGetContext(
           edgeScores.set(edge.id, 0.3);
         }
       }
-    } catch {
-      // Entity may not exist — skip
+    } catch (err) {
+      if (err instanceof EntityNotFoundError) {
+        // Entity may not exist — skip
+        continue;
+      }
+      throw err;
     }
   }
 

--- a/packages/engram-mcp/src/tools/context.ts
+++ b/packages/engram-mcp/src/tools/context.ts
@@ -1,0 +1,217 @@
+/**
+ * tools/context.ts — engram_get_context MCP tool implementation.
+ *
+ * The 95% tool: hybrid search -> fan-out traversal -> rank -> budget-aware truncation.
+ */
+
+import {
+  type Edge,
+  type EngramGraph,
+  type Entity,
+  type Episode,
+  getEdge,
+  getEntity,
+  getEpisode,
+  getNeighbors,
+  type SearchResult,
+  search,
+} from "engram-core";
+
+export const GET_CONTEXT_TOOL = {
+  name: "engram_get_context",
+  description:
+    "Retrieve rich context for a query: hybrid search followed by 1-hop graph fan-out, ranked and budget-truncated. This is the primary tool for answering questions about the codebase.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string",
+        description: "Query to retrieve context for",
+      },
+      max_tokens: {
+        type: "number",
+        description: "Token budget for returned context (default 4000)",
+      },
+      valid_at: {
+        type: "string",
+        description:
+          "ISO8601 UTC timestamp for temporal filtering (default: now)",
+      },
+      scope: {
+        type: "string",
+        description: "Scope filter (no-op in v0.1)",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+export interface GetContextInput {
+  query: string;
+  max_tokens?: number;
+  valid_at?: string;
+  scope?: string;
+}
+
+interface ScoredEntity {
+  entity: Entity;
+  score: number;
+}
+
+interface ScoredEdge {
+  edge: Edge;
+  score: number;
+}
+
+export interface ContextResult {
+  entities: Entity[];
+  edges: Edge[];
+  episodes: Episode[];
+  truncated: boolean;
+  total_relevant: number;
+  context_tokens: number;
+}
+
+function estimateTokens(obj: unknown): number {
+  return Math.ceil(JSON.stringify(obj).length / 4);
+}
+
+export function handleGetContext(
+  graph: EngramGraph,
+  input: GetContextInput,
+): ContextResult {
+  const maxTokens = input.max_tokens ?? 4000;
+
+  // Step 1: Hybrid search top 10
+  const searchResults: SearchResult[] = search(graph, input.query, {
+    mode: "hybrid",
+    limit: 10,
+    valid_at: input.valid_at,
+  });
+
+  // Step 2: Extract top-3 entity IDs for fan-out traversal
+  const entitySearchResults = searchResults.filter((r) => r.type === "entity");
+  const top3EntityIds = entitySearchResults.slice(0, 3).map((r) => r.id);
+
+  // Maps to track deduped scored entities and edges
+  const entityScores = new Map<string, number>();
+  const edgeScores = new Map<string, number>();
+  const episodeIdSet = new Set<string>();
+
+  // Seed from search results
+  for (const result of searchResults) {
+    if (result.type === "entity") {
+      if (!entityScores.has(result.id)) {
+        entityScores.set(result.id, result.score);
+      }
+      for (const pid of result.provenance) episodeIdSet.add(pid);
+    } else if (result.type === "edge") {
+      if (!edgeScores.has(result.id)) {
+        edgeScores.set(result.id, result.score);
+      }
+      for (const pid of result.provenance) episodeIdSet.add(pid);
+    } else if (result.type === "episode") {
+      episodeIdSet.add(result.id);
+    }
+  }
+
+  // Step 3: Fan-out 1-hop traversal from top 3 entity search results
+  for (const entityId of top3EntityIds) {
+    try {
+      const subgraph = getNeighbors(graph, entityId, {
+        depth: 1,
+        valid_at: input.valid_at,
+      });
+
+      for (const entity of subgraph.entities) {
+        if (!entityScores.has(entity.id)) {
+          entityScores.set(entity.id, 0.3);
+        }
+      }
+
+      for (const edge of subgraph.edges) {
+        if (!edgeScores.has(edge.id)) {
+          edgeScores.set(edge.id, 0.3);
+        }
+      }
+    } catch {
+      // Entity may not exist — skip
+    }
+  }
+
+  // Step 4: Resolve entities and edges from graph
+  const scoredEntities: ScoredEntity[] = [];
+  for (const [id, score] of entityScores) {
+    const entity = getEntity(graph, id);
+    if (entity) {
+      scoredEntities.push({ entity, score });
+    }
+  }
+
+  const scoredEdges: ScoredEdge[] = [];
+  for (const [id, score] of edgeScores) {
+    const edge = getEdge(graph, id);
+    if (edge) {
+      scoredEdges.push({ edge, score });
+    }
+  }
+
+  // Step 5: Sort by score descending
+  scoredEntities.sort((a, b) => b.score - a.score);
+  scoredEdges.sort((a, b) => b.score - a.score);
+
+  const total_relevant =
+    scoredEntities.length + scoredEdges.length + episodeIdSet.size;
+
+  // Step 6: Budget-aware truncation
+  const selectedEntities: Entity[] = [];
+  const selectedEdges: Edge[] = [];
+  const selectedEpisodes: Episode[] = [];
+  let usedTokens = 0;
+  let truncated = false;
+
+  for (const { entity } of scoredEntities) {
+    const tokens = estimateTokens(entity);
+    if (usedTokens + tokens > maxTokens) {
+      truncated = true;
+      break;
+    }
+    selectedEntities.push(entity);
+    usedTokens += tokens;
+  }
+
+  if (!truncated) {
+    for (const { edge } of scoredEdges) {
+      const tokens = estimateTokens(edge);
+      if (usedTokens + tokens > maxTokens) {
+        truncated = true;
+        break;
+      }
+      selectedEdges.push(edge);
+      usedTokens += tokens;
+    }
+  }
+
+  if (!truncated) {
+    for (const episodeId of episodeIdSet) {
+      const episode = getEpisode(graph, episodeId);
+      if (!episode) continue;
+      const tokens = estimateTokens(episode);
+      if (usedTokens + tokens > maxTokens) {
+        truncated = true;
+        break;
+      }
+      selectedEpisodes.push(episode);
+      usedTokens += tokens;
+    }
+  }
+
+  return {
+    entities: selectedEntities,
+    edges: selectedEdges,
+    episodes: selectedEpisodes,
+    truncated,
+    total_relevant,
+    context_tokens: usedTokens,
+  };
+}

--- a/packages/engram-mcp/src/tools/decay.ts
+++ b/packages/engram-mcp/src/tools/decay.ts
@@ -1,0 +1,58 @@
+/**
+ * tools/decay.ts — engram_get_decay MCP tool implementation.
+ */
+
+import {
+  type DecayReport,
+  type EngramGraph,
+  getDecayReport,
+} from "engram-core";
+
+export const GET_DECAY_TOOL = {
+  name: "engram_get_decay",
+  description:
+    "Get a knowledge decay report identifying stale, contradicted, orphaned, or at-risk entities and edges in the graph.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      stale_days: {
+        type: "number",
+        description:
+          "Days without evidence updates before entity/edge is considered stale (default 180)",
+      },
+      dormant_days: {
+        type: "number",
+        description:
+          "Days without activity before primary contributor is considered dormant (default 90)",
+      },
+      min_edges_for_risk: {
+        type: "number",
+        description:
+          "Minimum active edges for concentrated risk detection (default 3)",
+      },
+      scope: {
+        type: "string",
+        description: "Scope filter (no-op in v0.1)",
+      },
+    },
+    required: [],
+  },
+};
+
+export interface GetDecayInput {
+  stale_days?: number;
+  dormant_days?: number;
+  min_edges_for_risk?: number;
+  scope?: string;
+}
+
+export function handleGetDecay(
+  graph: EngramGraph,
+  input: GetDecayInput,
+): DecayReport {
+  return getDecayReport(graph, {
+    stale_days: input.stale_days,
+    dormant_days: input.dormant_days,
+    min_edges_for_risk: input.min_edges_for_risk,
+  });
+}

--- a/packages/engram-mcp/src/tools/entity.ts
+++ b/packages/engram-mcp/src/tools/entity.ts
@@ -1,0 +1,149 @@
+/**
+ * tools/entity.ts — engram_get_entity and engram_add_entity MCP tool implementations.
+ */
+
+import {
+  addEntity,
+  addEpisode,
+  type EngramGraph,
+  findEdges,
+  getEntity,
+  getEvidenceForEntity,
+} from "engram-core";
+
+// ---------------------------------------------------------------------------
+// engram_get_entity
+// ---------------------------------------------------------------------------
+
+export const GET_ENTITY_TOOL = {
+  name: "engram_get_entity",
+  description:
+    "Retrieve a single entity by ID including its relationships (edges) and evidence chain.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      entity_id: {
+        type: "string",
+        description: "ULID identifier of the entity",
+      },
+      include_invalidated_edges: {
+        type: "boolean",
+        description: "Include superseded/invalidated edges (default false)",
+      },
+      scope: {
+        type: "string",
+        description: "Scope filter (no-op in v0.1)",
+      },
+    },
+    required: ["entity_id"],
+  },
+};
+
+export interface GetEntityInput {
+  entity_id: string;
+  include_invalidated_edges?: boolean;
+  scope?: string;
+}
+
+export function handleGetEntity(graph: EngramGraph, input: GetEntityInput) {
+  const entity = getEntity(graph, input.entity_id);
+  if (!entity) {
+    return { error: `Entity not found: ${input.entity_id}` };
+  }
+
+  const edges = findEdges(graph, {
+    source_id: input.entity_id,
+    include_invalidated: input.include_invalidated_edges ?? false,
+  });
+  const inboundEdges = findEdges(graph, {
+    target_id: input.entity_id,
+    include_invalidated: input.include_invalidated_edges ?? false,
+  });
+
+  const evidence = getEvidenceForEntity(graph, input.entity_id);
+
+  return {
+    entity,
+    outbound_edges: edges,
+    inbound_edges: inboundEdges,
+    evidence,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// engram_add_entity
+// ---------------------------------------------------------------------------
+
+export const ADD_ENTITY_TOOL = {
+  name: "engram_add_entity",
+  description:
+    "Add a new entity to the knowledge graph with supporting evidence. Creates an episode first, then the entity linked to that episode.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      canonical_name: {
+        type: "string",
+        description: "Canonical name of the entity",
+      },
+      entity_type: {
+        type: "string",
+        description: "Type of entity (e.g. person, module, service, decision)",
+      },
+      summary: {
+        type: "string",
+        description: "Short descriptive summary of the entity",
+      },
+      episode_content: {
+        type: "string",
+        description: "Raw content for the backing evidence episode",
+      },
+      actor: {
+        type: "string",
+        description: "Who or what created this knowledge (optional)",
+      },
+      scope: {
+        type: "string",
+        description: "Scope filter (no-op in v0.1)",
+      },
+    },
+    required: ["canonical_name", "entity_type", "episode_content"],
+  },
+};
+
+export interface AddEntityInput {
+  canonical_name: string;
+  entity_type: string;
+  summary?: string;
+  episode_content: string;
+  actor?: string;
+  scope?: string;
+}
+
+export function handleAddEntity(graph: EngramGraph, input: AddEntityInput) {
+  const now = new Date().toISOString();
+
+  const episode = addEpisode(graph, {
+    source_type: "manual",
+    content: input.episode_content,
+    actor: input.actor,
+    timestamp: now,
+  });
+
+  const entity = addEntity(
+    graph,
+    {
+      canonical_name: input.canonical_name,
+      entity_type: input.entity_type,
+      summary: input.summary,
+    },
+    [
+      {
+        episode_id: episode.id,
+        extractor: "mcp:engram_add_entity",
+        confidence: 1.0,
+      },
+    ],
+  );
+
+  return { episode, entity };
+}

--- a/packages/engram-mcp/src/tools/history.ts
+++ b/packages/engram-mcp/src/tools/history.ts
@@ -1,0 +1,53 @@
+/**
+ * tools/history.ts — engram_get_history MCP tool implementation.
+ */
+
+import { type Edge, type EngramGraph, getFactHistory } from "engram-core";
+
+export const GET_HISTORY_TOOL = {
+  name: "engram_get_history",
+  description:
+    "Get the full temporal fact history between two entities: all edges (active and superseded) ordered chronologically.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      source_id: {
+        type: "string",
+        description: "ULID of the source entity",
+      },
+      target_id: {
+        type: "string",
+        description: "ULID of the target entity",
+      },
+      scope: {
+        type: "string",
+        description: "Scope filter (no-op in v0.1)",
+      },
+    },
+    required: ["source_id", "target_id"],
+  },
+};
+
+export interface GetHistoryInput {
+  source_id: string;
+  target_id: string;
+  scope?: string;
+}
+
+export interface HistoryResult {
+  source_id: string;
+  target_id: string;
+  edges: Edge[];
+}
+
+export function handleGetHistory(
+  graph: EngramGraph,
+  input: GetHistoryInput,
+): HistoryResult {
+  const edges = getFactHistory(graph, input.source_id, input.target_id);
+  return {
+    source_id: input.source_id,
+    target_id: input.target_id,
+    edges,
+  };
+}

--- a/packages/engram-mcp/src/tools/search.ts
+++ b/packages/engram-mcp/src/tools/search.ts
@@ -1,0 +1,78 @@
+/**
+ * tools/search.ts — engram_search MCP tool implementation.
+ */
+
+import { type EngramGraph, type SearchResult, search } from "engram-core";
+
+export const SEARCH_TOOL = {
+  name: "engram_search",
+  description:
+    "Search the engram knowledge graph using full-text or hybrid search across entities, edges, and episodes. Returns scored results sorted by relevance.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string",
+        description: "Search query string",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum number of results to return (default 20)",
+      },
+      mode: {
+        type: "string",
+        enum: ["fulltext", "hybrid"],
+        description: "Search mode: fulltext or hybrid (default fulltext)",
+      },
+      entity_types: {
+        type: "array",
+        items: { type: "string" },
+        description: "Filter entity results by entity_type values",
+      },
+      edge_kinds: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Filter edge results by edge_kind values (observed, inferred, asserted)",
+      },
+      valid_at: {
+        type: "string",
+        description: "ISO8601 UTC timestamp for temporal filtering of edges",
+      },
+      min_confidence: {
+        type: "number",
+        description: "Minimum confidence score 0.0–1.0 (default 0.0)",
+      },
+      scope: {
+        type: "string",
+        description: "Scope filter (no-op in v0.1)",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+export interface SearchInput {
+  query: string;
+  limit?: number;
+  mode?: "fulltext" | "hybrid";
+  entity_types?: string[];
+  edge_kinds?: string[];
+  valid_at?: string;
+  min_confidence?: number;
+  scope?: string;
+}
+
+export function handleSearch(
+  graph: EngramGraph,
+  input: SearchInput,
+): SearchResult[] {
+  return search(graph, input.query, {
+    limit: input.limit,
+    mode: input.mode,
+    entity_types: input.entity_types,
+    edge_kinds: input.edge_kinds,
+    valid_at: input.valid_at,
+    min_confidence: input.min_confidence,
+  });
+}

--- a/packages/engram-mcp/src/tools/write.ts
+++ b/packages/engram-mcp/src/tools/write.ts
@@ -1,0 +1,203 @@
+/**
+ * tools/write.ts — engram_add_episode and engram_add_edge MCP tool implementations.
+ */
+
+import {
+  addEdge,
+  addEpisode,
+  type Edge,
+  type EngramGraph,
+  type Episode,
+} from "engram-core";
+
+// ---------------------------------------------------------------------------
+// engram_add_episode
+// ---------------------------------------------------------------------------
+
+export const ADD_EPISODE_TOOL = {
+  name: "engram_add_episode",
+  description:
+    "Add a new raw evidence episode to the knowledge graph. Episodes are the immutable provenance layer backing all entities and edges.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      source_type: {
+        type: "string",
+        description:
+          "Source type (e.g. manual, git_commit, pr_comment, markdown)",
+      },
+      content: {
+        type: "string",
+        description: "Raw content of the episode",
+      },
+      source_ref: {
+        type: "string",
+        description:
+          "Unique reference for deduplication (e.g. commit SHA, PR URL)",
+      },
+      actor: {
+        type: "string",
+        description: "Who or what created this episode",
+      },
+      timestamp: {
+        type: "string",
+        description: "ISO8601 UTC timestamp for the episode (default: now)",
+      },
+      scope: {
+        type: "string",
+        description: "Scope filter (no-op in v0.1)",
+      },
+    },
+    required: ["source_type", "content"],
+  },
+};
+
+export interface AddEpisodeInput {
+  source_type: string;
+  content: string;
+  source_ref?: string;
+  actor?: string;
+  timestamp?: string;
+  scope?: string;
+}
+
+export function handleAddEpisode(
+  graph: EngramGraph,
+  input: AddEpisodeInput,
+): Episode {
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  return addEpisode(graph, {
+    source_type: input.source_type,
+    content: input.content,
+    source_ref: input.source_ref,
+    actor: input.actor,
+    timestamp,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// engram_add_edge
+// ---------------------------------------------------------------------------
+
+export const ADD_EDGE_TOOL = {
+  name: "engram_add_edge",
+  description:
+    "Add a new temporal fact (edge) between two entities, backed by evidence. Creates a supporting episode first.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      source_id: {
+        type: "string",
+        description: "ULID of the source entity",
+      },
+      target_id: {
+        type: "string",
+        description: "ULID of the target entity",
+      },
+      relation_type: {
+        type: "string",
+        description:
+          "Relationship type label (e.g. OWNS, DEPENDS_ON, AUTHORED)",
+      },
+      edge_kind: {
+        type: "string",
+        enum: ["observed", "inferred", "asserted"],
+        description:
+          "Kind of edge: observed (extracted from source), inferred (heuristic), asserted (human stated)",
+      },
+      fact: {
+        type: "string",
+        description:
+          "Human-readable statement of the fact this edge represents",
+      },
+      episode_content: {
+        type: "string",
+        description: "Content for the backing evidence episode",
+      },
+      valid_from: {
+        type: "string",
+        description: "ISO8601 UTC start of validity (null = unknown start)",
+      },
+      valid_until: {
+        type: "string",
+        description: "ISO8601 UTC end of validity (null = still current)",
+      },
+      confidence: {
+        type: "number",
+        description: "Confidence score 0.0–1.0 (default 1.0)",
+      },
+      actor: {
+        type: "string",
+        description: "Who or what asserted this fact",
+      },
+      scope: {
+        type: "string",
+        description: "Scope filter (no-op in v0.1)",
+      },
+    },
+    required: [
+      "source_id",
+      "target_id",
+      "relation_type",
+      "edge_kind",
+      "fact",
+      "episode_content",
+    ],
+  },
+};
+
+export interface AddEdgeInput {
+  source_id: string;
+  target_id: string;
+  relation_type: string;
+  edge_kind: string;
+  fact: string;
+  episode_content: string;
+  valid_from?: string;
+  valid_until?: string;
+  confidence?: number;
+  actor?: string;
+  scope?: string;
+}
+
+export interface AddEdgeResult {
+  episode: Episode;
+  edge: Edge;
+}
+
+export function handleAddEdge(
+  graph: EngramGraph,
+  input: AddEdgeInput,
+): AddEdgeResult {
+  const now = new Date().toISOString();
+
+  const episode = addEpisode(graph, {
+    source_type: "manual",
+    content: input.episode_content,
+    actor: input.actor,
+    timestamp: now,
+  });
+
+  const edge = addEdge(
+    graph,
+    {
+      source_id: input.source_id,
+      target_id: input.target_id,
+      relation_type: input.relation_type,
+      edge_kind: input.edge_kind,
+      fact: input.fact,
+      valid_from: input.valid_from,
+      valid_until: input.valid_until,
+      confidence: input.confidence,
+    },
+    [
+      {
+        episode_id: episode.id,
+        extractor: "mcp:engram_add_edge",
+        confidence: input.confidence ?? 1.0,
+      },
+    ],
+  );
+
+  return { episode, edge };
+}

--- a/packages/engram-mcp/test/mcp.test.ts
+++ b/packages/engram-mcp/test/mcp.test.ts
@@ -5,9 +5,9 @@
  * Does not test the full stdio protocol.
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { EngramGraph } from "engram-core";
-import { createGraph } from "engram-core";
+import { closeGraph, createGraph } from "engram-core";
 import { readRecentEpisodes, readStats } from "../src/resources.js";
 import { handleGetContext } from "../src/tools/context.js";
 import { handleGetDecay } from "../src/tools/decay.js";
@@ -72,6 +72,10 @@ describe("engram MCP tool handlers", () => {
 
   beforeEach(() => {
     graph = createGraph(":memory:");
+  });
+
+  afterEach(() => {
+    if (graph) closeGraph(graph);
   });
 
   // Write tools

--- a/packages/engram-mcp/test/mcp.test.ts
+++ b/packages/engram-mcp/test/mcp.test.ts
@@ -1,0 +1,309 @@
+/**
+ * mcp.test.ts — MCP tool handler tests.
+ *
+ * Tests tool handler functions directly using an in-memory SQLite graph.
+ * Does not test the full stdio protocol.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { EngramGraph } from "engram-core";
+import { createGraph } from "engram-core";
+import { readRecentEpisodes, readStats } from "../src/resources.js";
+import { handleGetContext } from "../src/tools/context.js";
+import { handleGetDecay } from "../src/tools/decay.js";
+import { handleAddEntity, handleGetEntity } from "../src/tools/entity.js";
+import { handleGetHistory } from "../src/tools/history.js";
+import { handleSearch } from "../src/tools/search.js";
+import { handleAddEdge, handleAddEpisode } from "../src/tools/write.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function seedGraph(graph: EngramGraph) {
+  // Add an episode + entity + edge for testing
+  const episodeResult = handleAddEpisode(graph, {
+    source_type: "manual",
+    content: "Alice owns the authentication module",
+    actor: "test",
+    timestamp: new Date().toISOString(),
+  });
+
+  const entityResult = handleAddEntity(graph, {
+    canonical_name: "Alice",
+    entity_type: "person",
+    summary: "Developer",
+    episode_content: "Alice is a developer on the team",
+    actor: "test",
+  });
+
+  const authResult = handleAddEntity(graph, {
+    canonical_name: "auth-module",
+    entity_type: "module",
+    summary: "Authentication module",
+    episode_content: "Auth module handles login flows",
+    actor: "test",
+  });
+
+  const edgeResult = handleAddEdge(graph, {
+    source_id: entityResult.entity.id,
+    target_id: authResult.entity.id,
+    relation_type: "OWNS",
+    edge_kind: "asserted",
+    fact: "Alice owns auth-module",
+    episode_content: "Alice owns the authentication module",
+    actor: "test",
+  });
+
+  return {
+    episode: episodeResult,
+    alice: entityResult,
+    authModule: authResult,
+    edge: edgeResult,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("engram MCP tool handlers", () => {
+  let graph: EngramGraph;
+
+  beforeEach(() => {
+    graph = createGraph(":memory:");
+  });
+
+  // Write tools
+  describe("handleAddEpisode", () => {
+    test("creates an episode and returns it", () => {
+      const result = handleAddEpisode(graph, {
+        source_type: "manual",
+        content: "Test episode content",
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(result.id).toBeTruthy();
+      expect(result.source_type).toBe("manual");
+      expect(result.content).toBe("Test episode content");
+      expect(result.status).toBe("active");
+    });
+
+    test("deduplicates episodes by source_ref", () => {
+      const first = handleAddEpisode(graph, {
+        source_type: "git_commit",
+        content: "First ingestion",
+        source_ref: "abc123",
+        timestamp: new Date().toISOString(),
+      });
+
+      const second = handleAddEpisode(graph, {
+        source_type: "git_commit",
+        content: "Duplicate ingestion",
+        source_ref: "abc123",
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(first.id).toBe(second.id);
+    });
+  });
+
+  describe("handleAddEntity", () => {
+    test("creates an episode and entity, returns both", () => {
+      const result = handleAddEntity(graph, {
+        canonical_name: "TestEntity",
+        entity_type: "module",
+        episode_content: "This is a test module",
+      });
+
+      expect(result.episode.id).toBeTruthy();
+      expect(result.entity.id).toBeTruthy();
+      expect(result.entity.canonical_name).toBe("TestEntity");
+      expect(result.entity.entity_type).toBe("module");
+    });
+  });
+
+  describe("handleAddEdge", () => {
+    test("creates an episode and edge, returns both", () => {
+      const { alice, authModule } = seedGraph(graph);
+
+      const result = handleAddEdge(graph, {
+        source_id: alice.entity.id,
+        target_id: authModule.entity.id,
+        relation_type: "REVIEWS",
+        edge_kind: "asserted",
+        fact: "Alice reviews auth-module PRs",
+        episode_content: "Alice is the primary reviewer for auth-module",
+      });
+
+      expect(result.episode.id).toBeTruthy();
+      expect(result.edge.id).toBeTruthy();
+      expect(result.edge.relation_type).toBe("REVIEWS");
+      expect(result.edge.edge_kind).toBe("asserted");
+      expect(result.edge.source_id).toBe(alice.entity.id);
+      expect(result.edge.target_id).toBe(authModule.entity.id);
+    });
+  });
+
+  // Read tools
+  describe("handleGetEntity", () => {
+    test("returns entity with edges and evidence", () => {
+      const { alice } = seedGraph(graph);
+
+      const result = handleGetEntity(graph, { entity_id: alice.entity.id });
+
+      expect(result).not.toHaveProperty("error");
+      const r = result as Exclude<typeof result, { error: string }>;
+      expect(r.entity.canonical_name).toBe("Alice");
+      expect(r.outbound_edges.length).toBeGreaterThan(0);
+      expect(r.evidence.length).toBeGreaterThan(0);
+    });
+
+    test("returns error for unknown entity", () => {
+      const result = handleGetEntity(graph, { entity_id: "NONEXISTENT" });
+      expect(result).toHaveProperty("error");
+    });
+  });
+
+  describe("handleSearch", () => {
+    test("returns results for matching query", () => {
+      seedGraph(graph);
+
+      const results = handleSearch(graph, { query: "Alice" });
+      expect(results.length).toBeGreaterThan(0);
+      // Results may be entity, edge, or episode — just check score
+      expect(results[0].score).toBeGreaterThan(0);
+      // Verify at least one entity result exists somewhere
+      const entityResults = results.filter((r) => r.type === "entity");
+      expect(entityResults.length).toBeGreaterThan(0);
+    });
+
+    test("returns empty array for no matches", () => {
+      seedGraph(graph);
+      const results = handleSearch(graph, { query: "zzznomatch999" });
+      expect(results).toEqual([]);
+    });
+
+    test("respects limit", () => {
+      seedGraph(graph);
+      const results = handleSearch(graph, { query: "Alice", limit: 1 });
+      expect(results.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe("handleGetContext", () => {
+    test("returns context with entities and edges", () => {
+      seedGraph(graph);
+
+      const result = handleGetContext(graph, { query: "Alice auth" });
+
+      expect(result).toHaveProperty("entities");
+      expect(result).toHaveProperty("edges");
+      expect(result).toHaveProperty("episodes");
+      expect(result).toHaveProperty("truncated");
+      expect(result).toHaveProperty("total_relevant");
+      expect(result).toHaveProperty("context_tokens");
+      expect(result.context_tokens).toBeGreaterThanOrEqual(0);
+    });
+
+    test("respects max_tokens budget", () => {
+      seedGraph(graph);
+
+      // Very small budget — should truncate
+      const result = handleGetContext(graph, {
+        query: "Alice",
+        max_tokens: 10,
+      });
+
+      // With only 10 tokens budget, should be truncated
+      expect(result.truncated).toBe(true);
+    });
+
+    test("returns empty context for no-match query", () => {
+      const result = handleGetContext(graph, { query: "zzznomatch999" });
+
+      expect(result.entities).toEqual([]);
+      expect(result.edges).toEqual([]);
+      expect(result.total_relevant).toBe(0);
+    });
+  });
+
+  describe("handleGetDecay", () => {
+    test("returns a decay report", () => {
+      seedGraph(graph);
+
+      const report = handleGetDecay(graph, {});
+
+      expect(report).toHaveProperty("generated_at");
+      expect(report).toHaveProperty("total_entities");
+      expect(report).toHaveProperty("total_edges");
+      expect(report).toHaveProperty("decay_items");
+      expect(report).toHaveProperty("summary");
+      expect(typeof report.total_entities).toBe("number");
+    });
+
+    test("accepts custom stale_days parameter", () => {
+      seedGraph(graph);
+      const report = handleGetDecay(graph, { stale_days: 30 });
+      expect(report).toHaveProperty("decay_items");
+    });
+  });
+
+  describe("handleGetHistory", () => {
+    test("returns edge history between two entities", () => {
+      const { alice, authModule } = seedGraph(graph);
+
+      const result = handleGetHistory(graph, {
+        source_id: alice.entity.id,
+        target_id: authModule.entity.id,
+      });
+
+      expect(result.source_id).toBe(alice.entity.id);
+      expect(result.target_id).toBe(authModule.entity.id);
+      expect(result.edges.length).toBeGreaterThan(0);
+    });
+
+    test("returns empty edges for unrelated entities", () => {
+      const { alice } = seedGraph(graph);
+
+      // Create a completely separate entity
+      const other = handleAddEntity(graph, {
+        canonical_name: "Unrelated",
+        entity_type: "module",
+        episode_content: "Unrelated module",
+      });
+
+      const result = handleGetHistory(graph, {
+        source_id: alice.entity.id,
+        target_id: other.entity.id,
+      });
+
+      expect(result.edges).toEqual([]);
+    });
+  });
+
+  // Resources
+  describe("resources", () => {
+    test("readStats returns entity/edge/episode counts", () => {
+      seedGraph(graph);
+
+      const stats = readStats(graph);
+
+      expect(stats.entities).toBeGreaterThan(0);
+      expect(stats.edges).toBeGreaterThan(0);
+      expect(stats.episodes).toBeGreaterThan(0);
+    });
+
+    test("readRecentEpisodes returns up to 10 episodes", () => {
+      seedGraph(graph);
+
+      const recent = readRecentEpisodes(graph);
+
+      expect(recent.length).toBeGreaterThan(0);
+      expect(recent.length).toBeLessThanOrEqual(10);
+      expect(recent[0]).toHaveProperty("id");
+      expect(recent[0]).toHaveProperty("source_type");
+      expect(recent[0]).toHaveProperty("content");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- MCP server via `@modelcontextprotocol/sdk` stdio transport
- 8 tools: `engram_search`, `engram_get_entity`, `engram_get_context`, `engram_get_decay`, `engram_get_history`, `engram_add_episode`, `engram_add_entity`, `engram_add_edge`
- 2 resources: `engram://stats`, `engram://recent`
- `engram_get_context` is the key tool: hybrid search → 1-hop fan-out → dedup/rank → budget-aware truncation
- DB path from `ENGRAM_DB` env var, default `.engram`

## Acceptance Criteria

- [x] MCP server via stdio transport
- [x] All 8 tools implemented
- [x] `engram_get_context` — search + traversal + budget truncation, returns `truncated` flag
- [x] `engram://stats` and `engram://recent` resources
- [x] All tools accept optional `scope` parameter (no-op in v0.1)

## Test plan

- [x] `bun test` — 241 tests pass (18 MCP tests using `:memory:` SQLite)
- [x] `bun run build` — succeeds
- [x] `bun run lint` — clean

> **Note:** Stacked on `feat/cli-commands-issue-11` (PR #26).

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)