### PR TITLE
fix: add pull-requests:read permission to commitlint CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/internal/STATUS.md
+++ b/docs/internal/STATUS.md
@@ -1,0 +1,57 @@
+# Engram — Status
+
+> Last synced: 2026-04-07
+
+## Phase 1 — Foundation (v0.1)
+
+### Done
+
+- [x] `.engram` file format — SQLite schema, metadata, FTS5, migrations (#15)
+- [x] Graph CRUD — entities, edges, episodes, evidence chains (#17)
+- [x] Temporal engine — validity windows, supersession, fact history (#18)
+- [x] Entity resolution — exact-match canonical name + alias lookup (#19)
+- [x] Git VCS ingestion — commits, blame, co-change, ownership inference (#20)
+- [x] GitHub enrichment adapter — PRs, issues, `reviewed_by` / `references` edges (#21)
+- [x] Full-text search — FTS5 across entities/edges/episodes, composite scoring (#23)
+- [x] Graph traversal — BFS neighbors, shortest path, temporal snapshots (#24)
+- [x] Knowledge decay detection — stale, contradicted, concentrated risk, dormant, orphaned (#25)
+- [x] CLI — full command surface: init, add, search, show, history, decay, stats, ingest, export, verify (#26)
+- [x] MCP server — stdio transport, 8 tools, 2 resources, context tool with budget-aware truncation (#27)
+- [x] Integrity verification — `verifyGraph()` with 8 checks, `engram verify` CLI command (#28)
+- [x] EngRAMark v0.1 — 20 ground-truth Q&A for Fastify, VCS-only + grep baselines (#29)
+- [x] Markdown and text ingestion (#30)
+
+### In Progress
+
+- [ ] AI provider integration — pluggable embeddings + entity extraction (#31, specced at `docs/internal/specs/ai-providers.md`)
+  - `AIProvider` interface, `NullProvider`, `OllamaProvider`, `GeminiProvider`
+  - `storeEmbedding()`, `findSimilar()`, hybrid search integration
+  - Unblocked — all Phase 1 dependencies shipped
+
+### Next Up
+
+- [ ] EngRAMark AI benchmarking extension (#32, specced at `docs/internal/specs/engramark-ai-benchmarking.md`)
+  - `ai-enhanced` runner, `--all` comparison mode, CI baseline regression detection
+  - **Blocked by**: #31
+
+### Bugs
+
+- [ ] commitlint CI action needs `pull-requests: read` permission (#16)
+
+## Phase 2 — Growth (v0.2+)
+
+Not started. Phase 1 completion (AI provider layer) is the gate.
+
+Planned per VISION.md:
+- Team/tribal knowledge merging
+- EngRAMark against Kubernetes
+- Enrichment adapters: Gerrit, Jira, Linear, GitLab
+- Non-git ingestors (Slack, Confluence)
+- Community detection and topic clustering
+- Rich TUI and graph visualization
+
+## Architecture Stats
+
+- **Test count**: ~293 (as of EngRAMark merge)
+- **Packages**: 4 (engram-core, engram-cli, engram-mcp, engramark)
+- **Specs**: 3 (format-v0.1, ai-providers, engramark-ai-benchmarking)


### PR DESCRIPTION
## Summary

- Adds `pull-requests: read` permission to the `commitlint` job in CI workflow
- Fixes `wagoid/commitlint-github-action@v6` failing with "Resource not accessible by integration" on PRs

## Test plan

- [ ] Open a PR and verify the commitlint check passes instead of erroring on permissions

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)