### PR TITLE
feat(format): schema migration v0.1 → v0.2 — projection layer tables

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,13 @@
   "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "files": {
-    "includes": ["**/*.ts", "**/*.json", "!**/dist", "!**/node_modules"]
+    "includes": [
+      "**/*.ts",
+      "**/*.json",
+      "!**/dist",
+      "!**/node_modules",
+      "!.claude/worktrees"
+    ]
   },
   "linter": {
     "enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "files": {
     "includes": [

--- a/packages/engram-core/src/format/graph.ts
+++ b/packages/engram-core/src/format/graph.ts
@@ -9,7 +9,11 @@
 import { Database } from "bun:sqlite";
 import { ulid } from "ulid";
 import { SCHEMA_DDL } from "./schema.js";
-import { ENGINE_VERSION, FORMAT_VERSION } from "./version.js";
+import {
+  ENGINE_VERSION,
+  FORMAT_VERSION,
+  MIN_READABLE_VERSION,
+} from "./version.js";
 
 export interface EngramGraph {
   db: Database;
@@ -30,6 +34,31 @@ export class EngramFormatError extends Error {
     super(message);
     this.name = "EngramFormatError";
   }
+}
+
+/**
+ * Compares two semver strings. Returns negative if a < b, 0 if equal, positive if a > b.
+ * Only handles simple MAJOR.MINOR.PATCH format.
+ */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Returns true if the given format version can be opened by this engine.
+ * The readable range is [MIN_READABLE_VERSION, FORMAT_VERSION].
+ */
+function isVersionReadable(version: string): boolean {
+  return (
+    compareSemver(version, MIN_READABLE_VERSION) >= 0 &&
+    compareSemver(version, FORMAT_VERSION) <= 0
+  );
 }
 
 function applyPragmas(db: Database): void {
@@ -115,10 +144,11 @@ export function openGraph(path: string): EngramGraph {
     );
   }
 
-  if (formatVersion !== FORMAT_VERSION) {
+  // Accept any version between MIN_READABLE_VERSION and FORMAT_VERSION (inclusive).
+  if (!isVersionReadable(formatVersion)) {
     db.close();
     throw new EngramFormatError(
-      `openGraph: unsupported format_version '${formatVersion}' (expected '${FORMAT_VERSION}'): ${path}`,
+      `openGraph: unsupported format_version '${formatVersion}' (readable range: ${MIN_READABLE_VERSION}–${FORMAT_VERSION}): ${path}`,
     );
   }
 

--- a/packages/engram-core/src/format/index.ts
+++ b/packages/engram-core/src/format/index.ts
@@ -9,6 +9,7 @@ export {
   EngramFormatError,
   openGraph,
 } from "./graph.js";
+export { migrate_0_1_0_to_0_2_0 } from "./migrations.js";
 export { SCHEMA_DDL } from "./schema.js";
 export type { VerifyResult, Violation, ViolationSeverity } from "./verify.js";
 export { verifyGraph } from "./verify.js";

--- a/packages/engram-core/src/format/migrations.ts
+++ b/packages/engram-core/src/format/migrations.ts
@@ -1,0 +1,53 @@
+/**
+ * migrations.ts — schema migration steps for the .engram format.
+ *
+ * Each migration function accepts a Database, applies the DDL for the new
+ * version, and updates schema_version (stored as 'format_version' in metadata).
+ */
+
+import type { Database } from "bun:sqlite";
+import {
+  CREATE_PROJECTION_EVIDENCE,
+  CREATE_PROJECTION_EVIDENCE_INDEXES,
+  CREATE_PROJECTIONS,
+  CREATE_PROJECTIONS_FTS,
+  CREATE_PROJECTIONS_FTS_TRIGGERS,
+  CREATE_PROJECTIONS_INDEXES,
+  CREATE_RECONCILIATION_RUNS,
+} from "./schema.js";
+
+/**
+ * Migrates a v0.1.0 database to v0.2.0.
+ *
+ * This migration is purely additive: it appends the projection-layer tables,
+ * indexes, FTS virtual table, and triggers. No existing tables are altered and
+ * no data is backfilled.
+ *
+ * DDL application order matches the spec (format-v0.2.md § DDL application order):
+ *  1. CREATE TABLE projections
+ *  2. Five projections indexes (including partial unique)
+ *  3. CREATE TABLE projection_evidence
+ *  4. idx_projection_evidence_target index
+ *  5. CREATE TABLE reconciliation_runs
+ *  6. CREATE VIRTUAL TABLE projections_fts
+ *  7. CREATE TRIGGER projections_ai / ad / au
+ *  8. UPDATE metadata schema_version to '0.2.0'
+ */
+export function migrate_0_1_0_to_0_2_0(db: Database): void {
+  const steps = [
+    CREATE_PROJECTIONS,
+    CREATE_PROJECTIONS_INDEXES,
+    CREATE_PROJECTION_EVIDENCE,
+    CREATE_PROJECTION_EVIDENCE_INDEXES,
+    CREATE_RECONCILIATION_RUNS,
+    CREATE_PROJECTIONS_FTS,
+    CREATE_PROJECTIONS_FTS_TRIGGERS,
+  ];
+
+  db.transaction(() => {
+    for (const ddl of steps) {
+      db.exec(ddl);
+    }
+    db.run("UPDATE metadata SET value = '0.2.0' WHERE key = 'format_version'");
+  })();
+}

--- a/packages/engram-core/src/format/migrations.ts
+++ b/packages/engram-core/src/format/migrations.ts
@@ -34,6 +34,15 @@ import {
  *  8. UPDATE metadata schema_version to '0.2.0'
  */
 export function migrate_0_1_0_to_0_2_0(db: Database): void {
+  const current = db
+    .query<{ value: string }, []>(
+      "SELECT value FROM metadata WHERE key = 'format_version'",
+    )
+    .get();
+  if (current?.value === "0.2.0") {
+    return; // already at target version, no-op
+  }
+
   const steps = [
     CREATE_PROJECTIONS,
     CREATE_PROJECTIONS_INDEXES,

--- a/packages/engram-core/src/format/schema.ts
+++ b/packages/engram-core/src/format/schema.ts
@@ -1,6 +1,6 @@
 /**
  * DDL SQL constants for the .engram file format (SQLite schema).
- * Schema version: 0.1.0
+ * Schema version: 0.2.0
  */
 
 export const CREATE_METADATA = `
@@ -209,6 +209,95 @@ CREATE TRIGGER episodes_au AFTER UPDATE ON episodes BEGIN
 END;
 `;
 
+// ─── v0.2 additions: projection layer ────────────────────────────────────────
+
+export const CREATE_PROJECTIONS = `
+CREATE TABLE projections (
+  _rowid             INTEGER PRIMARY KEY,
+  id                 TEXT NOT NULL UNIQUE,
+  kind               TEXT NOT NULL,
+  anchor_type        TEXT NOT NULL,
+  anchor_id          TEXT,
+  title              TEXT NOT NULL,
+  body               TEXT NOT NULL,
+  body_format        TEXT NOT NULL DEFAULT 'markdown',
+  model              TEXT NOT NULL,
+  prompt_template_id TEXT,
+  prompt_hash        TEXT,
+  input_fingerprint  TEXT NOT NULL,
+  confidence         REAL NOT NULL DEFAULT 1.0,
+  valid_from         TEXT NOT NULL,
+  valid_until        TEXT,
+  last_assessed_at   TEXT,
+  invalidated_at     TEXT,
+  superseded_by      TEXT REFERENCES projections(id),
+  created_at         TEXT NOT NULL,
+  owner_id           TEXT
+);
+`;
+
+export const CREATE_PROJECTIONS_INDEXES = `
+CREATE INDEX idx_projections_anchor ON projections(anchor_type, anchor_id);
+CREATE INDEX idx_projections_kind   ON projections(kind);
+CREATE INDEX idx_projections_valid  ON projections(valid_from, valid_until);
+CREATE INDEX idx_projections_active ON projections(invalidated_at) WHERE invalidated_at IS NULL;
+CREATE UNIQUE INDEX idx_projections_active_unique
+  ON projections(anchor_type, anchor_id, kind)
+  WHERE invalidated_at IS NULL;
+`;
+
+export const CREATE_PROJECTION_EVIDENCE = `
+CREATE TABLE projection_evidence (
+  projection_id TEXT NOT NULL REFERENCES projections(id),
+  target_type   TEXT NOT NULL,
+  target_id     TEXT NOT NULL,
+  role          TEXT NOT NULL DEFAULT 'input',
+  content_hash  TEXT,
+  PRIMARY KEY (projection_id, target_type, target_id, role)
+);
+`;
+
+export const CREATE_PROJECTION_EVIDENCE_INDEXES = `
+CREATE INDEX idx_projection_evidence_target ON projection_evidence(target_type, target_id);
+`;
+
+export const CREATE_RECONCILIATION_RUNS = `
+CREATE TABLE reconciliation_runs (
+  id                     TEXT PRIMARY KEY,
+  started_at             TEXT NOT NULL,
+  completed_at           TEXT,
+  scope                  TEXT,
+  phases                 TEXT NOT NULL DEFAULT 'assess,discover',
+  projections_checked    INTEGER DEFAULT 0,
+  projections_refreshed  INTEGER DEFAULT 0,
+  projections_superseded INTEGER DEFAULT 0,
+  projections_discovered INTEGER DEFAULT 0,
+  dry_run                INTEGER NOT NULL DEFAULT 0,
+  status                 TEXT NOT NULL DEFAULT 'running',
+  error                  TEXT
+);
+`;
+
+export const CREATE_PROJECTIONS_FTS = `
+CREATE VIRTUAL TABLE projections_fts USING fts5(
+  title, body,
+  content=projections, content_rowid=_rowid
+);
+`;
+
+export const CREATE_PROJECTIONS_FTS_TRIGGERS = `
+CREATE TRIGGER projections_ai AFTER INSERT ON projections BEGIN
+  INSERT INTO projections_fts(rowid, title, body) VALUES (new._rowid, new.title, new.body);
+END;
+CREATE TRIGGER projections_ad AFTER DELETE ON projections BEGIN
+  INSERT INTO projections_fts(projections_fts, rowid, title, body) VALUES ('delete', old._rowid, old.title, old.body);
+END;
+CREATE TRIGGER projections_au AFTER UPDATE ON projections BEGIN
+  INSERT INTO projections_fts(projections_fts, rowid, title, body) VALUES ('delete', old._rowid, old.title, old.body);
+  INSERT INTO projections_fts(rowid, title, body) VALUES (new._rowid, new.title, new.body);
+END;
+`;
+
 /**
  * All DDL statements in the order they must be applied.
  * Tables with foreign key dependencies come after their referenced tables.
@@ -232,4 +321,12 @@ export const SCHEMA_DDL: string[] = [
   CREATE_INGESTION_RUNS_INDEXES,
   CREATE_FTS_TABLES,
   CREATE_FTS_TRIGGERS,
+  // v0.2: projection layer
+  CREATE_PROJECTIONS,
+  CREATE_PROJECTIONS_INDEXES,
+  CREATE_PROJECTION_EVIDENCE,
+  CREATE_PROJECTION_EVIDENCE_INDEXES,
+  CREATE_RECONCILIATION_RUNS,
+  CREATE_PROJECTIONS_FTS,
+  CREATE_PROJECTIONS_FTS_TRIGGERS,
 ];

--- a/packages/engram-core/src/format/verify.ts
+++ b/packages/engram-core/src/format/verify.ts
@@ -6,7 +6,17 @@
  */
 
 import type { EngramGraph } from "./graph.js";
-import { FORMAT_VERSION } from "./version.js";
+import { FORMAT_VERSION, MIN_READABLE_VERSION } from "./version.js";
+
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
 
 export type ViolationSeverity = "error" | "warning";
 
@@ -54,10 +64,14 @@ function checkMetadata(graph: EngramGraph): Violation[] {
   }
 
   const formatVersion = found.get("format_version");
-  if (formatVersion && formatVersion !== FORMAT_VERSION) {
+  if (
+    formatVersion &&
+    (compareSemver(formatVersion, MIN_READABLE_VERSION) < 0 ||
+      compareSemver(formatVersion, FORMAT_VERSION) > 0)
+  ) {
     violations.push({
       check: "checkMetadata",
-      message: `Unrecognized format_version '${formatVersion}' (engine supports '${FORMAT_VERSION}')`,
+      message: `Unrecognized format_version '${formatVersion}' (engine supports ${MIN_READABLE_VERSION}–${FORMAT_VERSION})`,
       severity: "error",
     });
   }

--- a/packages/engram-core/src/format/version.ts
+++ b/packages/engram-core/src/format/version.ts
@@ -4,5 +4,17 @@
  * Extracted from index.ts to break circular imports between format/ and graph/ modules.
  */
 
-export const FORMAT_VERSION = "0.1.0";
+export const FORMAT_VERSION = "0.2.0";
 export const ENGINE_VERSION = "0.1.0";
+
+/**
+ * The oldest schema version this engine can read.
+ * v0.2 can read v0.1 files (projection-layer queries return empty sets).
+ */
+export const MIN_READABLE_VERSION = "0.1.0";
+
+/**
+ * The minimum schema version required before any write operation.
+ * Opening a v0.1 file for writes must first migrate it to v0.2.
+ */
+export const MIN_WRITABLE_VERSION = "0.2.0";

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -4,13 +4,6 @@
  * Public API surface. All consumer-facing types and functions are re-exported from here.
  */
 
-export {
-  ENGINE_VERSION,
-  FORMAT_VERSION,
-  MIN_READABLE_VERSION,
-  MIN_WRITABLE_VERSION,
-} from "./format/version.js";
-
 export type { AIConfig, AIProvider, EntityHint } from "./ai/index.js";
 export {
   createProvider,
@@ -34,6 +27,12 @@ export {
   SCHEMA_DDL,
   verifyGraph,
 } from "./format/index.js";
+export {
+  ENGINE_VERSION,
+  FORMAT_VERSION,
+  MIN_READABLE_VERSION,
+  MIN_WRITABLE_VERSION,
+} from "./format/version.js";
 export type {
   Alias,
   AliasInput,

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -4,8 +4,12 @@
  * Public API surface. All consumer-facing types and functions are re-exported from here.
  */
 
-export const FORMAT_VERSION = "0.1.0";
-export const ENGINE_VERSION = "0.1.0";
+export {
+  ENGINE_VERSION,
+  FORMAT_VERSION,
+  MIN_READABLE_VERSION,
+  MIN_WRITABLE_VERSION,
+} from "./format/version.js";
 
 export type { AIConfig, AIProvider, EntityHint } from "./ai/index.js";
 export {
@@ -25,6 +29,7 @@ export {
   closeGraph,
   createGraph,
   EngramFormatError,
+  migrate_0_1_0_to_0_2_0,
   openGraph,
   SCHEMA_DDL,
   verifyGraph,

--- a/packages/engram-core/test/format/schema-v0.2.test.ts
+++ b/packages/engram-core/test/format/schema-v0.2.test.ts
@@ -1,0 +1,699 @@
+/**
+ * schema-v0.2.test.ts — tests for the v0.2 schema migration and projection layer DDL.
+ *
+ * Covers:
+ *  - Fresh v0.2 database: all new tables, indexes, FTS virtual table, and triggers exist
+ *  - Migration from v0.1: schema_version bumps to '0.2.0' and new tables exist
+ *  - Data preservation: v0.1 data survives migration intact
+ *  - Compatibility: v0.2 reader on a migrated v0.1 file works (projection tables empty)
+ *  - Integration: raw insert/read of projections + projection_evidence
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ulid } from "ulid";
+import {
+  closeGraph,
+  createGraph,
+  migrate_0_1_0_to_0_2_0,
+  openGraph,
+} from "../../src/format/index.js";
+import {
+  CREATE_EDGE_EVIDENCE,
+  CREATE_EDGES,
+  CREATE_EDGES_INDEXES,
+  CREATE_EMBEDDINGS,
+  CREATE_EMBEDDINGS_INDEXES,
+  CREATE_ENTITIES,
+  CREATE_ENTITIES_INDEXES,
+  CREATE_ENTITY_ALIASES,
+  CREATE_ENTITY_ALIASES_INDEXES,
+  CREATE_ENTITY_EVIDENCE,
+  CREATE_EPISODES,
+  CREATE_EPISODES_INDEXES,
+  CREATE_FTS_TABLES,
+  CREATE_FTS_TRIGGERS,
+  CREATE_INGESTION_RUNS,
+  CREATE_INGESTION_RUNS_INDEXES,
+  CREATE_METADATA,
+} from "../../src/format/schema.js";
+
+function tmpPath(name: string): string {
+  return join(
+    tmpdir(),
+    `engram-test-v02-${name}-${crypto.randomUUID()}.engram`,
+  );
+}
+
+function cleanupFiles(paths: string[]): void {
+  for (const p of paths) {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      const full = p + suffix;
+      if (existsSync(full)) {
+        try {
+          unlinkSync(full);
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Build a minimal v0.1 database at the given path.
+ * Applies all v0.1 DDL and sets format_version='0.1.0'.
+ */
+function createV1Db(path: string): Database {
+  const db = new Database(path, { create: true });
+  db.run("PRAGMA journal_mode = WAL");
+  db.run("PRAGMA foreign_keys = ON");
+
+  const v1Ddl = [
+    CREATE_METADATA,
+    CREATE_ENTITIES,
+    CREATE_ENTITIES_INDEXES,
+    CREATE_EPISODES,
+    CREATE_EPISODES_INDEXES,
+    CREATE_ENTITY_ALIASES,
+    CREATE_ENTITY_ALIASES_INDEXES,
+    CREATE_EDGES,
+    CREATE_EDGES_INDEXES,
+    CREATE_ENTITY_EVIDENCE,
+    CREATE_EDGE_EVIDENCE,
+    CREATE_EMBEDDINGS,
+    CREATE_EMBEDDINGS_INDEXES,
+    CREATE_INGESTION_RUNS,
+    CREATE_INGESTION_RUNS_INDEXES,
+    CREATE_FTS_TABLES,
+    CREATE_FTS_TRIGGERS,
+  ].join("\n");
+
+  db.exec(v1Ddl);
+
+  const now = new Date().toISOString();
+  db.run(
+    "INSERT INTO metadata (key, value) VALUES ('format_version', '0.1.0')",
+  );
+  db.run(
+    "INSERT INTO metadata (key, value) VALUES ('engine_version', '0.1.0')",
+  );
+  db.run(`INSERT INTO metadata (key, value) VALUES ('created_at', '${now}')`);
+  db.run("INSERT INTO metadata (key, value) VALUES ('owner_id', 'test-owner')");
+  db.run(
+    "INSERT INTO metadata (key, value) VALUES ('default_timezone', 'UTC')",
+  );
+
+  return db;
+}
+
+// ─── Fresh v0.2 database ─────────────────────────────────────────────────────
+
+describe("fresh v0.2 database — new tables exist", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    cleanupFiles(created);
+    created.length = 0;
+  });
+
+  const NEW_TABLES = [
+    "projections",
+    "projection_evidence",
+    "reconciliation_runs",
+    "projections_fts",
+  ];
+
+  it("has all new v0.2 base tables", () => {
+    const path = tmpPath("fresh-tables");
+    created.push(path);
+    const graph = createGraph(path);
+
+    const existing = (
+      graph.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const table of NEW_TABLES) {
+      expect(existing).toContain(table);
+    }
+    closeGraph(graph);
+  });
+
+  it("has all new v0.2 indexes", () => {
+    const path = tmpPath("fresh-indexes");
+    created.push(path);
+    const graph = createGraph(path);
+
+    const NEW_INDEXES = [
+      "idx_projections_anchor",
+      "idx_projections_kind",
+      "idx_projections_valid",
+      "idx_projections_active",
+      "idx_projections_active_unique",
+      "idx_projection_evidence_target",
+    ];
+
+    const existing = (
+      graph.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'index'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const idx of NEW_INDEXES) {
+      expect(existing).toContain(idx);
+    }
+    closeGraph(graph);
+  });
+
+  it("has all new v0.2 triggers", () => {
+    const path = tmpPath("fresh-triggers");
+    created.push(path);
+    const graph = createGraph(path);
+
+    const NEW_TRIGGERS = ["projections_ai", "projections_ad", "projections_au"];
+
+    const existing = (
+      graph.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const trigger of NEW_TRIGGERS) {
+      expect(existing).toContain(trigger);
+    }
+    closeGraph(graph);
+  });
+
+  it("projections table has the expected columns", () => {
+    const path = tmpPath("fresh-cols");
+    created.push(path);
+    const graph = createGraph(path);
+
+    const cols = (
+      graph.db.prepare("PRAGMA table_info(projections)").all() as Array<{
+        name: string;
+      }>
+    ).map((r) => r.name);
+
+    const EXPECTED_COLS = [
+      "_rowid",
+      "id",
+      "kind",
+      "anchor_type",
+      "anchor_id",
+      "title",
+      "body",
+      "body_format",
+      "model",
+      "prompt_template_id",
+      "prompt_hash",
+      "input_fingerprint",
+      "confidence",
+      "valid_from",
+      "valid_until",
+      "last_assessed_at",
+      "invalidated_at",
+      "superseded_by",
+      "created_at",
+      "owner_id",
+    ];
+
+    for (const col of EXPECTED_COLS) {
+      expect(cols).toContain(col);
+    }
+    closeGraph(graph);
+  });
+
+  it("projection_evidence table has the expected columns", () => {
+    const path = tmpPath("fresh-pe-cols");
+    created.push(path);
+    const graph = createGraph(path);
+
+    const cols = (
+      graph.db
+        .prepare("PRAGMA table_info(projection_evidence)")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const col of [
+      "projection_id",
+      "target_type",
+      "target_id",
+      "role",
+      "content_hash",
+    ]) {
+      expect(cols).toContain(col);
+    }
+    closeGraph(graph);
+  });
+
+  it("reconciliation_runs table has the expected columns", () => {
+    const path = tmpPath("fresh-rr-cols");
+    created.push(path);
+    const graph = createGraph(path);
+
+    const cols = (
+      graph.db
+        .prepare("PRAGMA table_info(reconciliation_runs)")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const col of [
+      "id",
+      "started_at",
+      "completed_at",
+      "scope",
+      "phases",
+      "projections_checked",
+      "projections_refreshed",
+      "projections_superseded",
+      "projections_discovered",
+      "dry_run",
+      "status",
+      "error",
+    ]) {
+      expect(cols).toContain(col);
+    }
+    closeGraph(graph);
+  });
+
+  it("schema_version metadata is '0.2.0' in a fresh db", () => {
+    const path = tmpPath("fresh-version");
+    created.push(path);
+    const graph = createGraph(path);
+
+    const row = graph.db
+      .prepare("SELECT value FROM metadata WHERE key = 'format_version'")
+      .get() as { value: string } | undefined;
+
+    expect(row?.value).toBe("0.2.0");
+    closeGraph(graph);
+  });
+});
+
+// ─── Migration from v0.1 ─────────────────────────────────────────────────────
+
+describe("migrate_0_1_0_to_0_2_0", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    cleanupFiles(created);
+    created.length = 0;
+  });
+
+  it("bumps schema_version to '0.2.0'", () => {
+    const path = tmpPath("migrate-version");
+    created.push(path);
+
+    const db = createV1Db(path);
+    migrate_0_1_0_to_0_2_0(db);
+
+    const row = db
+      .prepare("SELECT value FROM metadata WHERE key = 'format_version'")
+      .get() as { value: string };
+    expect(row.value).toBe("0.2.0");
+    db.close();
+  });
+
+  it("creates all new tables after migration", () => {
+    const path = tmpPath("migrate-tables");
+    created.push(path);
+
+    const db = createV1Db(path);
+    migrate_0_1_0_to_0_2_0(db);
+
+    const existing = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const table of [
+      "projections",
+      "projection_evidence",
+      "reconciliation_runs",
+      "projections_fts",
+    ]) {
+      expect(existing).toContain(table);
+    }
+    db.close();
+  });
+
+  it("creates all new indexes after migration", () => {
+    const path = tmpPath("migrate-indexes");
+    created.push(path);
+
+    const db = createV1Db(path);
+    migrate_0_1_0_to_0_2_0(db);
+
+    const existing = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'index'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const idx of [
+      "idx_projections_anchor",
+      "idx_projections_kind",
+      "idx_projections_valid",
+      "idx_projections_active",
+      "idx_projections_active_unique",
+      "idx_projection_evidence_target",
+    ]) {
+      expect(existing).toContain(idx);
+    }
+    db.close();
+  });
+
+  it("creates all new triggers after migration", () => {
+    const path = tmpPath("migrate-triggers");
+    created.push(path);
+
+    const db = createV1Db(path);
+    migrate_0_1_0_to_0_2_0(db);
+
+    const existing = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'")
+        .all() as Array<{ name: string }>
+    ).map((r) => r.name);
+
+    for (const trigger of [
+      "projections_ai",
+      "projections_ad",
+      "projections_au",
+    ]) {
+      expect(existing).toContain(trigger);
+    }
+    db.close();
+  });
+});
+
+// ─── Data preservation ────────────────────────────────────────────────────────
+
+describe("v0.1 data survives migration", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    cleanupFiles(created);
+    created.length = 0;
+  });
+
+  it("existing entities are intact after migration", () => {
+    const path = tmpPath("preserve-entities");
+    created.push(path);
+
+    const db = createV1Db(path);
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO entities (id, canonical_name, entity_type, created_at, updated_at)
+       VALUES ('ent-1', 'AuthService', 'module', '${now}', '${now}')`,
+    );
+
+    migrate_0_1_0_to_0_2_0(db);
+
+    const row = db.prepare("SELECT * FROM entities WHERE id = 'ent-1'").get() as
+      | { canonical_name: string }
+      | undefined;
+    expect(row?.canonical_name).toBe("AuthService");
+    db.close();
+  });
+
+  it("existing episodes are intact after migration", () => {
+    const path = tmpPath("preserve-episodes");
+    created.push(path);
+
+    const db = createV1Db(path);
+    const now = new Date().toISOString();
+    db.run(
+      `INSERT INTO episodes (id, source_type, source_ref, content, content_hash, status, timestamp, ingested_at, extractor_version)
+       VALUES ('ep-1', 'manual', 'ref-1', 'test content', 'abc123', 'active', '${now}', '${now}', '0.1.0')`,
+    );
+
+    migrate_0_1_0_to_0_2_0(db);
+
+    const row = db.prepare("SELECT * FROM episodes WHERE id = 'ep-1'").get() as
+      | { content: string }
+      | undefined;
+    expect(row?.content).toBe("test content");
+    db.close();
+  });
+
+  it("metadata keys other than format_version are preserved", () => {
+    const path = tmpPath("preserve-meta");
+    created.push(path);
+
+    const db = createV1Db(path);
+    migrate_0_1_0_to_0_2_0(db);
+
+    const owner = db
+      .prepare("SELECT value FROM metadata WHERE key = 'owner_id'")
+      .get() as { value: string };
+    expect(owner.value).toBe("test-owner");
+
+    const tz = db
+      .prepare("SELECT value FROM metadata WHERE key = 'default_timezone'")
+      .get() as { value: string };
+    expect(tz.value).toBe("UTC");
+    db.close();
+  });
+});
+
+// ─── Compatibility: openGraph on migrated v0.1 file ──────────────────────────
+
+describe("compatibility: openGraph on migrated v0.1 file", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    cleanupFiles(created);
+    created.length = 0;
+  });
+
+  it("openGraph opens a migrated v0.1 file without error", () => {
+    const path = tmpPath("compat-open");
+    created.push(path);
+
+    const db = createV1Db(path);
+    migrate_0_1_0_to_0_2_0(db);
+    db.close();
+
+    expect(() => {
+      const g = openGraph(path);
+      closeGraph(g);
+    }).not.toThrow();
+  });
+
+  it("projection tables are empty on a freshly migrated v0.1 file", () => {
+    const path = tmpPath("compat-empty");
+    created.push(path);
+
+    const db = createV1Db(path);
+    migrate_0_1_0_to_0_2_0(db);
+    db.close();
+
+    const g = openGraph(path);
+    const projCount = (
+      g.db.prepare("SELECT COUNT(*) as cnt FROM projections").get() as {
+        cnt: number;
+      }
+    ).cnt;
+    expect(projCount).toBe(0);
+
+    const peCount = (
+      g.db.prepare("SELECT COUNT(*) as cnt FROM projection_evidence").get() as {
+        cnt: number;
+      }
+    ).cnt;
+    expect(peCount).toBe(0);
+
+    const rrCount = (
+      g.db.prepare("SELECT COUNT(*) as cnt FROM reconciliation_runs").get() as {
+        cnt: number;
+      }
+    ).cnt;
+    expect(rrCount).toBe(0);
+
+    closeGraph(g);
+  });
+});
+
+// ─── Integration: raw insert/read of projections ─────────────────────────────
+
+describe("integration: insert and read projections + projection_evidence", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    cleanupFiles(created);
+    created.length = 0;
+  });
+
+  it("inserts a projection row and reads it back", () => {
+    const path = tmpPath("insert-projection");
+    created.push(path);
+    const graph = createGraph(path);
+    const now = new Date().toISOString();
+    const projId = ulid();
+
+    graph.db
+      .prepare(
+        `INSERT INTO projections
+           (id, kind, anchor_type, anchor_id, title, body, model, input_fingerprint, valid_from, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        projId,
+        "entity_summary",
+        "entity",
+        "ent-1",
+        "AuthService summary",
+        `---\nid: ${projId}\n---\n\nThe auth module handles sessions.`,
+        "anthropic:claude-opus-4-6",
+        "sha256-fingerprint-abc",
+        now,
+        now,
+      );
+
+    const row = graph.db
+      .prepare("SELECT * FROM projections WHERE id = ?")
+      .get(projId) as { title: string; kind: string } | undefined;
+
+    expect(row?.title).toBe("AuthService summary");
+    expect(row?.kind).toBe("entity_summary");
+    closeGraph(graph);
+  });
+
+  it("inserts projection_evidence and reads it back", () => {
+    const path = tmpPath("insert-pe");
+    created.push(path);
+    const graph = createGraph(path);
+    const now = new Date().toISOString();
+    const projId = ulid();
+
+    graph.db
+      .prepare(
+        `INSERT INTO projections
+           (id, kind, anchor_type, anchor_id, title, body, model, input_fingerprint, valid_from, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        projId,
+        "entity_summary",
+        "entity",
+        "ent-1",
+        "AuthService",
+        "---\nbody\n---",
+        "human",
+        "fp-123",
+        now,
+        now,
+      );
+
+    graph.db
+      .prepare(
+        `INSERT INTO projection_evidence (projection_id, target_type, target_id, role, content_hash)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(projId, "episode", "ep-1", "input", "hash-abc");
+
+    const pe = graph.db
+      .prepare("SELECT * FROM projection_evidence WHERE projection_id = ?")
+      .get(projId) as { target_type: string; role: string } | undefined;
+
+    expect(pe?.target_type).toBe("episode");
+    expect(pe?.role).toBe("input");
+    closeGraph(graph);
+  });
+
+  it("FTS index is updated when a projection is inserted", () => {
+    const path = tmpPath("fts-projection");
+    created.push(path);
+    const graph = createGraph(path);
+    const now = new Date().toISOString();
+    const projId = ulid();
+
+    graph.db
+      .prepare(
+        `INSERT INTO projections
+           (id, kind, anchor_type, title, body, model, input_fingerprint, valid_from, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        projId,
+        "entity_summary",
+        "none",
+        "Payment gateway overview",
+        "The payment gateway handles Stripe integration.",
+        "human",
+        "fp-xyz",
+        now,
+        now,
+      );
+
+    const hits = graph.db
+      .prepare("SELECT * FROM projections_fts WHERE projections_fts MATCH ?")
+      .all("Stripe") as unknown[];
+
+    expect(hits.length).toBeGreaterThan(0);
+    closeGraph(graph);
+  });
+
+  it("unique active projection constraint prevents duplicate (anchor, kind)", () => {
+    const path = tmpPath("unique-active");
+    created.push(path);
+    const graph = createGraph(path);
+    const now = new Date().toISOString();
+
+    const insertProj = (id: string) =>
+      graph.db
+        .prepare(
+          `INSERT INTO projections
+             (id, kind, anchor_type, anchor_id, title, body, model, input_fingerprint, valid_from, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          id,
+          "entity_summary",
+          "entity",
+          "ent-1",
+          "Title",
+          "Body",
+          "human",
+          "fp",
+          now,
+          now,
+        );
+
+    insertProj(ulid());
+    // Second active projection for the same (anchor_type, anchor_id, kind) must fail
+    expect(() => insertProj(ulid())).toThrow();
+    closeGraph(graph);
+  });
+
+  it("inserting a reconciliation_run row works", () => {
+    const path = tmpPath("insert-rr");
+    created.push(path);
+    const graph = createGraph(path);
+    const now = new Date().toISOString();
+    const runId = ulid();
+
+    graph.db
+      .prepare(
+        `INSERT INTO reconciliation_runs (id, started_at, status)
+         VALUES (?, ?, ?)`,
+      )
+      .run(runId, now, "running");
+
+    const row = graph.db
+      .prepare("SELECT * FROM reconciliation_runs WHERE id = ?")
+      .get(runId) as { status: string; phases: string } | undefined;
+
+    expect(row?.status).toBe("running");
+    expect(row?.phases).toBe("assess,discover");
+    closeGraph(graph);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds all v0.2 DDL constants to `schema.ts`: `projections`, `projection_evidence`, `reconciliation_runs` tables, 5 indexes (including partial unique), FTS5 virtual table `projections_fts`, and 3 triggers (ai/ad/au)
- Adds `migrate_0_1_0_to_0_2_0` to the new `migrations.ts` — purely additive, runs all new DDL then bumps `format_version` to `0.2.0` atomically in a transaction
- Bumps `FORMAT_VERSION` to `0.2.0`, adds `MIN_READABLE_VERSION='0.1.0'` and `MIN_WRITABLE_VERSION='0.2.0'` in `version.ts`
- Updates `openGraph` and `verifyGraph` to use semver range checking (`MIN_READABLE_VERSION`..`FORMAT_VERSION`) so v0.2 engine opens v0.1 files

## Acceptance Criteria

- [x] All DDL constants added to `schema.ts` and applied in `SCHEMA_DDL`
- [x] `migrate_0_1_0_to_0_2_0` applies new DDL on existing v0.1 databases and bumps `schema_version` to `0.2.0`
- [x] All new tables, indexes, virtual table, and triggers exist in a fresh v0.2 database
- [x] Tests cover: fresh-create, migration-from-v0.1, v0.1-data-preservation, compatibility (openGraph on migrated file), raw insert/read
- [x] `bun test packages/engram-core/` passes (344 tests, 0 failures)
- [x] `bunx biome check` passes on all changed files

## Test plan

- `bun test packages/engram-core/test/format/schema-v0.2.test.ts` — 21 tests covering all acceptance criteria
- `bun test packages/engram-core/` — full 344-test suite passes

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)