### PR TITLE
feat: add project() operation and ProjectionGenerator interface

### DIFF
--- a/packages/engram-core/src/ai/projection-generator.ts
+++ b/packages/engram-core/src/ai/projection-generator.ts
@@ -1,0 +1,200 @@
+/**
+ * projection-generator.ts — ProjectionGenerator interface and implementations.
+ *
+ * A ProjectionGenerator wraps an AI provider and prompt template to produce
+ * projection bodies. It is the AI boundary for the projection authoring layer.
+ *
+ * Implementations:
+ * - NullGenerator: throws on generate() — used when no AI is configured.
+ * - AnthropicGenerator: stub that calls the Anthropic API with a placeholder prompt.
+ */
+
+import type { Projection } from "../graph/projections.js";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * A substrate element resolved from the database, ready to pass to an AI generator.
+ */
+export interface ResolvedInput {
+  type: "episode" | "entity" | "edge" | "projection";
+  id: string;
+  /** The content of the substrate element at resolution time. */
+  content: string | null;
+  /** SHA-256 hash of the content at resolution time. */
+  content_hash: string | null;
+}
+
+/**
+ * The verdict returned by generator.assess() during a reconcile() run.
+ */
+export type AssessVerdict =
+  | { verdict: "still_accurate" }
+  | { verdict: "needs_update"; reason: string }
+  | { verdict: "contradicted"; reason: string };
+
+/**
+ * Core interface for projection generation.
+ *
+ * Implementations wrap an AI provider plus a prompt template and handle:
+ * - generate(): produce the initial markdown body from resolved inputs.
+ * - assess(): determine whether an existing projection is still accurate
+ *   given the current (possibly changed) input state.
+ * - regenerate(): produce a revised body for an existing projection given
+ *   updated inputs.
+ */
+export interface ProjectionGenerator {
+  /**
+   * Generate a markdown body (with YAML frontmatter) from resolved inputs.
+   *
+   * The returned body MUST include all required frontmatter keys:
+   * id, kind, anchor, title, model, input_fingerprint, valid_from, inputs.
+   *
+   * @throws Error if generation fails or is not supported.
+   */
+  generate(
+    inputs: ResolvedInput[],
+  ): Promise<{ body: string; confidence: number }>;
+
+  /**
+   * Assess whether an existing projection is still accurate given the
+   * current state of its inputs.
+   *
+   * Called during reconcile() assess phase for projections whose
+   * input_fingerprint has drifted.
+   */
+  assess(
+    projection: Projection,
+    currentInputs: ResolvedInput[],
+  ): Promise<AssessVerdict>;
+
+  /**
+   * Regenerate a projection body based on updated inputs.
+   *
+   * Called during reconcile() when assess() returns 'needs_update' or
+   * 'contradicted'. The old projection is passed for context (e.g. to
+   * carry over parts of the body that haven't changed).
+   */
+  regenerate(
+    projection: Projection,
+    currentInputs: ResolvedInput[],
+  ): Promise<{ body: string; confidence: number }>;
+}
+
+// ─── NullGenerator ───────────────────────────────────────────────────────────
+
+/**
+ * NullGenerator: used when no AI provider is configured.
+ *
+ * generate() always throws — projections require an AI generator.
+ * assess() and regenerate() also throw for consistency.
+ */
+export class NullGenerator implements ProjectionGenerator {
+  async generate(
+    _inputs: ResolvedInput[],
+  ): Promise<{ body: string; confidence: number }> {
+    throw new Error(
+      "NullGenerator: no AI provider configured — cannot generate projections. " +
+        "Configure an AI provider (e.g. ENGRAM_AI_PROVIDER=anthropic) to use project().",
+    );
+  }
+
+  async assess(
+    _projection: Projection,
+    _currentInputs: ResolvedInput[],
+  ): Promise<AssessVerdict> {
+    throw new Error(
+      "NullGenerator: no AI provider configured — cannot assess projections.",
+    );
+  }
+
+  async regenerate(
+    _projection: Projection,
+    _currentInputs: ResolvedInput[],
+  ): Promise<{ body: string; confidence: number }> {
+    throw new Error(
+      "NullGenerator: no AI provider configured — cannot regenerate projections.",
+    );
+  }
+}
+
+// ─── AnthropicGenerator ──────────────────────────────────────────────────────
+
+/**
+ * AnthropicGenerator: stub implementation backed by the Anthropic API.
+ *
+ * This is a placeholder implementation. In production it would use the
+ * @anthropic-ai/sdk to call Claude with a prompt template populated from
+ * the resolved inputs.
+ *
+ * The stub returns a valid markdown body with frontmatter so the generate/
+ * validate/insert pipeline can be exercised end-to-end in tests.
+ */
+export class AnthropicGenerator implements ProjectionGenerator {
+  private readonly model: string;
+  private readonly promptTemplateId: string;
+  private readonly apiKey: string | undefined;
+
+  constructor(opts?: {
+    model?: string;
+    promptTemplateId?: string;
+    apiKey?: string;
+  }) {
+    this.model = opts?.model ?? "anthropic:claude-opus-4-6";
+    this.promptTemplateId = opts?.promptTemplateId ?? "default.v1";
+    this.apiKey = opts?.apiKey ?? process.env.ANTHROPIC_API_KEY;
+  }
+
+  async generate(
+    inputs: ResolvedInput[],
+  ): Promise<{ body: string; confidence: number }> {
+    // Stub: in production this would call the Anthropic API with a
+    // populated prompt template. For now, return a valid body so the
+    // pipeline works end-to-end.
+    const inputList = inputs.map((i) => `  - ${i.type}:${i.id}`).join("\n");
+    const now = new Date().toISOString();
+
+    const body =
+      `---\n` +
+      `id: placeholder\n` +
+      `kind: generated\n` +
+      `anchor: none\n` +
+      `title: "Generated Projection"\n` +
+      `model: ${this.model}\n` +
+      `prompt_template_id: ${this.promptTemplateId}\n` +
+      `prompt_hash: stub\n` +
+      `input_fingerprint: stub\n` +
+      `valid_from: ${now}\n` +
+      `valid_until: null\n` +
+      `inputs:\n${inputList}\n` +
+      `---\n\n` +
+      `# Generated Projection\n\n` +
+      `This projection was generated from ${inputs.length} input(s) by ${this.model}.\n\n` +
+      `> Note: AnthropicGenerator is a stub. Configure a real implementation for production use.\n`;
+
+    return { body, confidence: 0.9 };
+  }
+
+  async assess(
+    _projection: Projection,
+    _currentInputs: ResolvedInput[],
+  ): Promise<AssessVerdict> {
+    // Stub: always returns needs_update in production this would call
+    // the Anthropic API with the existing body + current inputs.
+    return {
+      verdict: "needs_update",
+      reason:
+        "AnthropicGenerator.assess() is a stub — always returns needs_update",
+    };
+  }
+
+  async regenerate(
+    projection: Projection,
+    inputs: ResolvedInput[],
+  ): Promise<{ body: string; confidence: number }> {
+    // Stub: delegates to generate() in this placeholder implementation.
+    // Production would call Anthropic with the old body as context.
+    void projection;
+    return this.generate(inputs);
+  }
+}

--- a/packages/engram-core/src/graph/index.ts
+++ b/packages/engram-core/src/graph/index.ts
@@ -29,3 +29,20 @@ export {
 } from "./errors.js";
 export type { EvidenceLink } from "./evidence.js";
 export { getEvidenceForEdge, getEvidenceForEntity } from "./evidence.js";
+export type {
+  AnchorType,
+  GetProjectionResult,
+  Projection,
+  ProjectionEvidenceRow,
+  ProjectionInput,
+  ProjectionInputType,
+  ProjectionOpts,
+} from "./projections.js";
+export {
+  getProjection,
+  ProjectionCycleError,
+  ProjectionFrontmatterError,
+  ProjectionInputMissingError,
+  project,
+  supersedeProjection,
+} from "./projections.js";

--- a/packages/engram-core/src/graph/projections-types.ts
+++ b/packages/engram-core/src/graph/projections-types.ts
@@ -1,0 +1,86 @@
+/**
+ * projections-types.ts — types and error classes for the projection layer.
+ *
+ * Split from projections.ts to keep that file under the 500-line limit.
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type AnchorType = "entity" | "edge" | "episode" | "projection" | "none";
+
+export type ProjectionInputType = "episode" | "entity" | "edge" | "projection";
+
+export interface ProjectionInput {
+  type: ProjectionInputType;
+  id: string;
+}
+
+export interface Projection {
+  id: string;
+  kind: string;
+  anchor_type: AnchorType;
+  anchor_id: string | null;
+  title: string;
+  body: string;
+  body_format: string;
+  model: string;
+  prompt_template_id: string | null;
+  prompt_hash: string | null;
+  input_fingerprint: string;
+  confidence: number;
+  valid_from: string;
+  valid_until: string | null;
+  last_assessed_at: string | null;
+  invalidated_at: string | null;
+  superseded_by: string | null;
+  created_at: string;
+  owner_id: string | null;
+}
+
+export interface ProjectionEvidenceRow {
+  projection_id: string;
+  target_type: string;
+  target_id: string;
+  role: string;
+  content_hash: string | null;
+}
+
+export interface ProjectionOpts {
+  kind: string;
+  anchor: { type: AnchorType; id?: string };
+  inputs: ProjectionInput[];
+  generator: import("../ai/projection-generator.js").ProjectionGenerator;
+  owner_id?: string;
+}
+
+export interface GetProjectionResult {
+  projection: Projection;
+  stale: boolean;
+  stale_reason?: "input_content_changed" | "input_deleted";
+  last_assessed_at: string | null;
+}
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+export class ProjectionCycleError extends Error {
+  constructor(inputId: string) {
+    super(
+      `project(): cycle detected — projection input ${inputId} would create a circular dependency`,
+    );
+    this.name = "ProjectionCycleError";
+  }
+}
+
+export class ProjectionInputMissingError extends Error {
+  constructor(type: string, id: string) {
+    super(`project(): input ${type}:${id} not found or is redacted`);
+    this.name = "ProjectionInputMissingError";
+  }
+}
+
+export class ProjectionFrontmatterError extends Error {
+  constructor(message: string) {
+    super(`project(): invalid frontmatter — ${message}`);
+    this.name = "ProjectionFrontmatterError";
+  }
+}

--- a/packages/engram-core/src/graph/projections.ts
+++ b/packages/engram-core/src/graph/projections.ts
@@ -1,0 +1,744 @@
+/**
+ * projections.ts — project() operation and Projection CRUD.
+ *
+ * Implements the explicit projection authoring primitive described in
+ * docs/internal/specs/projections.md. A projection is an AI-authored synthesis
+ * of substrate elements (episodes, entities, edges, or other projections).
+ */
+
+import { createHash } from "node:crypto";
+import { ulid } from "ulid";
+import type {
+  ProjectionGenerator,
+  ResolvedInput,
+} from "../ai/projection-generator.js";
+import type { EngramGraph } from "../format/index.js";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type AnchorType = "entity" | "edge" | "episode" | "projection" | "none";
+
+export type ProjectionInputType = "episode" | "entity" | "edge" | "projection";
+
+export interface ProjectionInput {
+  type: ProjectionInputType;
+  id: string;
+}
+
+export interface Projection {
+  id: string;
+  kind: string;
+  anchor_type: AnchorType;
+  anchor_id: string | null;
+  title: string;
+  body: string;
+  body_format: string;
+  model: string;
+  prompt_template_id: string | null;
+  prompt_hash: string | null;
+  input_fingerprint: string;
+  confidence: number;
+  valid_from: string;
+  valid_until: string | null;
+  last_assessed_at: string | null;
+  invalidated_at: string | null;
+  superseded_by: string | null;
+  created_at: string;
+  owner_id: string | null;
+}
+
+export interface ProjectionEvidenceRow {
+  projection_id: string;
+  target_type: string;
+  target_id: string;
+  role: string;
+  content_hash: string | null;
+}
+
+export interface ProjectionOpts {
+  kind: string;
+  anchor: { type: AnchorType; id?: string };
+  inputs: ProjectionInput[];
+  generator: ProjectionGenerator;
+  owner_id?: string;
+}
+
+export interface GetProjectionResult {
+  projection: Projection;
+  stale: boolean;
+  stale_reason?: "input_content_changed" | "input_deleted";
+  last_assessed_at: string | null;
+}
+
+// ─── Errors ─────────────────────────────────────────────────────────────────
+
+export class ProjectionCycleError extends Error {
+  constructor(inputId: string) {
+    super(
+      `project(): cycle detected — projection input ${inputId} would create a circular dependency`,
+    );
+    this.name = "ProjectionCycleError";
+  }
+}
+
+export class ProjectionInputMissingError extends Error {
+  constructor(type: string, id: string) {
+    super(`project(): input ${type}:${id} not found or is redacted`);
+    this.name = "ProjectionInputMissingError";
+  }
+}
+
+export class ProjectionFrontmatterError extends Error {
+  constructor(message: string) {
+    super(`project(): invalid frontmatter — ${message}`);
+    this.name = "ProjectionFrontmatterError";
+  }
+}
+
+// ─── Required frontmatter keys ───────────────────────────────────────────────
+
+const REQUIRED_FRONTMATTER_KEYS = [
+  "id",
+  "kind",
+  "anchor",
+  "title",
+  "model",
+  "input_fingerprint",
+  "valid_from",
+  "inputs",
+] as const;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Resolves input rows from the substrate. Returns ResolvedInput[] or throws
+ * ProjectionInputMissingError if any input is missing or redacted.
+ */
+function resolveInputs(
+  graph: EngramGraph,
+  inputs: ProjectionInput[],
+): ResolvedInput[] {
+  const resolved: ResolvedInput[] = [];
+
+  for (const input of inputs) {
+    let content: string | null = null;
+    let content_hash: string | null = null;
+
+    switch (input.type) {
+      case "episode": {
+        const row = graph.db
+          .query<
+            {
+              id: string;
+              content: string;
+              content_hash: string;
+              status: string;
+            },
+            [string]
+          >(
+            "SELECT id, content, content_hash, status FROM episodes WHERE id = ?",
+          )
+          .get(input.id);
+        if (!row || row.status === "redacted") {
+          throw new ProjectionInputMissingError(input.type, input.id);
+        }
+        content = row.content;
+        content_hash = row.content_hash;
+        break;
+      }
+      case "entity": {
+        const row = graph.db
+          .query<
+            {
+              id: string;
+              canonical_name: string;
+              summary: string | null;
+              status: string;
+            },
+            [string]
+          >(
+            "SELECT id, canonical_name, summary, status FROM entities WHERE id = ?",
+          )
+          .get(input.id);
+        if (!row || row.status === "archived") {
+          throw new ProjectionInputMissingError(input.type, input.id);
+        }
+        content = `${row.canonical_name}${row.summary ? `: ${row.summary}` : ""}`;
+        content_hash = createHash("sha256").update(content).digest("hex");
+        break;
+      }
+      case "edge": {
+        const row = graph.db
+          .query<
+            { id: string; fact: string; invalidated_at: string | null },
+            [string]
+          >("SELECT id, fact, invalidated_at FROM edges WHERE id = ?")
+          .get(input.id);
+        if (!row) {
+          throw new ProjectionInputMissingError(input.type, input.id);
+        }
+        content = row.fact;
+        content_hash = createHash("sha256").update(content).digest("hex");
+        break;
+      }
+      case "projection": {
+        const row = graph.db
+          .query<
+            { id: string; body: string; invalidated_at: string | null },
+            [string]
+          >("SELECT id, body, invalidated_at FROM projections WHERE id = ?")
+          .get(input.id);
+        if (!row || row.invalidated_at !== null) {
+          throw new ProjectionInputMissingError(input.type, input.id);
+        }
+        content = row.body;
+        content_hash = createHash("sha256").update(content).digest("hex");
+        break;
+      }
+      default: {
+        throw new ProjectionInputMissingError(input.type, input.id);
+      }
+    }
+
+    resolved.push({ type: input.type, id: input.id, content, content_hash });
+  }
+
+  return resolved;
+}
+
+/**
+ * Computes the input_fingerprint as sha256 over sorted "type:id:content_hash" entries.
+ */
+function computeFingerprint(resolved: ResolvedInput[]): string {
+  const entries = resolved
+    .map((r) => `${r.type}:${r.id}:${r.content_hash ?? ""}`)
+    .sort();
+  return createHash("sha256").update(entries.join("\n")).digest("hex");
+}
+
+/**
+ * Recomputes the current fingerprint for an existing projection by reading
+ * current content hashes from the substrate.
+ */
+function recomputeFingerprint(
+  graph: EngramGraph,
+  projectionId: string,
+): string {
+  const evidenceRows = graph.db
+    .query<ProjectionEvidenceRow, [string]>(
+      "SELECT * FROM projection_evidence WHERE projection_id = ? AND role = 'input'",
+    )
+    .all(projectionId);
+
+  const entries: string[] = [];
+
+  for (const row of evidenceRows) {
+    let currentHash: string | null = null;
+
+    switch (row.target_type) {
+      case "episode": {
+        const ep = graph.db
+          .query<{ content_hash: string; status: string }, [string]>(
+            "SELECT content_hash, status FROM episodes WHERE id = ?",
+          )
+          .get(row.target_id);
+        currentHash = ep && ep.status !== "redacted" ? ep.content_hash : null;
+        break;
+      }
+      case "entity": {
+        const ent = graph.db
+          .query<{ canonical_name: string; summary: string | null }, [string]>(
+            "SELECT canonical_name, summary FROM entities WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (ent) {
+          const content = `${ent.canonical_name}${ent.summary ? `: ${ent.summary}` : ""}`;
+          currentHash = createHash("sha256").update(content).digest("hex");
+        }
+        break;
+      }
+      case "edge": {
+        const edge = graph.db
+          .query<{ fact: string }, [string]>(
+            "SELECT fact FROM edges WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (edge) {
+          currentHash = createHash("sha256").update(edge.fact).digest("hex");
+        }
+        break;
+      }
+      case "projection": {
+        const proj = graph.db
+          .query<{ body: string; invalidated_at: string | null }, [string]>(
+            "SELECT body, invalidated_at FROM projections WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (proj && proj.invalidated_at === null) {
+          currentHash = createHash("sha256").update(proj.body).digest("hex");
+        }
+        break;
+      }
+    }
+
+    entries.push(`${row.target_type}:${row.target_id}:${currentHash ?? ""}`);
+  }
+
+  entries.sort();
+  return createHash("sha256").update(entries.join("\n")).digest("hex");
+}
+
+/**
+ * Detects if adding a dependency on any of `inputIds` would create a cycle in the
+ * projection dependency graph.
+ *
+ * A cycle would occur if any projection in the transitive dependency set of the
+ * candidate inputs is the same as `targetProjectionId` (the existing projection
+ * that is about to be superseded, which the new projection would conceptually replace).
+ *
+ * Uses a recursive CTE to walk DOWNWARD from each projection input (following
+ * their evidence targets where target_type='projection'), checking whether
+ * `targetProjectionId` is reachable.
+ */
+function detectProjectionCycle(
+  graph: EngramGraph,
+  targetProjectionId: string,
+  inputIds: string[],
+): string | null {
+  if (inputIds.length === 0) return null;
+
+  // Walk the dependency tree downward from each projection input.
+  // If we reach targetProjectionId, adding this dependency would form a cycle.
+  for (const inputId of inputIds) {
+    const cycleRow = graph.db
+      .query<{ id: string }, [string, string]>(
+        `WITH RECURSIVE deps(id) AS (
+           SELECT ? AS id
+           UNION ALL
+           SELECT pe.target_id
+             FROM projection_evidence pe
+             JOIN deps ON pe.projection_id = deps.id
+            WHERE pe.target_type = 'projection'
+              AND pe.role = 'input'
+         )
+         SELECT id FROM deps WHERE id = ? LIMIT 1`,
+      )
+      .get(inputId, targetProjectionId);
+
+    if (cycleRow) {
+      return inputId;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validates that the body frontmatter contains all required keys.
+ * This is a simple YAML frontmatter check — not a full YAML parser.
+ */
+function validateFrontmatter(body: string): void {
+  if (!body.startsWith("---\n")) {
+    throw new ProjectionFrontmatterError(
+      "body must begin with YAML frontmatter block (---)",
+    );
+  }
+
+  const endIdx = body.indexOf("\n---", 4);
+  if (endIdx === -1) {
+    throw new ProjectionFrontmatterError("frontmatter block is not closed");
+  }
+
+  const frontmatter = body.slice(4, endIdx);
+
+  for (const key of REQUIRED_FRONTMATTER_KEYS) {
+    // Accept "key:" or "key: " patterns
+    if (!frontmatter.includes(`${key}:`)) {
+      throw new ProjectionFrontmatterError(`missing required key: ${key}`);
+    }
+  }
+}
+
+// ─── Core operations ─────────────────────────────────────────────────────────
+
+/**
+ * Supersedes an existing projection with a new one atomically.
+ *
+ * In one transaction:
+ * 1. UPDATE old projection: set invalidated_at, valid_until, superseded_by
+ * 2. INSERT new projection row + evidence rows
+ *
+ * Returns the new projection.
+ */
+export function supersedeProjection(
+  graph: EngramGraph,
+  oldProjectionId: string,
+  newData: {
+    kind: string;
+    anchor_type: AnchorType;
+    anchor_id: string | null;
+    title: string;
+    body: string;
+    model: string;
+    prompt_template_id: string | null;
+    prompt_hash: string | null;
+    input_fingerprint: string;
+    confidence: number;
+    owner_id: string | null;
+  },
+  resolvedInputs: ResolvedInput[],
+): Projection {
+  const newId = ulid();
+  const now = new Date().toISOString();
+  const result: { projection: Projection | null } = { projection: null };
+
+  graph.db.transaction(() => {
+    const oldRow = graph.db
+      .query<Projection, [string]>("SELECT * FROM projections WHERE id = ?")
+      .get(oldProjectionId);
+
+    if (!oldRow) {
+      throw new Error(
+        `supersedeProjection: projection ${oldProjectionId} not found`,
+      );
+    }
+
+    if (oldRow.invalidated_at !== null) {
+      throw new Error(
+        `supersedeProjection: projection ${oldProjectionId} is already invalidated`,
+      );
+    }
+
+    // Invalidate old projection FIRST so the unique constraint clears before insert.
+    // The unique index is partial: WHERE invalidated_at IS NULL.
+    graph.db
+      .prepare(
+        `UPDATE projections
+           SET invalidated_at = ?,
+               valid_until    = ?
+         WHERE id = ? AND invalidated_at IS NULL`,
+      )
+      .run(now, now, oldProjectionId);
+
+    const verifyRow = graph.db
+      .query<{ invalidated_at: string | null }, [string]>(
+        "SELECT invalidated_at FROM projections WHERE id = ?",
+      )
+      .get(oldProjectionId);
+
+    if (!verifyRow || verifyRow.invalidated_at === null) {
+      throw new Error(
+        `supersedeProjection: failed to invalidate projection ${oldProjectionId}`,
+      );
+    }
+
+    // Insert new projection (unique constraint is now clear)
+    graph.db
+      .prepare(
+        `INSERT INTO projections
+           (id, kind, anchor_type, anchor_id, title, body, body_format,
+            model, prompt_template_id, prompt_hash, input_fingerprint,
+            confidence, valid_from, valid_until, last_assessed_at,
+            invalidated_at, superseded_by, created_at, owner_id)
+         VALUES (?, ?, ?, ?, ?, ?, 'markdown', ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+      )
+      .run(
+        newId,
+        newData.kind,
+        newData.anchor_type,
+        newData.anchor_id,
+        newData.title,
+        newData.body,
+        newData.model,
+        newData.prompt_template_id,
+        newData.prompt_hash,
+        newData.input_fingerprint,
+        newData.confidence,
+        now,
+        now,
+        newData.owner_id,
+      );
+
+    // Point old projection to new one
+    graph.db
+      .prepare(`UPDATE projections SET superseded_by = ? WHERE id = ?`)
+      .run(newId, oldProjectionId);
+
+    // Insert evidence rows for new projection
+    const insertEvidence = graph.db.prepare(
+      `INSERT INTO projection_evidence
+         (projection_id, target_type, target_id, role, content_hash)
+       VALUES (?, ?, ?, 'input', ?)`,
+    );
+    for (const inp of resolvedInputs) {
+      insertEvidence.run(newId, inp.type, inp.id, inp.content_hash);
+    }
+
+    const newRow = graph.db
+      .query<Projection, [string]>("SELECT * FROM projections WHERE id = ?")
+      .get(newId);
+
+    if (!newRow) {
+      throw new Error(
+        `supersedeProjection: failed to retrieve new projection ${newId}`,
+      );
+    }
+
+    result.projection = newRow;
+  })();
+
+  if (!result.projection) {
+    throw new Error("supersedeProjection: transaction produced no result");
+  }
+
+  return result.projection;
+}
+
+/**
+ * Authors a new projection (or returns an existing idempotent match).
+ *
+ * Steps:
+ * 1. Resolve input set from substrate — reject if any missing or redacted.
+ * 2. Compute input_fingerprint.
+ * 3. Cycle check: if any input is type='projection', detect would-be cycles.
+ * 4. Check whether active projection exists for (anchor, kind):
+ *    - If yes and fingerprint matches → return existing (idempotent no-op).
+ *    - If yes with different fingerprint → supersede after generation.
+ * 5. Call generator.generate(inputs) → body with frontmatter.
+ * 6. Validate frontmatter.
+ * 7. Insert projections row + projection_evidence rows in a single transaction.
+ */
+export async function project(
+  graph: EngramGraph,
+  opts: ProjectionOpts,
+): Promise<Projection> {
+  const { kind, anchor, inputs, generator, owner_id } = opts;
+  const anchor_id = anchor.id ?? null;
+  const anchor_type = anchor.type;
+
+  // Step 1: Resolve inputs
+  const resolved = resolveInputs(graph, inputs);
+
+  // Step 2: Compute fingerprint
+  const fingerprint = computeFingerprint(resolved);
+
+  // Step 3: Cycle check for projection inputs
+  const projectionInputIds = inputs
+    .filter((i) => i.type === "projection")
+    .map((i) => i.id);
+
+  if (projectionInputIds.length > 0) {
+    // We need an ID for the would-be new projection to check cycles.
+    // Use a temporary placeholder for cycle detection — we check if any
+    // existing projection in the candidate input set can reach itself.
+    // Actually, since the new projection doesn't exist yet, we check if
+    // the anchor's existing active projection (if any) would be in the cycle.
+    const existingActive = graph.db
+      .query<{ id: string }, [string, string | null, string]>(
+        `SELECT id FROM projections
+          WHERE anchor_type = ? AND anchor_id IS ? AND kind = ?
+            AND invalidated_at IS NULL
+          LIMIT 1`,
+      )
+      .get(anchor_type, anchor_id, kind);
+
+    if (existingActive) {
+      const cycleInputId = detectProjectionCycle(
+        graph,
+        existingActive.id,
+        projectionInputIds,
+      );
+      if (cycleInputId) {
+        throw new ProjectionCycleError(cycleInputId);
+      }
+    }
+  }
+
+  // Step 4: Check for existing active projection
+  const existingProjection = graph.db
+    .query<Projection, [string, string | null, string]>(
+      `SELECT * FROM projections
+        WHERE anchor_type = ? AND anchor_id IS ? AND kind = ?
+          AND invalidated_at IS NULL
+        LIMIT 1`,
+    )
+    .get(anchor_type, anchor_id, kind);
+
+  if (
+    existingProjection &&
+    existingProjection.input_fingerprint === fingerprint
+  ) {
+    // Idempotent no-op: same inputs, same projection
+    return existingProjection;
+  }
+
+  // Step 5: Generate body
+  const generated = await generator.generate(resolved);
+
+  // Step 6: Validate frontmatter
+  validateFrontmatter(generated.body);
+
+  // Extract title and model from frontmatter (simple string extraction)
+  const title = extractFrontmatterValue(generated.body, "title") ?? kind;
+  const model = extractFrontmatterValue(generated.body, "model") ?? "unknown";
+  const prompt_template_id =
+    extractFrontmatterValue(generated.body, "prompt_template_id") ?? null;
+  const prompt_hash =
+    extractFrontmatterValue(generated.body, "prompt_hash") ?? null;
+
+  const newData = {
+    kind,
+    anchor_type,
+    anchor_id,
+    title,
+    body: generated.body,
+    model,
+    prompt_template_id,
+    prompt_hash,
+    input_fingerprint: fingerprint,
+    confidence: generated.confidence,
+    owner_id: owner_id ?? null,
+  };
+
+  // Step 7: Insert or supersede
+  if (existingProjection) {
+    // Fingerprint differs — supersede
+    return supersedeProjection(graph, existingProjection.id, newData, resolved);
+  }
+
+  // No existing projection — insert fresh
+  const newId = ulid();
+  const now = new Date().toISOString();
+  const result: { projection: Projection | null } = { projection: null };
+
+  graph.db.transaction(() => {
+    graph.db
+      .prepare(
+        `INSERT INTO projections
+           (id, kind, anchor_type, anchor_id, title, body, body_format,
+            model, prompt_template_id, prompt_hash, input_fingerprint,
+            confidence, valid_from, valid_until, last_assessed_at,
+            invalidated_at, superseded_by, created_at, owner_id)
+         VALUES (?, ?, ?, ?, ?, ?, 'markdown', ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+      )
+      .run(
+        newId,
+        kind,
+        anchor_type,
+        anchor_id,
+        title,
+        generated.body,
+        model,
+        prompt_template_id,
+        prompt_hash,
+        fingerprint,
+        generated.confidence,
+        now,
+        now,
+        owner_id ?? null,
+      );
+
+    const insertEvidence = graph.db.prepare(
+      `INSERT INTO projection_evidence
+         (projection_id, target_type, target_id, role, content_hash)
+       VALUES (?, ?, ?, 'input', ?)`,
+    );
+    for (const inp of resolved) {
+      insertEvidence.run(newId, inp.type, inp.id, inp.content_hash);
+    }
+
+    const row = graph.db
+      .query<Projection, [string]>("SELECT * FROM projections WHERE id = ?")
+      .get(newId);
+
+    if (!row) {
+      throw new Error(
+        `project: failed to retrieve inserted projection ${newId}`,
+      );
+    }
+
+    result.projection = row;
+  })();
+
+  if (!result.projection) {
+    throw new Error("project: transaction produced no result");
+  }
+
+  return result.projection;
+}
+
+/**
+ * Reads a projection by ID, computing the stale flag at read time.
+ */
+export function getProjection(
+  graph: EngramGraph,
+  id: string,
+): GetProjectionResult | null {
+  const projection = graph.db
+    .query<Projection, [string]>("SELECT * FROM projections WHERE id = ?")
+    .get(id);
+
+  if (!projection) return null;
+
+  // Compute current fingerprint and compare
+  const currentFingerprint = recomputeFingerprint(graph, id);
+  const stale = currentFingerprint !== projection.input_fingerprint;
+
+  let stale_reason: GetProjectionResult["stale_reason"];
+  if (stale) {
+    // Check if any input is missing (deleted/redacted)
+    const evidenceRows = graph.db
+      .query<ProjectionEvidenceRow, [string]>(
+        "SELECT * FROM projection_evidence WHERE projection_id = ? AND role = 'input'",
+      )
+      .all(id);
+
+    let hasDeleted = false;
+    for (const row of evidenceRows) {
+      switch (row.target_type) {
+        case "episode": {
+          const ep = graph.db
+            .query<{ status: string }, [string]>(
+              "SELECT status FROM episodes WHERE id = ?",
+            )
+            .get(row.target_id);
+          if (!ep || ep.status === "redacted") hasDeleted = true;
+          break;
+        }
+        case "projection": {
+          const proj = graph.db
+            .query<{ invalidated_at: string | null }, [string]>(
+              "SELECT invalidated_at FROM projections WHERE id = ?",
+            )
+            .get(row.target_id);
+          if (!proj || proj.invalidated_at !== null) hasDeleted = true;
+          break;
+        }
+      }
+    }
+
+    stale_reason = hasDeleted ? "input_deleted" : "input_content_changed";
+  }
+
+  return {
+    projection,
+    stale,
+    stale_reason,
+    last_assessed_at: projection.last_assessed_at,
+  };
+}
+
+/**
+ * Extracts a scalar value from a YAML frontmatter block.
+ * Handles: key: value and key: "value" and key: 'value'
+ */
+function extractFrontmatterValue(body: string, key: string): string | null {
+  const endIdx = body.indexOf("\n---", 4);
+  if (endIdx === -1) return null;
+  const frontmatter = body.slice(4, endIdx);
+
+  const regex = new RegExp(`^${key}:\\s*['"']?([^'"'\\n]+)['"']?\\s*$`, "m");
+  const match = frontmatter.match(regex);
+  if (!match) return null;
+  return match[1].trim().replace(/^["']|["']$/g, "");
+}

--- a/packages/engram-core/src/graph/projections.ts
+++ b/packages/engram-core/src/graph/projections.ts
@@ -4,6 +4,8 @@
  * Implements the explicit projection authoring primitive described in
  * docs/internal/specs/projections.md. A projection is an AI-authored synthesis
  * of substrate elements (episodes, entities, edges, or other projections).
+ *
+ * Types and error classes live in projections-types.ts.
  */
 
 import { createHash } from "node:crypto";
@@ -13,87 +15,34 @@ import type {
   ResolvedInput,
 } from "../ai/projection-generator.js";
 import type { EngramGraph } from "../format/index.js";
+import type {
+  AnchorType,
+  GetProjectionResult,
+  Projection,
+  ProjectionEvidenceRow,
+  ProjectionInput,
+  ProjectionOpts,
+} from "./projections-types.js";
+import {
+  ProjectionCycleError,
+  ProjectionFrontmatterError,
+  ProjectionInputMissingError,
+} from "./projections-types.js";
 
-// ─── Types ──────────────────────────────────────────────────────────────────
-
-export type AnchorType = "entity" | "edge" | "episode" | "projection" | "none";
-
-export type ProjectionInputType = "episode" | "entity" | "edge" | "projection";
-
-export interface ProjectionInput {
-  type: ProjectionInputType;
-  id: string;
-}
-
-export interface Projection {
-  id: string;
-  kind: string;
-  anchor_type: AnchorType;
-  anchor_id: string | null;
-  title: string;
-  body: string;
-  body_format: string;
-  model: string;
-  prompt_template_id: string | null;
-  prompt_hash: string | null;
-  input_fingerprint: string;
-  confidence: number;
-  valid_from: string;
-  valid_until: string | null;
-  last_assessed_at: string | null;
-  invalidated_at: string | null;
-  superseded_by: string | null;
-  created_at: string;
-  owner_id: string | null;
-}
-
-export interface ProjectionEvidenceRow {
-  projection_id: string;
-  target_type: string;
-  target_id: string;
-  role: string;
-  content_hash: string | null;
-}
-
-export interface ProjectionOpts {
-  kind: string;
-  anchor: { type: AnchorType; id?: string };
-  inputs: ProjectionInput[];
-  generator: ProjectionGenerator;
-  owner_id?: string;
-}
-
-export interface GetProjectionResult {
-  projection: Projection;
-  stale: boolean;
-  stale_reason?: "input_content_changed" | "input_deleted";
-  last_assessed_at: string | null;
-}
-
-// ─── Errors ─────────────────────────────────────────────────────────────────
-
-export class ProjectionCycleError extends Error {
-  constructor(inputId: string) {
-    super(
-      `project(): cycle detected — projection input ${inputId} would create a circular dependency`,
-    );
-    this.name = "ProjectionCycleError";
-  }
-}
-
-export class ProjectionInputMissingError extends Error {
-  constructor(type: string, id: string) {
-    super(`project(): input ${type}:${id} not found or is redacted`);
-    this.name = "ProjectionInputMissingError";
-  }
-}
-
-export class ProjectionFrontmatterError extends Error {
-  constructor(message: string) {
-    super(`project(): invalid frontmatter — ${message}`);
-    this.name = "ProjectionFrontmatterError";
-  }
-}
+export type {
+  AnchorType,
+  GetProjectionResult,
+  Projection,
+  ProjectionEvidenceRow,
+  ProjectionInput,
+  ProjectionInputType,
+  ProjectionOpts,
+} from "./projections-types.js";
+export {
+  ProjectionCycleError,
+  ProjectionFrontmatterError,
+  ProjectionInputMissingError,
+} from "./projections-types.js";
 
 // ─── Required frontmatter keys ───────────────────────────────────────────────
 
@@ -108,12 +57,8 @@ const REQUIRED_FRONTMATTER_KEYS = [
   "inputs",
 ] as const;
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+// ─── Internal helpers ─────────────────────────────────────────────────────────
 
-/**
- * Resolves input rows from the substrate. Returns ResolvedInput[] or throws
- * ProjectionInputMissingError if any input is missing or redacted.
- */
 function resolveInputs(
   graph: EngramGraph,
   inputs: ProjectionInput[],
@@ -174,7 +119,7 @@ function resolveInputs(
             [string]
           >("SELECT id, fact, invalidated_at FROM edges WHERE id = ?")
           .get(input.id);
-        if (!row) {
+        if (!row || row.invalidated_at !== null) {
           throw new ProjectionInputMissingError(input.type, input.id);
         }
         content = row.fact;
@@ -206,9 +151,6 @@ function resolveInputs(
   return resolved;
 }
 
-/**
- * Computes the input_fingerprint as sha256 over sorted "type:id:content_hash" entries.
- */
 function computeFingerprint(resolved: ResolvedInput[]): string {
   const entries = resolved
     .map((r) => `${r.type}:${r.id}:${r.content_hash ?? ""}`)
@@ -216,10 +158,6 @@ function computeFingerprint(resolved: ResolvedInput[]): string {
   return createHash("sha256").update(entries.join("\n")).digest("hex");
 }
 
-/**
- * Recomputes the current fingerprint for an existing projection by reading
- * current content hashes from the substrate.
- */
 function recomputeFingerprint(
   graph: EngramGraph,
   projectionId: string,
@@ -252,8 +190,8 @@ function recomputeFingerprint(
           )
           .get(row.target_id);
         if (ent) {
-          const content = `${ent.canonical_name}${ent.summary ? `: ${ent.summary}` : ""}`;
-          currentHash = createHash("sha256").update(content).digest("hex");
+          const c = `${ent.canonical_name}${ent.summary ? `: ${ent.summary}` : ""}`;
+          currentHash = createHash("sha256").update(c).digest("hex");
         }
         break;
       }
@@ -263,9 +201,8 @@ function recomputeFingerprint(
             "SELECT fact FROM edges WHERE id = ?",
           )
           .get(row.target_id);
-        if (edge) {
+        if (edge)
           currentHash = createHash("sha256").update(edge.fact).digest("hex");
-        }
         break;
       }
       case "projection": {
@@ -288,18 +225,6 @@ function recomputeFingerprint(
   return createHash("sha256").update(entries.join("\n")).digest("hex");
 }
 
-/**
- * Detects if adding a dependency on any of `inputIds` would create a cycle in the
- * projection dependency graph.
- *
- * A cycle would occur if any projection in the transitive dependency set of the
- * candidate inputs is the same as `targetProjectionId` (the existing projection
- * that is about to be superseded, which the new projection would conceptually replace).
- *
- * Uses a recursive CTE to walk DOWNWARD from each projection input (following
- * their evidence targets where target_type='projection'), checking whether
- * `targetProjectionId` is reachable.
- */
 function detectProjectionCycle(
   graph: EngramGraph,
   targetProjectionId: string,
@@ -307,8 +232,6 @@ function detectProjectionCycle(
 ): string | null {
   if (inputIds.length === 0) return null;
 
-  // Walk the dependency tree downward from each projection input.
-  // If we reach targetProjectionId, adding this dependency would form a cycle.
   for (const inputId of inputIds) {
     const cycleRow = graph.db
       .query<{ id: string }, [string, string]>(
@@ -325,50 +248,46 @@ function detectProjectionCycle(
       )
       .get(inputId, targetProjectionId);
 
-    if (cycleRow) {
-      return inputId;
-    }
+    if (cycleRow) return inputId;
   }
 
   return null;
 }
 
-/**
- * Validates that the body frontmatter contains all required keys.
- * This is a simple YAML frontmatter check — not a full YAML parser.
- */
 function validateFrontmatter(body: string): void {
   if (!body.startsWith("---\n")) {
     throw new ProjectionFrontmatterError(
       "body must begin with YAML frontmatter block (---)",
     );
   }
-
   const endIdx = body.indexOf("\n---", 4);
   if (endIdx === -1) {
     throw new ProjectionFrontmatterError("frontmatter block is not closed");
   }
-
   const frontmatter = body.slice(4, endIdx);
-
   for (const key of REQUIRED_FRONTMATTER_KEYS) {
-    // Accept "key:" or "key: " patterns
     if (!frontmatter.includes(`${key}:`)) {
       throw new ProjectionFrontmatterError(`missing required key: ${key}`);
     }
   }
 }
 
+function extractFrontmatterValue(body: string, key: string): string | null {
+  const endIdx = body.indexOf("\n---", 4);
+  if (endIdx === -1) return null;
+  const frontmatter = body.slice(4, endIdx);
+  const safeKey = key.replace(/[^a-zA-Z0-9_]/g, "");
+  const regex = new RegExp(`^${safeKey}:\\s*["']?([^"'\\n]+?)["']?\\s*$`, "m");
+  const match = frontmatter.match(regex);
+  if (!match) return null;
+  return match[1].trim().replace(/^["']|["']$/g, "");
+}
+
 // ─── Core operations ─────────────────────────────────────────────────────────
 
 /**
  * Supersedes an existing projection with a new one atomically.
- *
- * In one transaction:
- * 1. UPDATE old projection: set invalidated_at, valid_until, superseded_by
- * 2. INSERT new projection row + evidence rows
- *
- * Returns the new projection.
+ * Invalidates the old row and inserts the new one in a single transaction.
  */
 export function supersedeProjection(
   graph: EngramGraph,
@@ -402,37 +321,22 @@ export function supersedeProjection(
         `supersedeProjection: projection ${oldProjectionId} not found`,
       );
     }
-
     if (oldRow.invalidated_at !== null) {
       throw new Error(
         `supersedeProjection: projection ${oldProjectionId} is already invalidated`,
       );
     }
 
-    // Invalidate old projection FIRST so the unique constraint clears before insert.
-    // The unique index is partial: WHERE invalidated_at IS NULL.
+    // Invalidate old FIRST so the partial unique index clears before INSERT.
     graph.db
       .prepare(
         `UPDATE projections
-           SET invalidated_at = ?,
-               valid_until    = ?
+           SET invalidated_at = ?, valid_until = ?
          WHERE id = ? AND invalidated_at IS NULL`,
       )
       .run(now, now, oldProjectionId);
 
-    const verifyRow = graph.db
-      .query<{ invalidated_at: string | null }, [string]>(
-        "SELECT invalidated_at FROM projections WHERE id = ?",
-      )
-      .get(oldProjectionId);
-
-    if (!verifyRow || verifyRow.invalidated_at === null) {
-      throw new Error(
-        `supersedeProjection: failed to invalidate projection ${oldProjectionId}`,
-      );
-    }
-
-    // Insert new projection (unique constraint is now clear)
+    // Insert new projection
     graph.db
       .prepare(
         `INSERT INTO projections
@@ -459,7 +363,7 @@ export function supersedeProjection(
         newData.owner_id,
       );
 
-    // Point old projection to new one
+    // Point old → new
     graph.db
       .prepare(`UPDATE projections SET superseded_by = ? WHERE id = ?`)
       .run(newId, oldProjectionId);
@@ -474,39 +378,18 @@ export function supersedeProjection(
       insertEvidence.run(newId, inp.type, inp.id, inp.content_hash);
     }
 
-    const newRow = graph.db
+    result.projection = graph.db
       .query<Projection, [string]>("SELECT * FROM projections WHERE id = ?")
       .get(newId);
-
-    if (!newRow) {
-      throw new Error(
-        `supersedeProjection: failed to retrieve new projection ${newId}`,
-      );
-    }
-
-    result.projection = newRow;
   })();
 
-  if (!result.projection) {
+  if (!result.projection)
     throw new Error("supersedeProjection: transaction produced no result");
-  }
-
   return result.projection;
 }
 
 /**
  * Authors a new projection (or returns an existing idempotent match).
- *
- * Steps:
- * 1. Resolve input set from substrate — reject if any missing or redacted.
- * 2. Compute input_fingerprint.
- * 3. Cycle check: if any input is type='projection', detect would-be cycles.
- * 4. Check whether active projection exists for (anchor, kind):
- *    - If yes and fingerprint matches → return existing (idempotent no-op).
- *    - If yes with different fingerprint → supersede after generation.
- * 5. Call generator.generate(inputs) → body with frontmatter.
- * 6. Validate frontmatter.
- * 7. Insert projections row + projection_evidence rows in a single transaction.
  */
 export async function project(
   graph: EngramGraph,
@@ -516,23 +399,15 @@ export async function project(
   const anchor_id = anchor.id ?? null;
   const anchor_type = anchor.type;
 
-  // Step 1: Resolve inputs
   const resolved = resolveInputs(graph, inputs);
-
-  // Step 2: Compute fingerprint
   const fingerprint = computeFingerprint(resolved);
 
-  // Step 3: Cycle check for projection inputs
+  // Cycle check for projection inputs
   const projectionInputIds = inputs
     .filter((i) => i.type === "projection")
     .map((i) => i.id);
 
   if (projectionInputIds.length > 0) {
-    // We need an ID for the would-be new projection to check cycles.
-    // Use a temporary placeholder for cycle detection — we check if any
-    // existing projection in the candidate input set can reach itself.
-    // Actually, since the new projection doesn't exist yet, we check if
-    // the anchor's existing active projection (if any) would be in the cycle.
     const existingActive = graph.db
       .query<{ id: string }, [string, string | null, string]>(
         `SELECT id FROM projections
@@ -548,13 +423,11 @@ export async function project(
         existingActive.id,
         projectionInputIds,
       );
-      if (cycleInputId) {
-        throw new ProjectionCycleError(cycleInputId);
-      }
+      if (cycleInputId) throw new ProjectionCycleError(cycleInputId);
     }
   }
 
-  // Step 4: Check for existing active projection
+  // Check for existing active projection
   const existingProjection = graph.db
     .query<Projection, [string, string | null, string]>(
       `SELECT * FROM projections
@@ -568,17 +441,12 @@ export async function project(
     existingProjection &&
     existingProjection.input_fingerprint === fingerprint
   ) {
-    // Idempotent no-op: same inputs, same projection
-    return existingProjection;
+    return existingProjection; // idempotent no-op
   }
 
-  // Step 5: Generate body
   const generated = await generator.generate(resolved);
-
-  // Step 6: Validate frontmatter
   validateFrontmatter(generated.body);
 
-  // Extract title and model from frontmatter (simple string extraction)
   const title = extractFrontmatterValue(generated.body, "title") ?? kind;
   const model = extractFrontmatterValue(generated.body, "model") ?? "unknown";
   const prompt_template_id =
@@ -600,18 +468,32 @@ export async function project(
     owner_id: owner_id ?? null,
   };
 
-  // Step 7: Insert or supersede
   if (existingProjection) {
-    // Fingerprint differs — supersede
     return supersedeProjection(graph, existingProjection.id, newData, resolved);
   }
 
-  // No existing projection — insert fresh
+  // Insert fresh projection
   const newId = ulid();
   const now = new Date().toISOString();
   const result: { projection: Projection | null } = { projection: null };
 
   graph.db.transaction(() => {
+    // Application-level uniqueness guard: SQLite's partial UNIQUE index does not
+    // enforce uniqueness when anchor_id IS NULL (each NULL is treated as distinct).
+    const duplicate = graph.db
+      .query<{ id: string }, [string, string | null, string]>(
+        `SELECT id FROM projections
+          WHERE anchor_type = ? AND anchor_id IS ? AND kind = ?
+            AND invalidated_at IS NULL
+          LIMIT 1`,
+      )
+      .get(anchor_type, anchor_id, kind);
+    if (duplicate) {
+      throw new Error(
+        `project: active projection already exists for (${anchor_type}, ${anchor_id ?? "null"}, ${kind})`,
+      );
+    }
+
     graph.db
       .prepare(
         `INSERT INTO projections
@@ -647,23 +529,13 @@ export async function project(
       insertEvidence.run(newId, inp.type, inp.id, inp.content_hash);
     }
 
-    const row = graph.db
+    result.projection = graph.db
       .query<Projection, [string]>("SELECT * FROM projections WHERE id = ?")
       .get(newId);
-
-    if (!row) {
-      throw new Error(
-        `project: failed to retrieve inserted projection ${newId}`,
-      );
-    }
-
-    result.projection = row;
   })();
 
-  if (!result.projection) {
+  if (!result.projection)
     throw new Error("project: transaction produced no result");
-  }
-
   return result.projection;
 }
 
@@ -680,13 +552,11 @@ export function getProjection(
 
   if (!projection) return null;
 
-  // Compute current fingerprint and compare
   const currentFingerprint = recomputeFingerprint(graph, id);
   const stale = currentFingerprint !== projection.input_fingerprint;
 
   let stale_reason: GetProjectionResult["stale_reason"];
   if (stale) {
-    // Check if any input is missing (deleted/redacted)
     const evidenceRows = graph.db
       .query<ProjectionEvidenceRow, [string]>(
         "SELECT * FROM projection_evidence WHERE projection_id = ? AND role = 'input'",
@@ -695,25 +565,20 @@ export function getProjection(
 
     let hasDeleted = false;
     for (const row of evidenceRows) {
-      switch (row.target_type) {
-        case "episode": {
-          const ep = graph.db
-            .query<{ status: string }, [string]>(
-              "SELECT status FROM episodes WHERE id = ?",
-            )
-            .get(row.target_id);
-          if (!ep || ep.status === "redacted") hasDeleted = true;
-          break;
-        }
-        case "projection": {
-          const proj = graph.db
-            .query<{ invalidated_at: string | null }, [string]>(
-              "SELECT invalidated_at FROM projections WHERE id = ?",
-            )
-            .get(row.target_id);
-          if (!proj || proj.invalidated_at !== null) hasDeleted = true;
-          break;
-        }
+      if (row.target_type === "episode") {
+        const ep = graph.db
+          .query<{ status: string }, [string]>(
+            "SELECT status FROM episodes WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (!ep || ep.status === "redacted") hasDeleted = true;
+      } else if (row.target_type === "projection") {
+        const proj = graph.db
+          .query<{ invalidated_at: string | null }, [string]>(
+            "SELECT invalidated_at FROM projections WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (!proj || proj.invalidated_at !== null) hasDeleted = true;
       }
     }
 
@@ -726,19 +591,4 @@ export function getProjection(
     stale_reason,
     last_assessed_at: projection.last_assessed_at,
   };
-}
-
-/**
- * Extracts a scalar value from a YAML frontmatter block.
- * Handles: key: value and key: "value" and key: 'value'
- */
-function extractFrontmatterValue(body: string, key: string): string | null {
-  const endIdx = body.indexOf("\n---", 4);
-  if (endIdx === -1) return null;
-  const frontmatter = body.slice(4, endIdx);
-
-  const regex = new RegExp(`^${key}:\\s*['"']?([^'"'\\n]+)['"']?\\s*$`, "m");
-  const match = frontmatter.match(regex);
-  if (!match) return null;
-  return match[1].trim().replace(/^["']|["']$/g, "");
 }

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -12,6 +12,15 @@ export {
   OllamaProvider,
 } from "./ai/index.js";
 export type {
+  AssessVerdict,
+  ProjectionGenerator,
+  ResolvedInput,
+} from "./ai/projection-generator.js";
+export {
+  AnthropicGenerator,
+  NullGenerator,
+} from "./ai/projection-generator.js";
+export type {
   CreateOpts,
   EngramGraph,
   VerifyResult,
@@ -36,6 +45,7 @@ export {
 export type {
   Alias,
   AliasInput,
+  AnchorType,
   Edge,
   EdgeInput,
   EmbeddingTargetType,
@@ -48,6 +58,12 @@ export type {
   FindEdgesQuery,
   FindEntitiesQuery,
   FindSimilarOpts,
+  GetProjectionResult,
+  Projection,
+  ProjectionEvidenceRow,
+  ProjectionInput,
+  ProjectionInputType,
+  ProjectionOpts,
   SimilarResult,
   StoredEmbedding,
 } from "./graph/index.js";
@@ -68,8 +84,14 @@ export {
   getEpisode,
   getEvidenceForEdge,
   getEvidenceForEntity,
+  getProjection,
+  ProjectionCycleError,
+  ProjectionFrontmatterError,
+  ProjectionInputMissingError,
+  project,
   resolveEntity,
   storeEmbedding,
+  supersedeProjection,
 } from "./graph/index.js";
 export type { EnrichmentAdapter, EnrichOpts } from "./ingest/adapter.js";
 export { GitHubAdapter } from "./ingest/adapters/github.js";

--- a/packages/engram-core/test/graph/projections.test.ts
+++ b/packages/engram-core/test/graph/projections.test.ts
@@ -1,0 +1,686 @@
+/**
+ * projections.test.ts — tests for project(), supersedeProjection(), and getProjection().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type {
+  AssessVerdict,
+  EngramGraph,
+  Projection,
+  ProjectionGenerator,
+  ResolvedInput,
+} from "../../src/index.js";
+import {
+  addEpisode,
+  closeGraph,
+  createGraph,
+  getProjection,
+  NullGenerator,
+  ProjectionCycleError,
+  ProjectionFrontmatterError,
+  ProjectionInputMissingError,
+  project,
+  supersedeProjection,
+} from "../../src/index.js";
+
+// ─── Mock generator ───────────────────────────────────────────────────────────
+
+function makeMockGenerator(opts?: {
+  body?: string;
+  confidence?: number;
+  assessVerdict?: AssessVerdict;
+  fail?: boolean;
+}): ProjectionGenerator {
+  return {
+    async generate(
+      inputs: ResolvedInput[],
+    ): Promise<{ body: string; confidence: number }> {
+      if (opts?.fail) throw new Error("generator failure");
+
+      const inputList = inputs.map((i) => `  - ${i.type}:${i.id}`).join("\n");
+      const now = new Date().toISOString();
+
+      const body =
+        opts?.body ??
+        `---\n` +
+          `id: test-id\n` +
+          `kind: entity_summary\n` +
+          `anchor: entity:test\n` +
+          `title: "Test Projection"\n` +
+          `model: mock\n` +
+          `prompt_template_id: test.v1\n` +
+          `prompt_hash: testhash\n` +
+          `input_fingerprint: testfingerprint\n` +
+          `valid_from: ${now}\n` +
+          `valid_until: null\n` +
+          `inputs:\n${inputList || "  []"}\n` +
+          `---\n\n` +
+          `# Test Projection\n\nContent here.\n`;
+
+      return { body, confidence: opts?.confidence ?? 1.0 };
+    },
+
+    async assess(
+      _projection: Projection,
+      _currentInputs: ResolvedInput[],
+    ): Promise<AssessVerdict> {
+      return opts?.assessVerdict ?? { verdict: "still_accurate" };
+    },
+
+    async regenerate(
+      _projection: Projection,
+      inputs: ResolvedInput[],
+    ): Promise<{ body: string; confidence: number }> {
+      return this.generate(inputs);
+    },
+  };
+}
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+function makeEpisode(content = "test content") {
+  return addEpisode(graph, {
+    source_type: "manual",
+    content,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+// ─── NullGenerator ────────────────────────────────────────────────────────────
+
+describe("NullGenerator", () => {
+  test("generate() throws with a helpful error message", async () => {
+    const gen = new NullGenerator();
+    await expect(gen.generate([])).rejects.toThrow("no AI provider configured");
+  });
+
+  test("assess() throws", async () => {
+    const gen = new NullGenerator();
+    const fakeProjection = {} as Projection;
+    await expect(gen.assess(fakeProjection, [])).rejects.toThrow(
+      "no AI provider configured",
+    );
+  });
+
+  test("regenerate() throws", async () => {
+    const gen = new NullGenerator();
+    const fakeProjection = {} as Projection;
+    await expect(gen.regenerate(fakeProjection, [])).rejects.toThrow(
+      "no AI provider configured",
+    );
+  });
+
+  test("project() with NullGenerator throws on generate()", async () => {
+    const ep = makeEpisode();
+    await expect(
+      project(graph, {
+        kind: "entity_summary",
+        anchor: { type: "none" },
+        inputs: [{ type: "episode", id: ep.id }],
+        generator: new NullGenerator(),
+      }),
+    ).rejects.toThrow("no AI provider configured");
+  });
+});
+
+// ─── project() — basic creation ───────────────────────────────────────────────
+
+describe("project() — basic creation", () => {
+  test("creates a projection and evidence rows", async () => {
+    const ep = makeEpisode("The auth module handles login.");
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    expect(proj.id).toBeDefined();
+    expect(proj.kind).toBe("entity_summary");
+    expect(proj.anchor_type).toBe("none");
+    expect(proj.anchor_id).toBeNull();
+    expect(proj.body).toContain("# Test Projection");
+    expect(proj.invalidated_at).toBeNull();
+    expect(proj.valid_from).toBeDefined();
+    expect(proj.input_fingerprint).toBeDefined();
+    expect(proj.confidence).toBe(1.0);
+
+    // Verify evidence rows were created
+    const evidenceRows = graph.db
+      .query<{ target_type: string; target_id: string }, [string]>(
+        "SELECT target_type, target_id FROM projection_evidence WHERE projection_id = ?",
+      )
+      .all(proj.id);
+
+    expect(evidenceRows.length).toBe(1);
+    expect(evidenceRows[0].target_type).toBe("episode");
+    expect(evidenceRows[0].target_id).toBe(ep.id);
+  });
+
+  test("creates projection with entity anchor", async () => {
+    const ep = makeEpisode();
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "entity", id: "entity-abc" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    expect(proj.anchor_type).toBe("entity");
+    expect(proj.anchor_id).toBe("entity-abc");
+  });
+
+  test("creates projection with multiple inputs", async () => {
+    const ep1 = makeEpisode("First episode");
+    const ep2 = makeEpisode("Second episode");
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [
+        { type: "episode", id: ep1.id },
+        { type: "episode", id: ep2.id },
+      ],
+      generator: gen,
+    });
+
+    const evidenceRows = graph.db
+      .query<{ target_id: string }, [string]>(
+        "SELECT target_id FROM projection_evidence WHERE projection_id = ? ORDER BY target_id",
+      )
+      .all(proj.id);
+
+    expect(evidenceRows.length).toBe(2);
+  });
+});
+
+// ─── project() — idempotency ──────────────────────────────────────────────────
+
+describe("project() — idempotency", () => {
+  test("returns existing projection when fingerprint matches", async () => {
+    const ep = makeEpisode();
+    const gen = makeMockGenerator();
+
+    const proj1 = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    const proj2 = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    expect(proj2.id).toBe(proj1.id);
+
+    // Should still be exactly one active projection
+    const rows = graph.db
+      .query<{ id: string }, []>(
+        "SELECT id FROM projections WHERE invalidated_at IS NULL",
+      )
+      .all();
+    expect(rows.length).toBe(1);
+  });
+
+  test("returns same projection for same anchor+kind+inputs", async () => {
+    const ep = makeEpisode("stable content");
+    const gen = makeMockGenerator();
+
+    const proj1 = await project(graph, {
+      kind: "decision_page",
+      anchor: { type: "entity", id: "ent-1" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    // Call again with identical opts
+    const proj2 = await project(graph, {
+      kind: "decision_page",
+      anchor: { type: "entity", id: "ent-1" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    expect(proj2.id).toBe(proj1.id);
+    expect(proj2.valid_from).toBe(proj1.valid_from);
+  });
+});
+
+// ─── project() — supersession ─────────────────────────────────────────────────
+
+describe("project() — supersession when fingerprint changes", () => {
+  test("supersedes when a new input is added", async () => {
+    const ep1 = makeEpisode("First content");
+    const gen = makeMockGenerator();
+
+    const proj1 = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "entity", id: "ent-x" },
+      inputs: [{ type: "episode", id: ep1.id }],
+      generator: gen,
+    });
+
+    // Add a second episode — different fingerprint
+    const ep2 = makeEpisode("Second content");
+
+    const proj2 = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "entity", id: "ent-x" },
+      inputs: [
+        { type: "episode", id: ep1.id },
+        { type: "episode", id: ep2.id },
+      ],
+      generator: gen,
+    });
+
+    expect(proj2.id).not.toBe(proj1.id);
+
+    // Old projection must be invalidated
+    const oldRow = graph.db
+      .query<
+        { invalidated_at: string | null; superseded_by: string | null },
+        [string]
+      >("SELECT invalidated_at, superseded_by FROM projections WHERE id = ?")
+      .get(proj1.id);
+
+    expect(oldRow?.invalidated_at).not.toBeNull();
+    expect(oldRow?.superseded_by).toBe(proj2.id);
+
+    // Only one active projection
+    const activeRows = graph.db
+      .query<{ id: string }, []>(
+        "SELECT id FROM projections WHERE invalidated_at IS NULL",
+      )
+      .all();
+    expect(activeRows.length).toBe(1);
+    expect(activeRows[0].id).toBe(proj2.id);
+  });
+});
+
+// ─── project() — missing inputs ───────────────────────────────────────────────
+
+describe("project() — missing inputs", () => {
+  test("throws ProjectionInputMissingError for unknown episode", async () => {
+    const gen = makeMockGenerator();
+
+    await expect(
+      project(graph, {
+        kind: "entity_summary",
+        anchor: { type: "none" },
+        inputs: [{ type: "episode", id: "nonexistent-id" }],
+        generator: gen,
+      }),
+    ).rejects.toThrow(ProjectionInputMissingError);
+  });
+
+  test("throws ProjectionInputMissingError for redacted episode", async () => {
+    const ep = makeEpisode("sensitive content");
+    // Redact the episode
+    graph.db.run("UPDATE episodes SET status = 'redacted' WHERE id = ?", [
+      ep.id,
+    ]);
+
+    const gen = makeMockGenerator();
+
+    await expect(
+      project(graph, {
+        kind: "entity_summary",
+        anchor: { type: "none" },
+        inputs: [{ type: "episode", id: ep.id }],
+        generator: gen,
+      }),
+    ).rejects.toThrow(ProjectionInputMissingError);
+  });
+
+  test("throws ProjectionInputMissingError for unknown projection input", async () => {
+    const gen = makeMockGenerator();
+
+    await expect(
+      project(graph, {
+        kind: "entity_summary",
+        anchor: { type: "none" },
+        inputs: [{ type: "projection", id: "nonexistent-projection" }],
+        generator: gen,
+      }),
+    ).rejects.toThrow(ProjectionInputMissingError);
+  });
+});
+
+// ─── project() — frontmatter validation ──────────────────────────────────────
+
+describe("project() — frontmatter validation", () => {
+  test("throws ProjectionFrontmatterError if body lacks frontmatter", async () => {
+    const ep = makeEpisode();
+    const gen = makeMockGenerator({ body: "# No frontmatter here\n" });
+
+    await expect(
+      project(graph, {
+        kind: "entity_summary",
+        anchor: { type: "none" },
+        inputs: [{ type: "episode", id: ep.id }],
+        generator: gen,
+      }),
+    ).rejects.toThrow(ProjectionFrontmatterError);
+  });
+
+  test("throws ProjectionFrontmatterError if required key is missing", async () => {
+    const ep = makeEpisode();
+    // Missing 'inputs' key
+    const badBody =
+      `---\n` +
+      `id: test-id\n` +
+      `kind: entity_summary\n` +
+      `anchor: none\n` +
+      `title: "Test"\n` +
+      `model: mock\n` +
+      `input_fingerprint: fp\n` +
+      `valid_from: 2026-01-01T00:00:00Z\n` +
+      `---\n\n# Content\n`;
+    const gen = makeMockGenerator({ body: badBody });
+
+    await expect(
+      project(graph, {
+        kind: "entity_summary",
+        anchor: { type: "none" },
+        inputs: [{ type: "episode", id: ep.id }],
+        generator: gen,
+      }),
+    ).rejects.toThrow(ProjectionFrontmatterError);
+  });
+});
+
+// ─── project() — cycle detection ─────────────────────────────────────────────
+
+describe("project() — cycle detection", () => {
+  test("detects cycle: projection A → projection B → projection A", async () => {
+    const ep = makeEpisode("base content");
+    const gen = makeMockGenerator();
+
+    // Create projection A (anchored to "ent-a")
+    const projA = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "entity", id: "ent-a" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    // Create projection B which depends on projection A
+    const projB = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "entity", id: "ent-b" },
+      inputs: [{ type: "projection", id: projA.id }],
+      generator: gen,
+    });
+
+    // Now try to create projection A with projection B as input — this would create a cycle
+    await expect(
+      project(graph, {
+        kind: "entity_summary",
+        anchor: { type: "entity", id: "ent-a" },
+        inputs: [{ type: "projection", id: projB.id }],
+        generator: gen,
+      }),
+    ).rejects.toThrow(ProjectionCycleError);
+  });
+});
+
+// ─── supersedeProjection() ────────────────────────────────────────────────────
+
+describe("supersedeProjection()", () => {
+  test("sets invalidated_at, valid_until, superseded_by on old projection", async () => {
+    const ep = makeEpisode();
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "entity", id: "ent-1" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    const ep2 = makeEpisode("new content");
+    const newResolved: ResolvedInput[] = [
+      {
+        type: "episode",
+        id: ep2.id,
+        content: "new content",
+        content_hash: "abc",
+      },
+    ];
+    const newData = {
+      kind: "entity_summary",
+      anchor_type: "entity" as const,
+      anchor_id: "ent-1",
+      title: "Updated Projection",
+      body:
+        `---\n` +
+        `id: new-id\n` +
+        `kind: entity_summary\n` +
+        `anchor: entity:ent-1\n` +
+        `title: "Updated Projection"\n` +
+        `model: mock\n` +
+        `prompt_template_id: test.v1\n` +
+        `prompt_hash: hash2\n` +
+        `input_fingerprint: fp2\n` +
+        `valid_from: 2026-01-02T00:00:00Z\n` +
+        `valid_until: null\n` +
+        `inputs:\n  - episode:${ep2.id}\n` +
+        `---\n\n# Updated\n`,
+      model: "mock",
+      prompt_template_id: "test.v1",
+      prompt_hash: "hash2",
+      input_fingerprint: "fp2",
+      confidence: 0.9,
+      owner_id: null,
+    };
+
+    const newProj = supersedeProjection(graph, proj.id, newData, newResolved);
+
+    expect(newProj.id).not.toBe(proj.id);
+
+    // Verify old projection is invalidated
+    const oldRow = graph.db
+      .query<
+        {
+          invalidated_at: string | null;
+          valid_until: string | null;
+          superseded_by: string | null;
+        },
+        [string]
+      >(
+        "SELECT invalidated_at, valid_until, superseded_by FROM projections WHERE id = ?",
+      )
+      .get(proj.id);
+
+    expect(oldRow?.invalidated_at).not.toBeNull();
+    expect(oldRow?.valid_until).not.toBeNull();
+    expect(oldRow?.superseded_by).toBe(newProj.id);
+
+    // New projection is active
+    expect(newProj.invalidated_at).toBeNull();
+    expect(newProj.superseded_by).toBeNull();
+  });
+
+  test("throws if old projection does not exist", () => {
+    const ep: ResolvedInput = {
+      type: "episode",
+      id: "fake",
+      content: "x",
+      content_hash: "hash",
+    };
+    expect(() =>
+      supersedeProjection(
+        graph,
+        "nonexistent-projection",
+        {
+          kind: "k",
+          anchor_type: "none",
+          anchor_id: null,
+          title: "T",
+          body: "---\nid: x\nkind: k\nanchor: none\ntitle: T\nmodel: m\ninput_fingerprint: f\nvalid_from: 2026-01-01T00:00:00Z\ninputs:\n  []\n---\n",
+          model: "m",
+          prompt_template_id: null,
+          prompt_hash: null,
+          input_fingerprint: "f",
+          confidence: 1.0,
+          owner_id: null,
+        },
+        [ep],
+      ),
+    ).toThrow("not found");
+  });
+
+  test("throws if old projection is already invalidated", async () => {
+    const ep = makeEpisode();
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    // Manually invalidate
+    graph.db.run("UPDATE projections SET invalidated_at = ? WHERE id = ?", [
+      new Date().toISOString(),
+      proj.id,
+    ]);
+
+    const resolved: ResolvedInput[] = [
+      { type: "episode", id: ep.id, content: "content", content_hash: "hash" },
+    ];
+
+    expect(() =>
+      supersedeProjection(
+        graph,
+        proj.id,
+        {
+          kind: "entity_summary",
+          anchor_type: "none",
+          anchor_id: null,
+          title: "New",
+          body:
+            `---\nid: new\nkind: entity_summary\nanchor: none\ntitle: "New"\n` +
+            `model: mock\nprompt_template_id: null\nprompt_hash: null\n` +
+            `input_fingerprint: fp2\nvalid_from: 2026-01-01T00:00:00Z\nvalid_until: null\n` +
+            `inputs:\n  - episode:${ep.id}\n---\n\n# New\n`,
+          model: "mock",
+          prompt_template_id: null,
+          prompt_hash: null,
+          input_fingerprint: "fp2",
+          confidence: 1.0,
+          owner_id: null,
+        },
+        resolved,
+      ),
+    ).toThrow("already invalidated");
+  });
+});
+
+// ─── getProjection() — stale detection ───────────────────────────────────────
+
+describe("getProjection() — stale detection", () => {
+  test("returns stale=false when inputs have not changed", async () => {
+    const ep = makeEpisode("stable content");
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    const result = getProjection(graph, proj.id);
+    expect(result).not.toBeNull();
+    expect(result?.stale).toBe(false);
+    expect(result?.stale_reason).toBeUndefined();
+  });
+
+  test("returns stale=true with input_content_changed when episode content changes", async () => {
+    const ep = makeEpisode("original content");
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    // Update episode content hash directly (simulating a content change)
+    const { createHash } = await import("node:crypto");
+    const newHash = createHash("sha256")
+      .update("updated content")
+      .digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'updated content', content_hash = ? WHERE id = ?",
+      [newHash, ep.id],
+    );
+
+    const result = getProjection(graph, proj.id);
+    expect(result?.stale).toBe(true);
+    expect(result?.stale_reason).toBe("input_content_changed");
+  });
+
+  test("returns stale=true with input_deleted when episode is redacted", async () => {
+    const ep = makeEpisode("sensitive content");
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    // Redact the episode
+    graph.db.run("UPDATE episodes SET status = 'redacted' WHERE id = ?", [
+      ep.id,
+    ]);
+
+    const result = getProjection(graph, proj.id);
+    expect(result?.stale).toBe(true);
+    expect(result?.stale_reason).toBe("input_deleted");
+  });
+
+  test("returns null for nonexistent projection", () => {
+    const result = getProjection(graph, "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("returns projection with last_assessed_at", async () => {
+    const ep = makeEpisode();
+    const gen = makeMockGenerator();
+
+    const proj = await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: gen,
+    });
+
+    const result = getProjection(graph, proj.id);
+    expect(result?.last_assessed_at).toBeNull(); // Not yet assessed
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the `project()` authoring primitive from the projection layer spec (ADR-002, `docs/internal/specs/projections.md`)
- Adds `ProjectionGenerator` interface with `NullGenerator` and `AnthropicGenerator` stub in `packages/engram-core/src/ai/projection-generator.ts`
- Adds `project()`, `supersedeProjection()`, `getProjection()` and error types in `packages/engram-core/src/graph/projections.ts`
- Exports all new types and functions from the public API (`packages/engram-core/src/index.ts`)

## Key behaviors

- **Idempotent**: returns the existing projection when `(anchor, kind, input_fingerprint)` match
- **Supersession**: atomically invalidates the old projection and inserts the new one when fingerprint differs (old-first ordering to satisfy the partial unique index)
- **Cycle detection**: recursive CTE walks downward through projection dependencies; rejects with `ProjectionCycleError` if the would-be superseded projection is reachable
- **Read-time stale detection**: `getProjection()` recomputes the fingerprint on every read and returns `stale: true` with reason (`input_content_changed` | `input_deleted`) — always correct regardless of reconcile cadence
- **Frontmatter validation**: required YAML keys enforced at write time

## Test plan

- [x] `NullGenerator.generate()` throws with a helpful error message
- [x] `project()` with `NullGenerator` throws before touching the DB
- [x] `project()` creates projection + evidence rows
- [x] `project()` is idempotent when fingerprint matches
- [x] `project()` supersedes when fingerprint changes (invalidates old, links `superseded_by`)
- [x] `project()` rejects missing or redacted inputs
- [x] `project()` rejects invalid frontmatter
- [x] `project()` detects projection DAG cycles
- [x] `supersedeProjection()` sets `invalidated_at`, `valid_until`, `superseded_by` correctly
- [x] `supersedeProjection()` throws for nonexistent or already-invalidated projections
- [x] `getProjection()` returns `stale: false` when inputs are unchanged
- [x] `getProjection()` returns `stale: true, stale_reason: input_content_changed` after episode update
- [x] `getProjection()` returns `stale: true, stale_reason: input_deleted` after episode redaction
- [x] All 368 `engram-core` tests pass

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)