### PR TITLE
feat(viz): foundation — engram-web package, HTTP server, visualize CLI

### DIFF
--- a/packages/engram-cli/package.json
+++ b/packages/engram-cli/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "engram-core": "workspace:*",
+    "@engram/engram-web": "workspace:*",
     "commander": "^13.0.0",
     "@clack/prompts": "^0.9.0"
   }

--- a/packages/engram-cli/src/cli.ts
+++ b/packages/engram-cli/src/cli.ts
@@ -13,6 +13,7 @@ import { registerSearch } from "./commands/search.js";
 import { registerShow } from "./commands/show.js";
 import { registerStats } from "./commands/stats.js";
 import { registerVerify } from "./commands/verify.js";
+import { registerVisualize } from "./commands/visualize.js";
 
 const program = new Command()
   .name("engram")
@@ -32,5 +33,6 @@ registerIngest(program);
 registerExport(program);
 registerVerify(program);
 registerMaintenance(program);
+registerVisualize(program);
 
 program.parse();

--- a/packages/engram-cli/src/commands/visualize.ts
+++ b/packages/engram-cli/src/commands/visualize.ts
@@ -1,0 +1,64 @@
+/**
+ * visualize.ts — `engram visualize` command.
+ *
+ * Starts the engram-web HTTP server, prints the URL, and waits for SIGINT.
+ */
+
+import * as path from "node:path";
+import { startServer } from "@engram/engram-web";
+import type { Command } from "commander";
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
+interface VisualizeOpts {
+  db: string;
+  port: string;
+  host: string;
+  readOnly: boolean;
+}
+
+export function registerVisualize(program: Command): void {
+  program
+    .command("visualize")
+    .description("Start a local HTTP server to visualize the knowledge graph")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .option("--port <n>", "HTTP port", "7878")
+    .option("--host <addr>", "bind address", "127.0.0.1")
+    .option("--read-only", "read-only mode (default; reserved for v1)", true)
+    .action((opts: VisualizeOpts) => {
+      const dbPath = path.resolve(opts.db);
+      const port = Number.parseInt(opts.port, 10);
+      const host = opts.host;
+
+      if (!LOOPBACK_HOSTS.has(host)) {
+        console.warn(
+          `\nWARNING: Serving on a non-loopback address. Anyone on the network can access your knowledge graph.\n`,
+        );
+      }
+
+      let handle: ReturnType<typeof startServer> | undefined;
+      try {
+        handle = startServer({ dbPath, port, host });
+      } catch (err) {
+        console.error(
+          `Error starting server: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      console.log(`engram visualize: http://${host}:${port}`);
+      console.log("  (press Ctrl+C to stop)");
+
+      function shutdown() {
+        if (handle) {
+          handle.stop();
+        }
+        process.exit(0);
+      }
+
+      process.on("SIGINT", shutdown);
+      process.on("SIGTERM", shutdown);
+
+      // Block until signal
+    });
+}

--- a/packages/engram-web/package.json
+++ b/packages/engram-web/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@engram/engram-web",
+  "version": "0.1.0",
+  "module": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "build": "bun build src/index.ts --outdir dist --target node",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "engram-core": "workspace:*"
+  }
+}

--- a/packages/engram-web/src/api/graph.ts
+++ b/packages/engram-web/src/api/graph.ts
@@ -1,0 +1,74 @@
+/**
+ * graph.ts — GET /api/graph handler.
+ *
+ * Returns nodes (entities) and edges for the active graph,
+ * optionally filtered to those valid at a given ISO8601 timestamp.
+ */
+
+import type { EngramGraph } from "engram-core";
+import { findEdges, findEntities } from "engram-core";
+
+export interface GraphNode {
+  id: string;
+  canonical_name: string;
+  entity_type: string;
+  status: string;
+  updated_at: string;
+}
+
+export interface GraphEdge {
+  id: string;
+  source_id: string;
+  target_id: string;
+  relation_type: string;
+  edge_kind: string;
+  confidence: number;
+  valid_from: string | null;
+  valid_until: string | null;
+}
+
+export interface GraphResponse {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  stats: {
+    entity_count: number;
+    edge_count: number;
+  };
+}
+
+export function handleGraph(
+  graph: EngramGraph,
+  validAt?: string,
+): GraphResponse {
+  const entities = findEntities(graph);
+  const edgeQuery = validAt ? { valid_at: validAt } : {};
+  const edges = findEdges(graph, edgeQuery);
+
+  const nodes: GraphNode[] = entities.map((e) => ({
+    id: e.id,
+    canonical_name: e.canonical_name,
+    entity_type: e.entity_type,
+    status: e.status,
+    updated_at: e.updated_at,
+  }));
+
+  const graphEdges: GraphEdge[] = edges.map((e) => ({
+    id: e.id,
+    source_id: e.source_id,
+    target_id: e.target_id,
+    relation_type: e.relation_type,
+    edge_kind: e.edge_kind,
+    confidence: e.confidence,
+    valid_from: e.valid_from,
+    valid_until: e.valid_until,
+  }));
+
+  return {
+    nodes,
+    edges: graphEdges,
+    stats: {
+      entity_count: nodes.length,
+      edge_count: graphEdges.length,
+    },
+  };
+}

--- a/packages/engram-web/src/api/stats.ts
+++ b/packages/engram-web/src/api/stats.ts
@@ -1,0 +1,37 @@
+/**
+ * stats.ts — GET /api/stats handler.
+ *
+ * Returns entity_count, edge_count, episode_count from the graph.
+ */
+
+import type { EngramGraph } from "engram-core";
+
+export interface StatsResponse {
+  entity_count: number;
+  edge_count: number;
+  episode_count: number;
+}
+
+export function handleStats(graph: EngramGraph): StatsResponse {
+  const entity_count = (
+    graph.db
+      .query<{ count: number }, []>("SELECT COUNT(*) as count FROM entities")
+      .get() ?? { count: 0 }
+  ).count;
+
+  const edge_count = (
+    graph.db
+      .query<{ count: number }, []>(
+        "SELECT COUNT(*) as count FROM edges WHERE invalidated_at IS NULL",
+      )
+      .get() ?? { count: 0 }
+  ).count;
+
+  const episode_count = (
+    graph.db
+      .query<{ count: number }, []>("SELECT COUNT(*) as count FROM episodes")
+      .get() ?? { count: 0 }
+  ).count;
+
+  return { entity_count, edge_count, episode_count };
+}

--- a/packages/engram-web/src/api/temporal.ts
+++ b/packages/engram-web/src/api/temporal.ts
@@ -1,0 +1,35 @@
+/**
+ * temporal.ts — GET /api/temporal-bounds handler.
+ *
+ * Returns the min valid_from and max valid_until across all active edges,
+ * used to calibrate the time slider in the UI.
+ */
+
+import type { EngramGraph } from "engram-core";
+
+export interface TemporalBoundsResponse {
+  min_valid_from: string | null;
+  max_valid_until: string | null;
+}
+
+export function handleTemporalBounds(
+  graph: EngramGraph,
+): TemporalBoundsResponse {
+  const row = graph.db
+    .query<
+      { min_valid_from: string | null; max_valid_until: string | null },
+      []
+    >(
+      `SELECT
+         MIN(valid_from) as min_valid_from,
+         MAX(valid_until) as max_valid_until
+       FROM edges
+       WHERE invalidated_at IS NULL`,
+    )
+    .get();
+
+  return {
+    min_valid_from: row?.min_valid_from ?? null,
+    max_valid_until: row?.max_valid_until ?? null,
+  };
+}

--- a/packages/engram-web/src/index.ts
+++ b/packages/engram-web/src/index.ts
@@ -1,0 +1,53 @@
+/**
+ * index.ts — public API for engram-web.
+ *
+ * Exports startServer(opts) for use by the CLI.
+ */
+
+import type { EngramGraph } from "engram-core";
+import { closeGraph, openGraph } from "engram-core";
+import { createHandler } from "./server.js";
+
+export interface ServerOpts {
+  dbPath: string;
+  port?: number;
+  host?: string;
+}
+
+export interface ServerHandle {
+  graph: EngramGraph;
+  server: ReturnType<typeof Bun.serve>;
+  stop: () => void;
+}
+
+/**
+ * Starts the engram-web HTTP server.
+ *
+ * Opens the .engram database at dbPath, binds on host:port (defaults: 127.0.0.1:7878),
+ * and returns a handle with a stop() function to close cleanly.
+ */
+export function startServer(opts: ServerOpts): ServerHandle {
+  const port = opts.port ?? 7878;
+  const host = opts.host ?? "127.0.0.1";
+
+  const graph = openGraph(opts.dbPath);
+  const handler = createHandler(graph);
+
+  const server = Bun.serve({
+    port,
+    hostname: host,
+    fetch: handler,
+  });
+
+  function stop() {
+    server.stop();
+    closeGraph(graph);
+  }
+
+  return { graph, server, stop };
+}
+
+export { handleGraph } from "./api/graph.js";
+export { handleStats } from "./api/stats.js";
+export { handleTemporalBounds } from "./api/temporal.js";
+export { createHandler } from "./server.js";

--- a/packages/engram-web/src/server.ts
+++ b/packages/engram-web/src/server.ts
@@ -1,0 +1,104 @@
+/**
+ * server.ts — Bun.serve() HTTP server for engram-web.
+ *
+ * Routes:
+ *   GET /              → dist/ui/index.html
+ *   GET /assets/*      → dist/ui/assets/*
+ *   GET /api/stats     → StatsResponse
+ *   GET /api/graph     → GraphResponse (optional ?valid_at=ISO8601)
+ *   GET /api/temporal-bounds → TemporalBoundsResponse
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { EngramGraph } from "engram-core";
+import { handleGraph } from "./api/graph.js";
+import { handleStats } from "./api/stats.js";
+import { handleTemporalBounds } from "./api/temporal.js";
+
+const DIST_UI_DIR = path.resolve(import.meta.dir, "..", "dist", "ui");
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function serveStatic(requestPath: string): Response {
+  // Resolve path and ensure it stays within dist/ui/
+  const resolved = path.resolve(DIST_UI_DIR, requestPath.replace(/^\//, ""));
+  if (
+    !resolved.startsWith(DIST_UI_DIR + path.sep) &&
+    resolved !== DIST_UI_DIR
+  ) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  if (!fs.existsSync(resolved)) {
+    return new Response("Not Found", { status: 404 });
+  }
+
+  const file = Bun.file(resolved);
+  return new Response(file);
+}
+
+export function createHandler(graph: EngramGraph) {
+  return (req: Request): Response => {
+    const url = new URL(req.url);
+    const pathname = url.pathname;
+
+    // API routes
+    if (pathname === "/api/stats") {
+      try {
+        return json(handleStats(graph));
+      } catch (err) {
+        return json(
+          { error: err instanceof Error ? err.message : String(err) },
+          500,
+        );
+      }
+    }
+
+    if (pathname === "/api/graph") {
+      try {
+        const validAt = url.searchParams.get("valid_at") ?? undefined;
+        return json(handleGraph(graph, validAt));
+      } catch (err) {
+        return json(
+          { error: err instanceof Error ? err.message : String(err) },
+          500,
+        );
+      }
+    }
+
+    if (pathname === "/api/temporal-bounds") {
+      try {
+        return json(handleTemporalBounds(graph));
+      } catch (err) {
+        return json(
+          { error: err instanceof Error ? err.message : String(err) },
+          500,
+        );
+      }
+    }
+
+    // Static asset serving
+    if (pathname === "/") {
+      const indexPath = path.join(DIST_UI_DIR, "index.html");
+      if (!fs.existsSync(indexPath)) {
+        return new Response(
+          "UI not built. Run `bun run build` in packages/engram-web.",
+          { status: 503, headers: { "Content-Type": "text/plain" } },
+        );
+      }
+      return new Response(Bun.file(indexPath));
+    }
+
+    if (pathname.startsWith("/assets/")) {
+      return serveStatic(pathname);
+    }
+
+    return new Response("Not Found", { status: 404 });
+  };
+}

--- a/packages/engram-web/test/server.test.ts
+++ b/packages/engram-web/test/server.test.ts
@@ -1,0 +1,186 @@
+/**
+ * server.test.ts — unit tests for the engram-web API handlers.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EngramGraph } from "engram-core";
+import {
+  addEdge,
+  addEntity,
+  addEpisode,
+  closeGraph,
+  createGraph,
+} from "engram-core";
+import { handleGraph } from "../src/api/graph.js";
+import { handleStats } from "../src/api/stats.js";
+import { handleTemporalBounds } from "../src/api/temporal.js";
+
+let graph: EngramGraph;
+
+function addTestData(g: EngramGraph) {
+  const ep = addEpisode(g, {
+    source_type: "manual",
+    source_ref: "test-001",
+    content: "Test episode",
+    timestamp: "2024-01-01T00:00:00Z",
+  });
+
+  const evidence = [{ episode_id: ep.id, extractor: "test" }];
+
+  const entityA = addEntity(
+    g,
+    { canonical_name: "EntityA", entity_type: "module" },
+    evidence,
+  );
+  const entityB = addEntity(
+    g,
+    { canonical_name: "EntityB", entity_type: "module" },
+    evidence,
+  );
+
+  addEdge(
+    g,
+    {
+      source_id: entityA.id,
+      target_id: entityB.id,
+      relation_type: "depends_on",
+      edge_kind: "observed",
+      fact: "EntityA depends on EntityB",
+      valid_from: "2024-01-01T00:00:00Z",
+      valid_until: "2024-06-01T00:00:00Z",
+    },
+    evidence,
+  );
+
+  addEdge(
+    g,
+    {
+      source_id: entityB.id,
+      target_id: entityA.id,
+      relation_type: "owned_by",
+      edge_kind: "inferred",
+      fact: "EntityB owned by EntityA",
+      valid_from: "2024-03-01T00:00:00Z",
+    },
+    evidence,
+  );
+
+  return { ep, entityA, entityB };
+}
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ---------------------------------------------------------------------------
+// handleStats
+// ---------------------------------------------------------------------------
+
+describe("handleStats", () => {
+  test("returns zero counts on empty graph", () => {
+    const stats = handleStats(graph);
+    expect(stats.entity_count).toBe(0);
+    expect(stats.edge_count).toBe(0);
+    expect(stats.episode_count).toBe(0);
+  });
+
+  test("returns correct counts after adding data", () => {
+    addTestData(graph);
+    const stats = handleStats(graph);
+    expect(stats.entity_count).toBe(2);
+    expect(stats.edge_count).toBe(2);
+    expect(stats.episode_count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleGraph
+// ---------------------------------------------------------------------------
+
+describe("handleGraph", () => {
+  test("returns empty nodes and edges on empty graph", () => {
+    const result = handleGraph(graph);
+    expect(result.nodes).toHaveLength(0);
+    expect(result.edges).toHaveLength(0);
+    expect(result.stats.entity_count).toBe(0);
+    expect(result.stats.edge_count).toBe(0);
+  });
+
+  test("returns all active nodes and edges", () => {
+    addTestData(graph);
+    const result = handleGraph(graph);
+    expect(result.nodes).toHaveLength(2);
+    expect(result.edges).toHaveLength(2);
+    expect(result.stats.entity_count).toBe(2);
+    expect(result.stats.edge_count).toBe(2);
+  });
+
+  test("node shape includes required fields", () => {
+    addTestData(graph);
+    const result = handleGraph(graph);
+    const node = result.nodes[0];
+    expect(node).toHaveProperty("id");
+    expect(node).toHaveProperty("canonical_name");
+    expect(node).toHaveProperty("entity_type");
+    expect(node).toHaveProperty("status");
+    expect(node).toHaveProperty("updated_at");
+  });
+
+  test("edge shape includes required fields", () => {
+    addTestData(graph);
+    const result = handleGraph(graph);
+    const edge = result.edges[0];
+    expect(edge).toHaveProperty("id");
+    expect(edge).toHaveProperty("source_id");
+    expect(edge).toHaveProperty("target_id");
+    expect(edge).toHaveProperty("relation_type");
+    expect(edge).toHaveProperty("edge_kind");
+    expect(edge).toHaveProperty("confidence");
+    expect(edge).toHaveProperty("valid_from");
+    expect(edge).toHaveProperty("valid_until");
+  });
+
+  test("filters edges by valid_at", () => {
+    addTestData(graph);
+    // First edge is valid 2024-01-01 to 2024-06-01
+    // Second edge is valid from 2024-03-01 (no end)
+    // At 2024-02-01: only first edge is valid
+    const result = handleGraph(graph, "2024-02-01T00:00:00Z");
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].relation_type).toBe("depends_on");
+  });
+
+  test("valid_at=after all edges returns only open-ended edges", () => {
+    addTestData(graph);
+    // After 2024-06-01: first edge expired, second is still open
+    const result = handleGraph(graph, "2024-07-01T00:00:00Z");
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].relation_type).toBe("owned_by");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleTemporalBounds
+// ---------------------------------------------------------------------------
+
+describe("handleTemporalBounds", () => {
+  test("returns nulls on empty graph", () => {
+    const bounds = handleTemporalBounds(graph);
+    expect(bounds.min_valid_from).toBeNull();
+    expect(bounds.max_valid_until).toBeNull();
+  });
+
+  test("returns correct bounds after adding edges", () => {
+    addTestData(graph);
+    const bounds = handleTemporalBounds(graph);
+    // min_valid_from should be 2024-01-01
+    expect(bounds.min_valid_from).toBe("2024-01-01T00:00:00Z");
+    // max_valid_until: one edge has null (open-ended), one has 2024-06-01
+    // MAX(null, '2024-06-01') in SQLite returns '2024-06-01' because NULL < any value
+    expect(bounds.max_valid_until).toBe("2024-06-01T00:00:00Z");
+  });
+});

--- a/packages/engram-web/tsconfig.json
+++ b/packages/engram-web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/engram-web/ui/index.html
+++ b/packages/engram-web/ui/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>engram — knowledge graph</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+        background: #0d1117;
+        color: #c9d1d9;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        gap: 1rem;
+      }
+      h1 { font-size: 1.5rem; font-weight: 600; color: #58a6ff; }
+      #status { font-size: 1rem; color: #8b949e; }
+      #stats { font-size: 1.25rem; color: #c9d1d9; }
+      .error { color: #f85149; }
+    </style>
+  </head>
+  <body>
+    <h1>engram</h1>
+    <div id="stats">Loading...</div>
+    <div id="status">rendering coming soon</div>
+    <script>
+      async function loadStats() {
+        try {
+          const res = await fetch('/api/stats');
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          const data = await res.json();
+          document.getElementById('stats').textContent =
+            `engram — ${data.entity_count} entities, ${data.edge_count} edges — rendering coming soon`;
+        } catch (err) {
+          document.getElementById('stats').className = 'error';
+          document.getElementById('stats').textContent = 'Error loading stats: ' + err.message;
+        }
+      }
+      loadStats();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- New `packages/engram-web` package with `Bun.serve()` HTTP server exposing `GET /api/stats`, `GET /api/graph?valid_at=ISO8601`, and `GET /api/temporal-bounds`
- Static asset serving from `dist/ui/` with path-traversal protection
- `startServer(opts)` exported for use by CLI (port 7878, host 127.0.0.1 defaults)
- New `engram visualize` CLI command with `--db`, `--port`, `--host`, `--read-only` flags; prints non-loopback warning banner when bound outside loopback
- Placeholder `index.html` that fetches `/api/stats` and displays entity/edge counts
- 10 unit tests covering all three API handlers including `valid_at` temporal filtering

Closes #47

## Acceptance Criteria

- [x] `engram visualize --db <path>` starts a server — `startServer()` opens the graph, calls `Bun.serve()`, and prints `engram visualize: http://{host}:{port}`
- [x] Default host is `127.0.0.1`; `--host 0.0.0.0` works and prints the warning banner
- [x] `GET /api/stats` returns `{ entity_count, edge_count, episode_count }` — verified by tests
- [x] `GET /api/graph?valid_at=ISO8601` returns nodes + edges filtered to the given timestamp — verified by temporal filter tests
- [x] `GET /api/temporal-bounds` returns `{ min_valid_from, max_valid_until }` — verified by tests
- [x] Static asset serving with path-traversal protection (resolves paths, checks prefix)
- [x] `GET /` serves `dist/ui/index.html`; 503 if not yet built
- [x] Placeholder UI fetches `/api/stats` on load and displays counts
- [x] All HTTP endpoints are read-only (no mutation surface)
- [x] All tests pass (`bun test` — 439 pass, 0 fail)
- [x] `bun run build` succeeds for all packages including `@engram/engram-web`
- [x] New package lints clean (`biome check .` — no errors)

## Test plan

- [x] `bun test` — 439 pass, 0 fail (10 new tests in `packages/engram-web/test/server.test.ts`)
- [x] `bun run build` — all packages bundled successfully
- [x] `bun run lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)