### PR TITLE
feat: integrity verification — engram verify

### DIFF
--- a/packages/engram-core/src/format/index.ts
+++ b/packages/engram-core/src/format/index.ts
@@ -10,3 +10,5 @@ export {
   openGraph,
 } from "./graph.js";
 export { SCHEMA_DDL } from "./schema.js";
+export type { VerifyResult, Violation, ViolationSeverity } from "./verify.js";
+export { verifyGraph } from "./verify.js";

--- a/packages/engram-core/src/format/verify.ts
+++ b/packages/engram-core/src/format/verify.ts
@@ -1,0 +1,267 @@
+/**
+ * verify.ts — integrity verification for .engram graph files.
+ *
+ * verifyGraph() runs a suite of checks and returns a VerifyResult.
+ * valid = true means no error-severity violations (warnings are acceptable).
+ */
+
+import { FORMAT_VERSION } from "../index.js";
+import type { EngramGraph } from "./graph.js";
+
+export type ViolationSeverity = "error" | "warning";
+
+export interface Violation {
+  check: string;
+  entity_or_edge_id?: string;
+  message: string;
+  severity: ViolationSeverity;
+}
+
+export interface VerifyResult {
+  valid: boolean;
+  violations: Violation[];
+}
+
+const REQUIRED_METADATA_KEYS = [
+  "format_version",
+  "engine_version",
+  "created_at",
+  "owner_id",
+  "default_timezone",
+] as const;
+
+function checkMetadata(graph: EngramGraph): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const key of REQUIRED_METADATA_KEYS) {
+    const row = graph.db
+      .query<{ value: string }, [string]>(
+        "SELECT value FROM metadata WHERE key = ?",
+      )
+      .get(key);
+
+    if (!row) {
+      violations.push({
+        check: "checkMetadata",
+        message: `Required metadata key '${key}' is missing`,
+        severity: "error",
+      });
+    }
+  }
+
+  const versionRow = graph.db
+    .query<{ value: string }, [string]>(
+      "SELECT value FROM metadata WHERE key = ?",
+    )
+    .get("format_version");
+
+  if (versionRow && versionRow.value !== FORMAT_VERSION) {
+    violations.push({
+      check: "checkMetadata",
+      message: `Unrecognized format_version '${versionRow.value}' (engine supports '${FORMAT_VERSION}')`,
+      severity: "error",
+    });
+  }
+
+  return violations;
+}
+
+function checkEntityEvidence(graph: EngramGraph): Violation[] {
+  const rows = graph.db
+    .query<{ id: string }, []>(
+      `SELECT e.id FROM entities e
+       LEFT JOIN entity_evidence ev ON e.id = ev.entity_id
+       WHERE ev.entity_id IS NULL`,
+    )
+    .all();
+
+  return rows.map((row) => ({
+    check: "checkEntityEvidence",
+    entity_or_edge_id: row.id,
+    message: `Entity '${row.id}' has no evidence links`,
+    severity: "error" as ViolationSeverity,
+  }));
+}
+
+function checkEdgeEvidence(graph: EngramGraph): Violation[] {
+  const rows = graph.db
+    .query<{ id: string }, []>(
+      `SELECT e.id FROM edges e
+       LEFT JOIN edge_evidence ev ON e.id = ev.edge_id
+       WHERE ev.edge_id IS NULL`,
+    )
+    .all();
+
+  return rows.map((row) => ({
+    check: "checkEdgeEvidence",
+    entity_or_edge_id: row.id,
+    message: `Edge '${row.id}' has no evidence links`,
+    severity: "error" as ViolationSeverity,
+  }));
+}
+
+function checkSupersededByRefs(graph: EngramGraph): Violation[] {
+  const rows = graph.db
+    .query<{ id: string; superseded_by: string }, []>(
+      `SELECT e.id, e.superseded_by FROM edges e
+       LEFT JOIN edges e2 ON e.superseded_by = e2.id
+       WHERE e.superseded_by IS NOT NULL AND e2.id IS NULL`,
+    )
+    .all();
+
+  return rows.map((row) => ({
+    check: "checkSupersededByRefs",
+    entity_or_edge_id: row.id,
+    message: `Edge '${row.id}' references nonexistent superseded_by edge '${row.superseded_by}'`,
+    severity: "error" as ViolationSeverity,
+  }));
+}
+
+function checkAliasEpisodeRefs(graph: EngramGraph): Violation[] {
+  const rows = graph.db
+    .query<{ id: string; episode_id: string }, []>(
+      `SELECT a.id, a.episode_id FROM entity_aliases a
+       LEFT JOIN episodes ep ON a.episode_id = ep.id
+       WHERE a.episode_id IS NOT NULL AND ep.id IS NULL`,
+    )
+    .all();
+
+  return rows.map((row) => ({
+    check: "checkAliasEpisodeRefs",
+    entity_or_edge_id: row.id,
+    message: `Alias '${row.id}' references nonexistent episode '${row.episode_id}'`,
+    severity: "warning" as ViolationSeverity,
+  }));
+}
+
+function checkEvidenceEpisodeRefs(graph: EngramGraph): Violation[] {
+  const violations: Violation[] = [];
+
+  const entityRows = graph.db
+    .query<{ entity_id: string; episode_id: string }, []>(
+      `SELECT ev.entity_id, ev.episode_id FROM entity_evidence ev
+       LEFT JOIN episodes ep ON ev.episode_id = ep.id
+       WHERE ep.id IS NULL`,
+    )
+    .all();
+
+  for (const row of entityRows) {
+    violations.push({
+      check: "checkEvidenceEpisodeRefs",
+      entity_or_edge_id: row.entity_id,
+      message: `entity_evidence for entity '${row.entity_id}' references nonexistent episode '${row.episode_id}'`,
+      severity: "error",
+    });
+  }
+
+  const edgeRows = graph.db
+    .query<{ edge_id: string; episode_id: string }, []>(
+      `SELECT ev.edge_id, ev.episode_id FROM edge_evidence ev
+       LEFT JOIN episodes ep ON ev.episode_id = ep.id
+       WHERE ep.id IS NULL`,
+    )
+    .all();
+
+  for (const row of edgeRows) {
+    violations.push({
+      check: "checkEvidenceEpisodeRefs",
+      entity_or_edge_id: row.edge_id,
+      message: `edge_evidence for edge '${row.edge_id}' references nonexistent episode '${row.episode_id}'`,
+      severity: "error",
+    });
+  }
+
+  return violations;
+}
+
+function checkEmbeddingTargets(graph: EngramGraph): Violation[] {
+  const violations: Violation[] = [];
+
+  const entityEmbeddings = graph.db
+    .query<{ id: string; target_id: string }, []>(
+      `SELECT em.id, em.target_id FROM embeddings em
+       LEFT JOIN entities e ON em.target_id = e.id
+       WHERE em.target_type = 'entity' AND e.id IS NULL`,
+    )
+    .all();
+
+  for (const row of entityEmbeddings) {
+    violations.push({
+      check: "checkEmbeddingTargets",
+      entity_or_edge_id: row.target_id,
+      message: `Embedding '${row.id}' references nonexistent entity '${row.target_id}'`,
+      severity: "warning",
+    });
+  }
+
+  const edgeEmbeddings = graph.db
+    .query<{ id: string; target_id: string }, []>(
+      `SELECT em.id, em.target_id FROM embeddings em
+       LEFT JOIN edges e ON em.target_id = e.id
+       WHERE em.target_type = 'edge' AND e.id IS NULL`,
+    )
+    .all();
+
+  for (const row of edgeEmbeddings) {
+    violations.push({
+      check: "checkEmbeddingTargets",
+      entity_or_edge_id: row.target_id,
+      message: `Embedding '${row.id}' references nonexistent edge '${row.target_id}'`,
+      severity: "warning",
+    });
+  }
+
+  return violations;
+}
+
+function checkActiveEdgeOverlaps(graph: EngramGraph): Violation[] {
+  // Find pairs of active edges (no invalidated_at) sharing the same
+  // (source_id, target_id, relation_type, edge_kind) with overlapping validity windows.
+  // Two half-open intervals [a_from, a_until) and [b_from, b_until) overlap when:
+  //   a_from < b_until (or b_until IS NULL) AND b_from < a_until (or a_until IS NULL)
+  // We only report each pair once (a._rowid < b._rowid).
+  const rows = graph.db
+    .query<{ id_a: string; id_b: string }, []>(
+      `SELECT a.id AS id_a, b.id AS id_b
+       FROM edges a
+       JOIN edges b ON
+         a.source_id     = b.source_id AND
+         a.target_id     = b.target_id AND
+         a.relation_type = b.relation_type AND
+         a.edge_kind     = b.edge_kind AND
+         a._rowid        < b._rowid
+       WHERE
+         a.invalidated_at IS NULL AND
+         b.invalidated_at IS NULL AND
+         (a.valid_from  IS NULL OR b.valid_until IS NULL OR a.valid_from  < b.valid_until) AND
+         (b.valid_from  IS NULL OR a.valid_until IS NULL OR b.valid_from  < a.valid_until)`,
+    )
+    .all();
+
+  return rows.map((row) => ({
+    check: "checkActiveEdgeOverlaps",
+    entity_or_edge_id: row.id_a,
+    message: `Active edges '${row.id_a}' and '${row.id_b}' share the same (source, target, relation, kind) with overlapping validity windows`,
+    severity: "warning" as ViolationSeverity,
+  }));
+}
+
+/**
+ * Runs all integrity checks against the graph and returns a VerifyResult.
+ * valid is true when there are no error-severity violations.
+ */
+export function verifyGraph(graph: EngramGraph): VerifyResult {
+  const violations: Violation[] = [];
+
+  violations.push(...checkMetadata(graph));
+  violations.push(...checkEntityEvidence(graph));
+  violations.push(...checkEdgeEvidence(graph));
+  violations.push(...checkSupersededByRefs(graph));
+  violations.push(...checkAliasEpisodeRefs(graph));
+  violations.push(...checkEvidenceEpisodeRefs(graph));
+  violations.push(...checkEmbeddingTargets(graph));
+  violations.push(...checkActiveEdgeOverlaps(graph));
+
+  const valid = !violations.some((v) => v.severity === "error");
+  return { valid, violations };
+}

--- a/packages/engram-core/src/format/verify.ts
+++ b/packages/engram-core/src/format/verify.ts
@@ -5,8 +5,8 @@
  * valid = true means no error-severity violations (warnings are acceptable).
  */
 
-import { FORMAT_VERSION } from "../index.js";
 import type { EngramGraph } from "./graph.js";
+import { FORMAT_VERSION } from "./version.js";
 
 export type ViolationSeverity = "error" | "warning";
 
@@ -33,14 +33,18 @@ const REQUIRED_METADATA_KEYS = [
 function checkMetadata(graph: EngramGraph): Violation[] {
   const violations: Violation[] = [];
 
-  for (const key of REQUIRED_METADATA_KEYS) {
-    const row = graph.db
-      .query<{ value: string }, [string]>(
-        "SELECT value FROM metadata WHERE key = ?",
-      )
-      .get(key);
+  // Batch fetch all required metadata keys in a single query
+  const placeholders = REQUIRED_METADATA_KEYS.map(() => "?").join(", ");
+  const rows = graph.db
+    .query<{ key: string; value: string }, string[]>(
+      `SELECT key, value FROM metadata WHERE key IN (${placeholders})`,
+    )
+    .all(...(REQUIRED_METADATA_KEYS as unknown as string[]));
 
-    if (!row) {
+  const found = new Map(rows.map((r) => [r.key, r.value]));
+
+  for (const key of REQUIRED_METADATA_KEYS) {
+    if (!found.has(key)) {
       violations.push({
         check: "checkMetadata",
         message: `Required metadata key '${key}' is missing`,
@@ -49,16 +53,11 @@ function checkMetadata(graph: EngramGraph): Violation[] {
     }
   }
 
-  const versionRow = graph.db
-    .query<{ value: string }, [string]>(
-      "SELECT value FROM metadata WHERE key = ?",
-    )
-    .get("format_version");
-
-  if (versionRow && versionRow.value !== FORMAT_VERSION) {
+  const formatVersion = found.get("format_version");
+  if (formatVersion && formatVersion !== FORMAT_VERSION) {
     violations.push({
       check: "checkMetadata",
-      message: `Unrecognized format_version '${versionRow.value}' (engine supports '${FORMAT_VERSION}')`,
+      message: `Unrecognized format_version '${formatVersion}' (engine supports '${FORMAT_VERSION}')`,
       severity: "error",
     });
   }

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -7,13 +7,20 @@
 export const FORMAT_VERSION = "0.1.0";
 export const ENGINE_VERSION = "0.1.0";
 
-export type { CreateOpts, EngramGraph } from "./format/index.js";
+export type {
+  CreateOpts,
+  EngramGraph,
+  VerifyResult,
+  Violation,
+  ViolationSeverity,
+} from "./format/index.js";
 export {
   closeGraph,
   createGraph,
   EngramFormatError,
   openGraph,
   SCHEMA_DDL,
+  verifyGraph,
 } from "./format/index.js";
 export type {
   Alias,

--- a/packages/engram-core/test/format/verify.test.ts
+++ b/packages/engram-core/test/format/verify.test.ts
@@ -1,0 +1,486 @@
+/**
+ * verify.test.ts — integrity verification tests for verifyGraph().
+ *
+ * Each test creates deliberate violations and confirms they are detected.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ulid } from "ulid";
+import type { EngramGraph } from "../../src/index.js";
+import {
+  addEdge,
+  addEntity,
+  addEpisode,
+  closeGraph,
+  createGraph,
+  verifyGraph,
+} from "../../src/index.js";
+
+let graph: EngramGraph;
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+function makeEpisode(g: EngramGraph, ref?: string) {
+  return addEpisode(g, {
+    source_type: "manual",
+    source_ref: ref ?? ulid(),
+    content: "test episode",
+    timestamp: now(),
+  });
+}
+
+function makeEntity(g: EngramGraph, ep: { id: string }) {
+  return addEntity(
+    g,
+    {
+      canonical_name: `Entity-${ulid()}`,
+      entity_type: "person",
+    },
+    [{ episode_id: ep.id, extractor: "test", confidence: 1 }],
+  );
+}
+
+function makeEdge(
+  g: EngramGraph,
+  sourceId: string,
+  targetId: string,
+  ep: { id: string },
+) {
+  return addEdge(
+    g,
+    {
+      source_id: sourceId,
+      target_id: targetId,
+      relation_type: "knows",
+      edge_kind: "observed",
+      fact: "test fact",
+    },
+    [{ episode_id: ep.id, extractor: "test", confidence: 1 }],
+  );
+}
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ---------------------------------------------------------------------------
+// Clean graph
+// ---------------------------------------------------------------------------
+
+describe("clean graph", () => {
+  test("empty graph is valid (no violations)", () => {
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  test("graph with entities, edges, and evidence is valid", () => {
+    const ep = makeEpisode(graph);
+    const a = makeEntity(graph, ep);
+    const b = makeEntity(graph, ep);
+    makeEdge(graph, a.id, b.id, ep);
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkMetadata
+// ---------------------------------------------------------------------------
+
+describe("checkMetadata", () => {
+  test("missing required metadata key produces error violation", () => {
+    graph.db.run("DELETE FROM metadata WHERE key = 'owner_id'");
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+    const v = result.violations.find(
+      (x) => x.check === "checkMetadata" && x.message.includes("owner_id"),
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+
+  test("unrecognized format_version produces error violation", () => {
+    graph.db.run(
+      "UPDATE metadata SET value = '99.0.0' WHERE key = 'format_version'",
+    );
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+    const v = result.violations.find(
+      (x) => x.check === "checkMetadata" && x.message.includes("99.0.0"),
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+
+  test("all required keys present with correct version is clean", () => {
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkMetadata",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkEntityEvidence
+// ---------------------------------------------------------------------------
+
+describe("checkEntityEvidence", () => {
+  test("entity with no evidence rows produces error violation", () => {
+    const ep = makeEpisode(graph);
+    const entity = makeEntity(graph, ep);
+
+    // Remove evidence manually
+    graph.db.run("DELETE FROM entity_evidence WHERE entity_id = ?", [
+      entity.id,
+    ]);
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkEntityEvidence" && x.entity_or_edge_id === entity.id,
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+
+  test("entity with evidence produces no violation", () => {
+    const ep = makeEpisode(graph);
+    makeEntity(graph, ep);
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkEntityEvidence",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkEdgeEvidence
+// ---------------------------------------------------------------------------
+
+describe("checkEdgeEvidence", () => {
+  test("edge with no evidence rows produces error violation", () => {
+    const ep = makeEpisode(graph);
+    const a = makeEntity(graph, ep);
+    const b = makeEntity(graph, ep);
+    const edge = makeEdge(graph, a.id, b.id, ep);
+
+    graph.db.run("DELETE FROM edge_evidence WHERE edge_id = ?", [edge.id]);
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+    const v = result.violations.find(
+      (x) => x.check === "checkEdgeEvidence" && x.entity_or_edge_id === edge.id,
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkSupersededByRefs
+// ---------------------------------------------------------------------------
+
+describe("checkSupersededByRefs", () => {
+  test("edge with dangling superseded_by produces error", () => {
+    const ep = makeEpisode(graph);
+    const a = makeEntity(graph, ep);
+    const b = makeEntity(graph, ep);
+    const edge = makeEdge(graph, a.id, b.id, ep);
+
+    // Temporarily disable FK checks to create a dangling reference
+    graph.db.run("PRAGMA foreign_keys = OFF");
+    graph.db.run("UPDATE edges SET superseded_by = ? WHERE id = ?", [
+      "nonexistent-edge-id",
+      edge.id,
+    ]);
+    graph.db.run("PRAGMA foreign_keys = ON");
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkSupersededByRefs" && x.entity_or_edge_id === edge.id,
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+
+  test("valid superseded_by ref produces no violation", () => {
+    const ep = makeEpisode(graph);
+    const a = makeEntity(graph, ep);
+    const b = makeEntity(graph, ep);
+    const edge1 = makeEdge(graph, a.id, b.id, ep);
+    const edge2 = makeEdge(graph, a.id, b.id, ep);
+
+    graph.db.run("UPDATE edges SET superseded_by = ? WHERE id = ?", [
+      edge2.id,
+      edge1.id,
+    ]);
+
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkSupersededByRefs",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkAliasEpisodeRefs
+// ---------------------------------------------------------------------------
+
+describe("checkAliasEpisodeRefs", () => {
+  test("alias with dangling episode_id produces warning", () => {
+    const ep = makeEpisode(graph);
+    const entity = makeEntity(graph, ep);
+
+    // Insert alias with broken episode ref directly (FK off to allow dangling ref)
+    const aliasId = ulid();
+    graph.db.run("PRAGMA foreign_keys = OFF");
+    graph.db.run(
+      "INSERT INTO entity_aliases (id, entity_id, alias, episode_id, created_at) VALUES (?, ?, ?, ?, ?)",
+      [aliasId, entity.id, "BadAlias", "nonexistent-ep", now()],
+    );
+    graph.db.run("PRAGMA foreign_keys = ON");
+
+    const result = verifyGraph(graph);
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkAliasEpisodeRefs" && x.entity_or_edge_id === aliasId,
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("warning");
+    // Warning only — should still be valid
+    const errors = result.violations.filter((x) => x.severity === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  test("alias with null episode_id produces no violation", () => {
+    const ep = makeEpisode(graph);
+    const entity = makeEntity(graph, ep);
+
+    graph.db.run(
+      "INSERT INTO entity_aliases (id, entity_id, alias, episode_id, created_at) VALUES (?, ?, ?, NULL, ?)",
+      [ulid(), entity.id, "NullAlias", now()],
+    );
+
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkAliasEpisodeRefs",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkEvidenceEpisodeRefs
+// ---------------------------------------------------------------------------
+
+describe("checkEvidenceEpisodeRefs", () => {
+  test("entity_evidence with dangling episode_id produces error", () => {
+    const ep = makeEpisode(graph);
+    const entity = makeEntity(graph, ep);
+
+    // Update evidence to point at nonexistent episode (FK off to allow dangling ref)
+    graph.db.run("PRAGMA foreign_keys = OFF");
+    graph.db.run(
+      "UPDATE entity_evidence SET episode_id = ? WHERE entity_id = ?",
+      ["ghost-episode", entity.id],
+    );
+    graph.db.run("PRAGMA foreign_keys = ON");
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkEvidenceEpisodeRefs" &&
+        x.entity_or_edge_id === entity.id,
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+
+  test("edge_evidence with dangling episode_id produces error", () => {
+    const ep = makeEpisode(graph);
+    const a = makeEntity(graph, ep);
+    const b = makeEntity(graph, ep);
+    const edge = makeEdge(graph, a.id, b.id, ep);
+
+    // Update evidence to point at nonexistent episode (FK off to allow dangling ref)
+    graph.db.run("PRAGMA foreign_keys = OFF");
+    graph.db.run("UPDATE edge_evidence SET episode_id = ? WHERE edge_id = ?", [
+      "ghost-episode",
+      edge.id,
+    ]);
+    graph.db.run("PRAGMA foreign_keys = ON");
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkEvidenceEpisodeRefs" &&
+        x.entity_or_edge_id === edge.id,
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkEmbeddingTargets
+// ---------------------------------------------------------------------------
+
+describe("checkEmbeddingTargets", () => {
+  test("embedding pointing at nonexistent entity produces warning", () => {
+    const embId = ulid();
+    graph.db.run(
+      "INSERT INTO embeddings (id, target_type, target_id, model, dimensions, vector, source_text, created_at) VALUES (?, 'entity', ?, 'test-model', 4, ?, 'text', ?)",
+      [embId, "ghost-entity", new Uint8Array(16), now()],
+    );
+
+    const result = verifyGraph(graph);
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkEmbeddingTargets" &&
+        x.entity_or_edge_id === "ghost-entity",
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("warning");
+  });
+
+  test("embedding pointing at nonexistent edge produces warning", () => {
+    const embId = ulid();
+    graph.db.run(
+      "INSERT INTO embeddings (id, target_type, target_id, model, dimensions, vector, source_text, created_at) VALUES (?, 'edge', ?, 'test-model', 4, ?, 'text', ?)",
+      [embId, "ghost-edge", new Uint8Array(16), now()],
+    );
+
+    const result = verifyGraph(graph);
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkEmbeddingTargets" &&
+        x.entity_or_edge_id === "ghost-edge",
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("warning");
+  });
+
+  test("valid embedding produces no violation", () => {
+    const ep = makeEpisode(graph);
+    const entity = makeEntity(graph, ep);
+
+    graph.db.run(
+      "INSERT INTO embeddings (id, target_type, target_id, model, dimensions, vector, source_text, created_at) VALUES (?, 'entity', ?, 'test-model', 4, ?, 'text', ?)",
+      [ulid(), entity.id, new Uint8Array(16), now()],
+    );
+
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkEmbeddingTargets",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkActiveEdgeOverlaps
+// ---------------------------------------------------------------------------
+
+describe("checkActiveEdgeOverlaps", () => {
+  test("two active edges with same (source, target, relation, kind) and overlapping windows produce warning", () => {
+    const ep = makeEpisode(graph);
+    const a = makeEntity(graph, ep);
+    const b = makeEntity(graph, ep);
+    const _edge1 = makeEdge(graph, a.id, b.id, ep);
+    const _edge2 = makeEdge(graph, a.id, b.id, ep);
+
+    // Both have NULL valid_from and valid_until → they fully overlap
+    const result = verifyGraph(graph);
+    const v = result.violations.find(
+      (x) => x.check === "checkActiveEdgeOverlaps",
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("warning");
+  });
+
+  test("invalidated edge is excluded from overlap check", () => {
+    const ep = makeEpisode(graph);
+    const a = makeEntity(graph, ep);
+    const b = makeEntity(graph, ep);
+    const edge1 = makeEdge(graph, a.id, b.id, ep);
+    makeEdge(graph, a.id, b.id, ep);
+
+    // Invalidate edge1 — should remove it from overlap candidates
+    graph.db.run("UPDATE edges SET invalidated_at = ? WHERE id = ?", [
+      now(),
+      edge1.id,
+    ]);
+
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkActiveEdgeOverlaps",
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  test("non-overlapping windows produce no violation", () => {
+    const ep = makeEpisode(graph);
+    const a = makeEntity(graph, ep);
+    const b = makeEntity(graph, ep);
+    const edge1 = makeEdge(graph, a.id, b.id, ep);
+    const edge2 = makeEdge(graph, a.id, b.id, ep);
+
+    // Set non-overlapping windows: [2020, 2021) and [2022, 2023)
+    graph.db.run(
+      "UPDATE edges SET valid_from = '2020-01-01T00:00:00Z', valid_until = '2021-01-01T00:00:00Z' WHERE id = ?",
+      [edge1.id],
+    );
+    graph.db.run(
+      "UPDATE edges SET valid_from = '2022-01-01T00:00:00Z', valid_until = '2023-01-01T00:00:00Z' WHERE id = ?",
+      [edge2.id],
+    );
+
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkActiveEdgeOverlaps",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// VerifyResult.valid semantics
+// ---------------------------------------------------------------------------
+
+describe("VerifyResult.valid", () => {
+  test("warnings alone do not make the graph invalid", () => {
+    const ep = makeEpisode(graph);
+    const _entity = makeEntity(graph, ep);
+
+    // Insert an embedding with a nonexistent entity (warning)
+    graph.db.run(
+      "INSERT INTO embeddings (id, target_type, target_id, model, dimensions, vector, source_text, created_at) VALUES (?, 'entity', ?, 'test-model', 4, ?, 'text', ?)",
+      [ulid(), "ghost-entity", new Uint8Array(16), now()],
+    );
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(true);
+    expect(result.violations.some((v) => v.severity === "warning")).toBe(true);
+  });
+
+  test("a single error-severity violation makes valid = false", () => {
+    const ep = makeEpisode(graph);
+    const entity = makeEntity(graph, ep);
+    graph.db.run("DELETE FROM entity_evidence WHERE entity_id = ?", [
+      entity.id,
+    ]);
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `verifyGraph(graph)` — 8 checks, returns `VerifyResult` with `valid` flag and `Violation[]`
- Error checks: missing metadata, entities/edges without evidence, broken `superseded_by` refs, dangling evidence episode refs
- Warning checks: alias episode refs, embedding target refs, active edge overlaps
- `valid = true` means no error-severity violations (warnings are acceptable)
- Enables the CLI's `engram verify` (exit 0 if clean, 2 if violations)

## Acceptance Criteria

- [x] `verifyGraph` returns `VerifyResult { valid, violations }`
- [x] All 8 checks implemented (5 error, 3 warning)
- [x] SQL LEFT JOIN approach for efficiency
- [x] Tests with deliberate violations confirm detection

## Test plan

- [x] `bun test` — 263 tests pass
- [x] `bun run build` — succeeds
- [x] `bun run lint` — clean

> **Note:** Stacked on `feat/mcp-server-issue-12` (PR #27).

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)