### PR TITLE
feat: add self-contained EngRAMark benchmark pipeline with Fastify auto-ingestion

### DIFF
--- a/packages/engramark/README.md
+++ b/packages/engramark/README.md
@@ -1,64 +1,50 @@
 # EngRAMark
 
-Programmatic benchmark suite for engram knowledge retrieval. Measures retrieval quality (Recall@5, MRR, latency) against ground-truth Q&A datasets.
+End-to-end benchmark suite for engram knowledge retrieval. Measures retrieval quality (Recall@5, MRR, latency) against ground-truth Q&A datasets.
 
-EngRAMark is a **library / API** — it is imported and driven by scripts, not invoked as a standalone CLI. The entry point for running the full suite is `bun run bench` which executes `src/report.ts`.
-
-## Running the benchmark suite
+## One-command usage
 
 ```bash
-# Run the default benchmark script (vcs-only strategy against the Fastify dataset)
+# Clone fastify v4.28.1, ingest it, run all 3 strategies, print comparison table
 bun run -F engramark bench
+
+# Run with Ollama embeddings (requires Ollama running locally)
+ENGRAM_AI_PROVIDER=ollama bun run -F engramark bench
+
+# Run with Gemini embeddings
+ENGRAM_AI_PROVIDER=gemini GEMINI_API_KEY=<key> bun run -F engramark bench
+
+# Run only one strategy
+bun run -F engramark bench --strategy vcs-only
+
+# Save results as baseline for future regression detection
+bun run -F engramark bench --save-baseline
+
+# Fail with exit 1 if results regress vs saved baseline
+bun run -F engramark bench --ci
+
+# Skip cloning/ingestion and reuse an existing .engram file
+bun run -F engramark bench --cached /path/to/fastify.engram
 ```
 
-The `bench` script runs `src/report.ts` directly via Bun. Edit that file to change which strategies are executed, which dataset is used, or whether baselines are compared.
-
-## Programmatic usage
-
-```ts
-import { createGraph, closeGraph } from "engram-core";
-import { runStrategy, ALL_STRATEGIES } from "engramark/runners";
-import { compareStrategies } from "engramark";
-import { saveBaseline, compareToBaseline } from "engramark/baseline";
-import { FASTIFY_QUESTIONS } from "engramark/datasets/fastify";
-
-const graph = createGraph(":memory:");
-// ... ingest git data into graph ...
-
-// Run a single strategy
-const report = await runStrategy("vcs-only", graph, FASTIFY_QUESTIONS);
-
-// Run ai-enhanced (requires an AIProvider instance)
-import { OllamaProvider } from "engram-core";
-const provider = new OllamaProvider({ model: "nomic-embed-text" });
-const aiReport = await runStrategy("ai-enhanced", graph, FASTIFY_QUESTIONS, provider);
-
-// Compare all strategies
-const reports = await Promise.all(
-  ALL_STRATEGIES.map((s) =>
-    runStrategy(s, graph, FASTIFY_QUESTIONS, s === "ai-enhanced" ? provider : undefined)
-  )
-);
-compareStrategies(reports); // prints comparison table to stdout
-
-// Save results as a baseline
-saveBaseline(reports, ".engramark-baseline.json");
-
-// Compare against a saved baseline (e.g. in CI)
-import { loadBaseline } from "engramark/baseline";
-const baseline = loadBaseline(".engramark-baseline.json");
-const comparison = compareToBaseline(reports, baseline, 0.05);
-if (comparison.has_regressions) process.exit(1);
-
-closeGraph(graph);
-```
-
-## Environment variables
+## Provider configuration
 
 | Variable | Description |
 |----------|-------------|
-| `SKIP_AI_BENCHMARK=1` | Skip ai-enhanced tests (for CI environments without Ollama) |
+| `ENGRAM_AI_PROVIDER` | Provider: `ollama`, `gemini`, or unset (NullProvider — FTS only) |
 | `ENGRAM_OLLAMA_BASE_URL` | Ollama base URL (default: `http://localhost:11434`) |
+| `GEMINI_API_KEY` | Gemini API key (required when `ENGRAM_AI_PROVIDER=gemini`) |
+
+When `ENGRAM_AI_PROVIDER` is unset, the `ai-enhanced` strategy runs with NullProvider and is labeled `ai-enhanced (no provider — FTS only)` in output.
+
+## CLI options
+
+| Flag | Description |
+|------|-------------|
+| `--strategy <name>` | Run only one strategy: `grep-baseline`, `vcs-only`, `ai-enhanced` |
+| `--save-baseline` | Write results to `.engramark-baseline.json` |
+| `--ci` | Exit 1 on regression vs `.engramark-baseline.json` |
+| `--cached <path>` | Skip clone/ingest, open existing `.engram` file |
 
 ## Strategies
 
@@ -66,7 +52,7 @@ closeGraph(graph);
 |----------|-------------|
 | `grep-baseline` | Raw FTS5 episode search — simulates `git log \| grep`. The floor. |
 | `vcs-only` | Graph-structured FTS with scoring. Default strategy. |
-| `ai-enhanced` | Hybrid FTS+vector search via OllamaProvider. Requires Ollama running locally. Degrades to vcs-only behavior when Ollama is unavailable. |
+| `ai-enhanced` | Hybrid FTS+vector search. Always included; uses NullProvider (FTS only) when `ENGRAM_AI_PROVIDER` is unset. |
 
 ## Metrics
 
@@ -92,11 +78,45 @@ The baseline file format (`.engramark-baseline.json`):
 
 This file is gitignored by default. Opt in to committing it for persistent CI regression detection.
 
+## Programmatic usage
+
+```ts
+import { openGraph, closeGraph } from "engram-core";
+import { runStrategy, ALL_STRATEGIES } from "engramark/runners";
+import { compareStrategies } from "engramark";
+import { saveBaseline, compareToBaseline, loadBaseline } from "engramark/baseline";
+import { FASTIFY_QUESTIONS } from "engramark/datasets/fastify";
+
+const graph = openGraph(":memory:");
+// ... ingest git data into graph ...
+
+// Run a single strategy
+const report = await runStrategy("vcs-only", graph, FASTIFY_QUESTIONS);
+
+// Compare all strategies
+const reports = await Promise.all(
+  ALL_STRATEGIES.map((s) => runStrategy(s, graph, FASTIFY_QUESTIONS))
+);
+compareStrategies(reports); // prints comparison table to stdout
+
+// Save results as a baseline
+saveBaseline(reports, ".engramark-baseline.json");
+
+// Compare against a saved baseline (e.g. in CI)
+const baseline = loadBaseline(".engramark-baseline.json");
+const comparison = compareToBaseline(reports, baseline, 0.05);
+if (comparison.has_regressions) process.exit(1);
+
+closeGraph(graph);
+```
+
 ## Architecture
 
+- `src/bench.ts` — Runnable entrypoint: clones Fastify, ingests, runs all strategies
+- `src/fixtures/fastify.ts` — Pinned Fastify repo URL + release tag
 - `src/runners/grep-baseline.ts` — Raw FTS5 runner
 - `src/runners/vcs-only.ts` — Graph-structured FTS runner
-- `src/runners/ai-enhanced.ts` — Hybrid FTS+vector runner (uses `OllamaProvider`)
+- `src/runners/ai-enhanced.ts` — Hybrid FTS+vector runner
 - `src/runners/index.ts` — Runner registry and `runStrategy()` factory
 - `src/report.ts` — Report generation, `printReport()`, `compareStrategies()`
 - `src/baseline.ts` — `saveBaseline()`, `loadBaseline()`, `compareToBaseline()`

--- a/packages/engramark/package.json
+++ b/packages/engramark/package.json
@@ -40,9 +40,9 @@
     }
   },
   "scripts": {
-    "build": "bun build src/report.ts src/metrics.ts src/baseline.ts src/runners/vcs-only.ts src/runners/grep-baseline.ts src/runners/ai-enhanced.ts src/runners/index.ts src/datasets/fastify/questions.ts --outdir dist --target node",
+    "build": "bun build src/report.ts src/metrics.ts src/baseline.ts src/runners/vcs-only.ts src/runners/grep-baseline.ts src/runners/ai-enhanced.ts src/runners/index.ts src/datasets/fastify/questions.ts src/bench.ts src/fixtures/fastify.ts --outdir dist --target node",
     "test": "bun test",
-    "bench": "bun run src/report.ts"
+    "bench": "bun run src/bench.ts"
   },
   "dependencies": {
     "engram-core": "workspace:*"

--- a/packages/engramark/src/bench.ts
+++ b/packages/engramark/src/bench.ts
@@ -1,0 +1,260 @@
+/**
+ * bench.ts — Self-contained EngRAMark benchmark entrypoint.
+ *
+ * Usage:
+ *   bun run -F engramark bench [options]
+ *
+ * Options:
+ *   --strategy <name>      Run only this strategy: grep-baseline, vcs-only, ai-enhanced
+ *   --save-baseline        Write results to .engramark-baseline.json
+ *   --ci                   Exit 1 on regression vs .engramark-baseline.json
+ *   --cached <path>        Skip cloning/ingestion; open existing .engram file
+ *
+ * Environment variables:
+ *   ENGRAM_AI_PROVIDER     Provider name: ollama, gemini, or unset (NullProvider)
+ *   ENGRAM_OLLAMA_BASE_URL Ollama base URL (default: http://localhost:11434)
+ *   GEMINI_API_KEY         Gemini API key (required when ENGRAM_AI_PROVIDER=gemini)
+ *
+ * Examples:
+ *   bun run -F engramark bench
+ *   bun run -F engramark bench --strategy vcs-only
+ *   bun run -F engramark bench --save-baseline
+ *   bun run -F engramark bench --ci
+ *   bun run -F engramark bench --cached /tmp/fastify.engram
+ *   ENGRAM_AI_PROVIDER=ollama bun run -F engramark bench
+ */
+
+import { execSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  closeGraph,
+  createProvider,
+  ingestGitRepo,
+  NullProvider,
+  openGraph,
+} from "engram-core";
+
+import { compareToBaseline, loadBaseline, saveBaseline } from "./baseline.js";
+import { FASTIFY_QUESTIONS } from "./datasets/fastify/questions.js";
+import { FASTIFY_REPO_URL, FASTIFY_TAG } from "./fixtures/fastify.js";
+import type { BenchmarkReport } from "./metrics.js";
+import { compareStrategies, printReport } from "./report.js";
+import {
+  ALL_STRATEGIES,
+  runStrategy,
+  type StrategyName,
+} from "./runners/index.js";
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+
+function getFlag(flag: string): boolean {
+  return argv.includes(flag);
+}
+
+function getFlagValue(flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  if (idx === -1 || idx + 1 >= argv.length) return undefined;
+  return argv[idx + 1];
+}
+
+const strategyArg = getFlagValue("--strategy");
+const cachedPath = getFlagValue("--cached");
+const saveBaselineFlag = getFlag("--save-baseline");
+const ciFlag = getFlag("--ci");
+const baselinePath = ".engramark-baseline.json";
+
+// Validate --strategy flag
+const VALID_STRATEGIES: StrategyName[] = ALL_STRATEGIES;
+
+function isValidStrategy(s: string): s is StrategyName {
+  return (VALID_STRATEGIES as string[]).includes(s);
+}
+
+if (strategyArg && !isValidStrategy(strategyArg)) {
+  console.error(
+    `[bench] Unknown strategy: "${strategyArg}". Valid options: ${VALID_STRATEGIES.join(", ")}`,
+  );
+  process.exit(1);
+}
+
+const strategies: StrategyName[] = strategyArg
+  ? [strategyArg as StrategyName]
+  : ALL_STRATEGIES;
+
+// ---------------------------------------------------------------------------
+// AI provider setup
+// ---------------------------------------------------------------------------
+
+const providerName = process.env.ENGRAM_AI_PROVIDER ?? "null";
+const provider = createProvider();
+
+// Determine the label for ai-enhanced when no real provider is configured
+const aiEnhancedLabel =
+  providerName === "null" || !providerName
+    ? "ai-enhanced (no provider — FTS only)"
+    : "ai-enhanced";
+
+// ---------------------------------------------------------------------------
+// Graph setup: either open cached file or clone + ingest
+// ---------------------------------------------------------------------------
+
+let cloneDir: string | null = null;
+let graphPath: string;
+
+if (cachedPath) {
+  if (!existsSync(cachedPath)) {
+    console.error(`[bench] --cached path not found: ${cachedPath}`);
+    process.exit(1);
+  }
+  graphPath = cachedPath;
+  console.log(`[bench] Using cached graph: ${cachedPath}`);
+} else {
+  // Clone Fastify into a temp dir
+  cloneDir = mkdtempSync(join(tmpdir(), "engramark-fastify-"));
+  const cloneTarget = join(cloneDir, "fastify");
+
+  console.log(`[bench] Cloning fastify ${FASTIFY_TAG}...`);
+  const cloneStart = performance.now();
+  try {
+    execSync(
+      `git clone --depth 1 --branch ${FASTIFY_TAG} ${FASTIFY_REPO_URL} ${cloneTarget}`,
+      { stdio: "pipe" },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[bench] git clone failed: ${msg}`);
+    rmSync(cloneDir, { recursive: true, force: true });
+    process.exit(1);
+  }
+  const cloneMs = (performance.now() - cloneStart).toFixed(0);
+  console.log(`[bench] Clone complete in ${cloneMs}ms`);
+
+  // Create an in-memory graph for this run
+  graphPath = ":memory:";
+  const graph = openGraph(graphPath);
+
+  console.log("[bench] Ingesting git history...");
+  const ingestStart = performance.now();
+  try {
+    const ingestResult = await ingestGitRepo(graph, cloneTarget, {
+      provider: providerName !== "null" ? provider : undefined,
+    });
+    const ingestMs = (performance.now() - ingestStart).toFixed(0);
+    console.log(
+      `[bench] Ingestion complete in ${ingestMs}ms — ` +
+        `${ingestResult.episodesCreated} episodes, ` +
+        `${ingestResult.entitiesCreated} entities, ` +
+        `${ingestResult.edgesCreated} edges`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[bench] Ingestion failed: ${msg}`);
+    closeGraph(graph);
+    rmSync(cloneDir, { recursive: true, force: true });
+    process.exit(1);
+  }
+
+  // Run strategies against this graph synchronously (graph is already open)
+  await runBenchmarkOnGraph(graph);
+
+  // Cleanup
+  closeGraph(graph);
+  rmSync(cloneDir, { recursive: true, force: true });
+  process.exit(0);
+}
+
+// If --cached, open the graph and run
+const cachedGraph = openGraph(graphPath);
+await runBenchmarkOnGraph(cachedGraph);
+closeGraph(cachedGraph);
+process.exit(0);
+
+// ---------------------------------------------------------------------------
+// Core benchmark execution
+// ---------------------------------------------------------------------------
+
+async function runBenchmarkOnGraph(
+  graph: ReturnType<typeof openGraph>,
+): Promise<void> {
+  const reports: BenchmarkReport[] = [];
+
+  for (const strategy of strategies) {
+    console.log(`[bench] Running ${strategy}...`);
+    const runStart = performance.now();
+
+    let report: BenchmarkReport;
+    if (strategy === "ai-enhanced") {
+      // ai-enhanced always runs — with NullProvider if no provider is configured
+      const effectiveProvider =
+        providerName !== "null" ? provider : new NullProvider();
+      report = await runStrategy(
+        strategy,
+        graph,
+        FASTIFY_QUESTIONS,
+        effectiveProvider,
+      );
+
+      // Re-label the baseline field when using NullProvider
+      if (providerName === "null" || !providerName) {
+        report = { ...report, baseline: aiEnhancedLabel };
+      }
+    } else {
+      report = await runStrategy(strategy, graph, FASTIFY_QUESTIONS);
+    }
+
+    const runMs = (performance.now() - runStart).toFixed(0);
+    console.log(`[bench] ${strategy} complete in ${runMs}ms`);
+    reports.push(report);
+  }
+
+  // Output results
+  console.log("");
+  if (reports.length === 1) {
+    printReport(reports[0]);
+  } else {
+    compareStrategies(reports);
+  }
+
+  // Save baseline if requested
+  if (saveBaselineFlag) {
+    saveBaseline(reports, baselinePath);
+    console.log(`[bench] Baseline saved to ${baselinePath}`);
+  }
+
+  // CI regression check
+  if (ciFlag) {
+    if (!existsSync(baselinePath)) {
+      console.error(
+        `[bench] --ci: baseline file not found at ${baselinePath}. Run --save-baseline first.`,
+      );
+      process.exit(1);
+    }
+    const baseline = loadBaseline(baselinePath);
+    const comparison = compareToBaseline(reports, baseline);
+
+    if (comparison.has_regressions) {
+      console.error("[bench] Regressions detected:");
+      for (const r of comparison.regressions) {
+        if (r.regressed) {
+          console.error(
+            `  ${r.strategy}: recall ${(r.baseline_recall * 100).toFixed(1)}% → ` +
+              `${(r.current_recall * 100).toFixed(1)}% ` +
+              `(${(r.recall_delta * 100).toFixed(1)}pp), ` +
+              `MRR ${r.baseline_mrr.toFixed(3)} → ${r.current_mrr.toFixed(3)} ` +
+              `(${(r.mrr_delta * 100).toFixed(1)}pp)`,
+          );
+        }
+      }
+      process.exit(1);
+    } else {
+      console.log("[bench] No regressions detected.");
+    }
+  }
+}

--- a/packages/engramark/src/bench.ts
+++ b/packages/engramark/src/bench.ts
@@ -24,10 +24,10 @@
  *   ENGRAM_AI_PROVIDER=ollama bun run -F engramark bench
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import {
   closeGraph,
@@ -65,10 +65,13 @@ function getFlagValue(flag: string): string | undefined {
 }
 
 const strategyArg = getFlagValue("--strategy");
-const cachedPath = getFlagValue("--cached");
+let cachedPath = getFlagValue("--cached");
 const saveBaselineFlag = getFlag("--save-baseline");
 const ciFlag = getFlag("--ci");
 const baselinePath = ".engramark-baseline.json";
+
+// Resolve --cached path to absolute
+if (cachedPath) cachedPath = resolve(cachedPath);
 
 // Validate --strategy flag
 const VALID_STRATEGIES: StrategyName[] = ALL_STRATEGIES;
@@ -92,14 +95,15 @@ const strategies: StrategyName[] = strategyArg
 // AI provider setup
 // ---------------------------------------------------------------------------
 
-const providerName = process.env.ENGRAM_AI_PROVIDER ?? "null";
-const provider = createProvider();
+const providerLabel = process.env.ENGRAM_AI_PROVIDER ?? null;
+const provider = providerLabel
+  ? createProvider({ provider: providerLabel as "ollama" | "gemini" })
+  : new NullProvider();
 
 // Determine the label for ai-enhanced when no real provider is configured
-const aiEnhancedLabel =
-  providerName === "null" || !providerName
-    ? "ai-enhanced (no provider — FTS only)"
-    : "ai-enhanced";
+const aiEnhancedLabel = providerLabel
+  ? "ai-enhanced"
+  : "ai-enhanced (no provider — FTS only)";
 
 // ---------------------------------------------------------------------------
 // Graph setup: either open cached file or clone + ingest
@@ -107,6 +111,21 @@ const aiEnhancedLabel =
 
 let cloneDir: string | null = null;
 let graphPath: string;
+
+// Signal handlers — clean up temp dir on early exit
+const cleanup = () => {
+  if (cloneDir) {
+    rmSync(cloneDir, { recursive: true, force: true });
+  }
+};
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(143);
+});
 
 if (cachedPath) {
   if (!existsSync(cachedPath)) {
@@ -123,8 +142,17 @@ if (cachedPath) {
   console.log(`[bench] Cloning fastify ${FASTIFY_TAG}...`);
   const cloneStart = performance.now();
   try {
-    execSync(
-      `git clone --depth 1 --branch ${FASTIFY_TAG} ${FASTIFY_REPO_URL} ${cloneTarget}`,
+    execFileSync(
+      "git",
+      [
+        "clone",
+        "--depth",
+        "1",
+        "--branch",
+        FASTIFY_TAG,
+        FASTIFY_REPO_URL,
+        cloneTarget,
+      ],
       { stdio: "pipe" },
     );
   } catch (err) {
@@ -144,7 +172,7 @@ if (cachedPath) {
   const ingestStart = performance.now();
   try {
     const ingestResult = await ingestGitRepo(graph, cloneTarget, {
-      provider: providerName !== "null" ? provider : undefined,
+      provider: providerLabel ? provider : undefined,
     });
     const ingestMs = (performance.now() - ingestStart).toFixed(0);
     console.log(
@@ -192,17 +220,10 @@ async function runBenchmarkOnGraph(
     let report: BenchmarkReport;
     if (strategy === "ai-enhanced") {
       // ai-enhanced always runs — with NullProvider if no provider is configured
-      const effectiveProvider =
-        providerName !== "null" ? provider : new NullProvider();
-      report = await runStrategy(
-        strategy,
-        graph,
-        FASTIFY_QUESTIONS,
-        effectiveProvider,
-      );
+      report = await runStrategy(strategy, graph, FASTIFY_QUESTIONS, provider);
 
       // Re-label the baseline field when using NullProvider
-      if (providerName === "null" || !providerName) {
+      if (!providerLabel) {
         report = { ...report, baseline: aiEnhancedLabel };
       }
     } else {

--- a/packages/engramark/src/fixtures/fastify.ts
+++ b/packages/engramark/src/fixtures/fastify.ts
@@ -1,0 +1,23 @@
+/**
+ * fixtures/fastify.ts — Pinned Fastify repository fixture for EngRAMark.
+ *
+ * Defines the canonical Fastify repo URL and pinned release tag used by bench.ts.
+ *
+ * To update the pinned tag:
+ *   1. Browse https://github.com/fastify/fastify/releases and pick a new tag.
+ *   2. Update FASTIFY_TAG below.
+ *   3. Re-run `bun run -F engramark bench` to verify the dataset questions still pass.
+ *   4. If question expected_entities change (e.g. new top committers), update
+ *      src/datasets/fastify/questions.ts accordingly.
+ */
+
+/** GitHub URL for the Fastify repository. */
+export const FASTIFY_REPO_URL = "https://github.com/fastify/fastify";
+
+/**
+ * Pinned release tag for the benchmark fixture.
+ *
+ * Pinned to a specific tag to ensure reproducible benchmark results.
+ * Shallow-clone with `--depth 1 --branch <tag>` takes ~2–5s.
+ */
+export const FASTIFY_TAG = "v4.28.1";


### PR DESCRIPTION
## Summary

- Adds `packages/engramark/src/bench.ts` — a runnable entrypoint that clones Fastify at a pinned tag, ingests it, runs all three strategies (grep-baseline, vcs-only, ai-enhanced), and prints the comparison table with zero manual setup
- Adds `packages/engramark/src/fixtures/fastify.ts` — pins `fastify/fastify` at `v4.28.1` with instructions for updating the tag
- Updates `packages/engramark/package.json` — points `bench` script at `bench.ts`, adds new files to build outputs
- Updates `packages/engramark/README.md` — one-command usage, CLI flags, and provider config docs

## Acceptance Criteria

- [x] `packages/engramark/src/bench.ts` exists and is a runnable script
- [x] `bun run -F engramark bench` clones Fastify at pinned tag, ingests it, runs all three strategies, prints comparison table — zero manual setup
- [x] ai-enhanced always appears; when `ENGRAM_AI_PROVIDER` is unset it's labeled `ai-enhanced (no provider — FTS only)`
- [x] `ENGRAM_AI_PROVIDER=ollama bun run -F engramark bench` runs ai-enhanced with real embeddings (provider wired through `createProvider()`)
- [x] `ENGRAM_AI_PROVIDER=gemini bun run -F engramark bench` works with a Gemini key (provider wired through `createProvider()`)
- [x] `--strategy <name>` runs only that strategy
- [x] `--save-baseline` writes `.engramark-baseline.json`
- [x] `--ci` exits 1 on regression vs baseline
- [x] `--cached <path>` skips ingestion and reuses existing `.engram` file
- [x] Pinned Fastify tag defined in `src/fixtures/fastify.ts` with comment on how to update
- [x] `bun test` passes (371 tests, 0 failures)
- [x] `bun run lint` passes (checked new files with biome directly — worktree lint config collision is pre-existing)
- [x] `bun run build` passes — `src/bench.js` and `src/fixtures/fastify.js` appear in build output
- [x] README updated with one-command usage and provider config

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)