### PR TITLE
feat(core): reconcile() assess phase — Budget, softRefresh, currentInputState

### DIFF
--- a/packages/engram-core/src/ai/budget.ts
+++ b/packages/engram-core/src/ai/budget.ts
@@ -1,0 +1,46 @@
+/**
+ * budget.ts — Simple token budget tracker for reconcile() and other LLM-calling operations.
+ *
+ * If maxTokens is undefined, the budget is unlimited and exhausted() always returns false.
+ */
+
+export class Budget {
+  private readonly maxTokens: number | undefined;
+  private consumed: number;
+
+  constructor(maxTokens?: number) {
+    this.maxTokens = maxTokens;
+    this.consumed = 0;
+  }
+
+  /**
+   * Record that `tokens` tokens have been consumed.
+   */
+  consume(tokens: number): void {
+    this.consumed += tokens;
+  }
+
+  /**
+   * Returns true if the budget has been exhausted (consumed >= maxTokens).
+   * Always returns false when maxTokens is undefined (unlimited budget).
+   */
+  exhausted(): boolean {
+    if (this.maxTokens === undefined) return false;
+    return this.consumed >= this.maxTokens;
+  }
+
+  /**
+   * Returns the number of remaining tokens, or undefined if unlimited.
+   */
+  remaining(): number | undefined {
+    if (this.maxTokens === undefined) return undefined;
+    return Math.max(0, this.maxTokens - this.consumed);
+  }
+
+  /**
+   * Returns total tokens consumed so far.
+   */
+  totalConsumed(): number {
+    return this.consumed;
+  }
+}

--- a/packages/engram-core/src/graph/index.ts
+++ b/packages/engram-core/src/graph/index.ts
@@ -52,3 +52,12 @@ export {
   listActiveProjections,
   searchProjections,
 } from "./projections-list.js";
+export type {
+  ReconcileOpts,
+  ReconciliationRunResult,
+} from "./reconcile.js";
+export {
+  currentInputState,
+  reconcile,
+  softRefresh,
+} from "./reconcile.js";

--- a/packages/engram-core/src/graph/reconcile.ts
+++ b/packages/engram-core/src/graph/reconcile.ts
@@ -361,9 +361,9 @@ export async function reconcile(
 
       const projection: Projection = result.projection;
       const inputs = currentInputState(graph, projection.id);
-      const assessedAt = new Date().toISOString();
 
       const verdict = await generator.assess(projection, inputs);
+      const assessedAt = new Date().toISOString(); // after assess completes
 
       // Treat token usage as 1 per assess call (generators don't report tokens yet)
       budget.consume(1);
@@ -400,12 +400,18 @@ export async function reconcile(
           budget.consume(1);
 
           if (!dryRun) {
-            // Extract metadata from the generated body for supersedeProjection
+            // Recompute fingerprint from current substrate state — never inherit
+            // from the old projection or rely on generator frontmatter, which
+            // would cause the new projection to read as immediately stale.
+            const currentFingerprint = recomputeCurrentFingerprint(
+              graph,
+              projection.id,
+            );
             const newData = buildNewProjectionData(
               projection,
               generated.body,
               generated.confidence,
-              inputs,
+              currentFingerprint,
             );
             supersedeProjection(graph, projection.id, newData, inputs);
           }
@@ -459,7 +465,7 @@ function buildNewProjectionData(
   original: Projection,
   body: string,
   confidence: number,
-  _inputs: ResolvedInput[],
+  input_fingerprint: string,
 ): {
   kind: string;
   anchor_type: import("./projections-types.js").AnchorType;
@@ -480,9 +486,8 @@ function buildNewProjectionData(
     original.prompt_template_id;
   const prompt_hash =
     extractFrontmatterValue(body, "prompt_hash") ?? original.prompt_hash;
-  const input_fingerprint =
-    extractFrontmatterValue(body, "input_fingerprint") ??
-    original.input_fingerprint;
+  // input_fingerprint is passed in from caller (recomputed from substrate),
+  // not extracted from frontmatter — prevents infinite re-supersession
 
   return {
     kind: original.kind,

--- a/packages/engram-core/src/graph/reconcile.ts
+++ b/packages/engram-core/src/graph/reconcile.ts
@@ -1,0 +1,516 @@
+/**
+ * reconcile.ts — reconcile() assess phase and softRefresh() helper.
+ *
+ * Implements Operation 2 from docs/internal/specs/projections.md.
+ * The discover phase is stubbed as a no-op (out of scope for this issue).
+ *
+ * Exported: reconcile, softRefresh, currentInputState, ReconcileOpts, ReconciliationRunResult
+ */
+
+import { createHash } from "node:crypto";
+import { ulid } from "ulid";
+import { Budget } from "../ai/budget.js";
+import type {
+  ProjectionGenerator,
+  ResolvedInput,
+} from "../ai/projection-generator.js";
+import type { EngramGraph } from "../format/index.js";
+import { supersedeProjection } from "./projections.js";
+import { listActiveProjections } from "./projections-list.js";
+import type {
+  Projection,
+  ProjectionEvidenceRow,
+  ProjectionInputType,
+} from "./projections-types.js";
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface ReconcileOpts {
+  /** Optional filter to limit which projections to assess (e.g. 'kind:entity_summary'). */
+  scope?: string;
+  /** Which phases to run. Defaults to ['assess', 'discover']. */
+  phases?: ("assess" | "discover")[];
+  /** Token budget shared across all LLM calls. Unlimited if undefined. */
+  maxCost?: number;
+  /** If true, assess but don't write any changes to the database. */
+  dryRun?: boolean;
+}
+
+export interface ReconciliationRunResult {
+  run_id: string;
+  status: "completed" | "partial" | "failed";
+  assessed: number;
+  superseded: number;
+  soft_refreshed: number;
+  started_at: string;
+  completed_at: string;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Inserts a reconciliation_runs row with status='running'.
+ * Returns the run ID.
+ */
+function startReconciliationRun(
+  graph: EngramGraph,
+  runId: string,
+  opts: ReconcileOpts,
+  startedAt: string,
+): void {
+  const phases = (opts.phases ?? ["assess", "discover"]).join(",");
+  graph.db
+    .prepare(
+      `INSERT INTO reconciliation_runs
+         (id, started_at, scope, phases, dry_run, status,
+          projections_checked, projections_refreshed, projections_superseded, projections_discovered)
+       VALUES (?, ?, ?, ?, ?, 'running', 0, 0, 0, 0)`,
+    )
+    .run(runId, startedAt, opts.scope ?? null, phases, opts.dryRun ? 1 : 0);
+}
+
+/**
+ * Updates the reconciliation_runs row with final counts and status.
+ */
+function finishReconciliationRun(
+  graph: EngramGraph,
+  runId: string,
+  completedAt: string,
+  status: "completed" | "partial" | "failed",
+  assessed: number,
+  refreshed: number,
+  superseded: number,
+): void {
+  graph.db
+    .prepare(
+      `UPDATE reconciliation_runs
+          SET completed_at = ?,
+              status = ?,
+              projections_checked = ?,
+              projections_refreshed = ?,
+              projections_superseded = ?
+        WHERE id = ?`,
+    )
+    .run(completedAt, status, assessed, refreshed, superseded, runId);
+}
+
+/**
+ * Recomputes the input fingerprint for a projection from its current
+ * projection_evidence rows, using each target's *current* content hash.
+ *
+ * This is the same algorithm as recomputeFingerprint() in projections.ts,
+ * duplicated here to avoid a circular dependency (projections.ts is not exported
+ * through this module, and the helper is private there).
+ */
+function recomputeCurrentFingerprint(
+  graph: EngramGraph,
+  projectionId: string,
+): string {
+  const evidenceRows = graph.db
+    .query<ProjectionEvidenceRow, [string]>(
+      "SELECT * FROM projection_evidence WHERE projection_id = ? AND role = 'input'",
+    )
+    .all(projectionId);
+
+  const entries: string[] = [];
+
+  for (const row of evidenceRows) {
+    let currentHash: string | null = null;
+
+    switch (row.target_type) {
+      case "episode": {
+        const ep = graph.db
+          .query<{ content_hash: string; status: string }, [string]>(
+            "SELECT content_hash, status FROM episodes WHERE id = ?",
+          )
+          .get(row.target_id);
+        currentHash = ep && ep.status !== "redacted" ? ep.content_hash : null;
+        break;
+      }
+      case "entity": {
+        const ent = graph.db
+          .query<{ canonical_name: string; summary: string | null }, [string]>(
+            "SELECT canonical_name, summary FROM entities WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (ent) {
+          const c = `${ent.canonical_name}${ent.summary ? `: ${ent.summary}` : ""}`;
+          currentHash = createHash("sha256").update(c).digest("hex");
+        }
+        break;
+      }
+      case "edge": {
+        const edge = graph.db
+          .query<{ fact: string; invalidated_at: string | null }, [string]>(
+            "SELECT fact, invalidated_at FROM edges WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (edge && edge.invalidated_at === null) {
+          currentHash = createHash("sha256").update(edge.fact).digest("hex");
+        }
+        break;
+      }
+      case "projection": {
+        const proj = graph.db
+          .query<{ body: string; invalidated_at: string | null }, [string]>(
+            "SELECT body, invalidated_at FROM projections WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (proj && proj.invalidated_at === null) {
+          currentHash = createHash("sha256").update(proj.body).digest("hex");
+        }
+        break;
+      }
+    }
+
+    entries.push(`${row.target_type}:${row.target_id}:${currentHash ?? ""}`);
+  }
+
+  entries.sort();
+  return createHash("sha256").update(entries.join("\n")).digest("hex");
+}
+
+// ─── Exported helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Resolves the current state of all inputs for a projection from
+ * projection_evidence rows, reading fresh content from the substrate.
+ *
+ * Used by assess() and regenerate() calls during the reconcile assess phase.
+ */
+export function currentInputState(
+  graph: EngramGraph,
+  projectionId: string,
+): ResolvedInput[] {
+  const evidenceRows = graph.db
+    .query<ProjectionEvidenceRow, [string]>(
+      "SELECT * FROM projection_evidence WHERE projection_id = ? AND role = 'input'",
+    )
+    .all(projectionId);
+
+  const resolved: ResolvedInput[] = [];
+
+  for (const row of evidenceRows) {
+    const type = row.target_type as ProjectionInputType;
+    let content: string | null = null;
+    let content_hash: string | null = null;
+
+    switch (type) {
+      case "episode": {
+        const ep = graph.db
+          .query<
+            { content: string; content_hash: string; status: string },
+            [string]
+          >("SELECT content, content_hash, status FROM episodes WHERE id = ?")
+          .get(row.target_id);
+        if (ep && ep.status !== "redacted") {
+          content = ep.content;
+          content_hash = ep.content_hash;
+        }
+        break;
+      }
+      case "entity": {
+        const ent = graph.db
+          .query<
+            { canonical_name: string; summary: string | null; status: string },
+            [string]
+          >("SELECT canonical_name, summary, status FROM entities WHERE id = ?")
+          .get(row.target_id);
+        if (ent && ent.status !== "archived") {
+          content = `${ent.canonical_name}${ent.summary ? `: ${ent.summary}` : ""}`;
+          content_hash = createHash("sha256").update(content).digest("hex");
+        }
+        break;
+      }
+      case "edge": {
+        const edge = graph.db
+          .query<{ fact: string; invalidated_at: string | null }, [string]>(
+            "SELECT fact, invalidated_at FROM edges WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (edge && edge.invalidated_at === null) {
+          content = edge.fact;
+          content_hash = createHash("sha256").update(content).digest("hex");
+        }
+        break;
+      }
+      case "projection": {
+        const proj = graph.db
+          .query<{ body: string; invalidated_at: string | null }, [string]>(
+            "SELECT body, invalidated_at FROM projections WHERE id = ?",
+          )
+          .get(row.target_id);
+        if (proj && proj.invalidated_at === null) {
+          content = proj.body;
+          content_hash = createHash("sha256").update(content).digest("hex");
+        }
+        break;
+      }
+    }
+
+    resolved.push({ type, id: row.target_id, content, content_hash });
+  }
+
+  return resolved;
+}
+
+/**
+ * Updates input_fingerprint and last_assessed_at for a projection WITHOUT
+ * changing valid_from, valid_until, invalidated_at, or superseded_by.
+ *
+ * Also updates content_hash values in projection_evidence to reflect the
+ * current substrate state at assessment time.
+ *
+ * Used when assess() returns 'still_accurate': the projection content is
+ * correct, but the fingerprint needs updating to reflect the new input state.
+ */
+export function softRefresh(
+  graph: EngramGraph,
+  projectionId: string,
+  newFingerprint: string,
+  assessedAt: string,
+  currentInputs: ResolvedInput[],
+): void {
+  graph.db.transaction(() => {
+    graph.db
+      .prepare(
+        `UPDATE projections
+            SET input_fingerprint = ?,
+                last_assessed_at = ?
+          WHERE id = ?`,
+      )
+      .run(newFingerprint, assessedAt, projectionId);
+
+    const updateEvidence = graph.db.prepare(
+      `UPDATE projection_evidence
+          SET content_hash = ?
+        WHERE projection_id = ? AND target_type = ? AND target_id = ? AND role = 'input'`,
+    );
+
+    for (const inp of currentInputs) {
+      updateEvidence.run(inp.content_hash, projectionId, inp.type, inp.id);
+    }
+  })();
+}
+
+// ─── Scope filter helper ──────────────────────────────────────────────────────
+
+/**
+ * Parses the scope string into ListProjectionsOpts-compatible fields.
+ * Supported formats:
+ *   'kind:entity_summary'  → { kind: 'entity_summary' }
+ *   'anchor:entity'        → { anchor_type: 'entity' }
+ *   undefined              → {} (no filter)
+ */
+function parseScopeToOpts(scope?: string): {
+  kind?: string;
+  anchor_type?: string;
+} {
+  if (!scope) return {};
+  const [key, value] = scope.split(":");
+  if (key === "kind" && value) return { kind: value };
+  if (key === "anchor" && value) return { anchor_type: value };
+  return {};
+}
+
+// ─── reconcile() ─────────────────────────────────────────────────────────────
+
+/**
+ * Reconciliation loop — assess phase (discover phase is a no-op stub).
+ *
+ * For each stale active projection whose input_fingerprint has drifted:
+ * - Calls generator.assess() to determine the verdict.
+ * - 'still_accurate': calls softRefresh() to update fingerprint + evidence hashes.
+ * - 'needs_update' | 'contradicted': calls generator.regenerate() then supersedeProjection().
+ * - If dryRun=true, tracks counts but skips writes.
+ * - Stops early if the budget is exhausted (status='partial').
+ *
+ * Inserts a reconciliation_runs row at start and updates it at completion.
+ */
+export async function reconcile(
+  graph: EngramGraph,
+  generator: ProjectionGenerator,
+  opts?: ReconcileOpts,
+): Promise<ReconciliationRunResult> {
+  const runId = ulid();
+  const startedAt = new Date().toISOString();
+  const budget = new Budget(opts?.maxCost);
+  const dryRun = opts?.dryRun ?? false;
+  const phases = opts?.phases ?? ["assess", "discover"];
+
+  startReconciliationRun(graph, runId, opts ?? {}, startedAt);
+
+  let assessed = 0;
+  let superseded = 0;
+  let softRefreshed = 0;
+  let budgetHit = false;
+
+  // ── Phase 1: assess existing active projections ────────────────────────────
+  if (phases.includes("assess")) {
+    const scopeOpts = parseScopeToOpts(opts?.scope);
+    const activeProjections = listActiveProjections(graph, scopeOpts);
+
+    // Only process stale projections
+    const staleResults = activeProjections.filter((r) => r.stale);
+
+    for (const result of staleResults) {
+      if (budget.exhausted()) {
+        budgetHit = true;
+        break;
+      }
+
+      const projection: Projection = result.projection;
+      const inputs = currentInputState(graph, projection.id);
+      const assessedAt = new Date().toISOString();
+
+      const verdict = await generator.assess(projection, inputs);
+
+      // Treat token usage as 1 per assess call (generators don't report tokens yet)
+      budget.consume(1);
+
+      assessed++;
+
+      switch (verdict.verdict) {
+        case "still_accurate": {
+          const newFingerprint = recomputeCurrentFingerprint(
+            graph,
+            projection.id,
+          );
+          if (!dryRun) {
+            softRefresh(
+              graph,
+              projection.id,
+              newFingerprint,
+              assessedAt,
+              inputs,
+            );
+          }
+          softRefreshed++;
+          break;
+        }
+
+        case "needs_update":
+        case "contradicted": {
+          if (budget.exhausted()) {
+            budgetHit = true;
+            break;
+          }
+
+          const generated = await generator.regenerate(projection, inputs);
+          budget.consume(1);
+
+          if (!dryRun) {
+            // Extract metadata from the generated body for supersedeProjection
+            const newData = buildNewProjectionData(
+              projection,
+              generated.body,
+              generated.confidence,
+              inputs,
+            );
+            supersedeProjection(graph, projection.id, newData, inputs);
+          }
+          superseded++;
+          break;
+        }
+      }
+
+      if (budget.exhausted()) {
+        budgetHit = true;
+        break;
+      }
+    }
+  }
+
+  // ── Phase 2: discover new projections (stub — out of scope) ───────────────
+  // The discover phase is not implemented in this issue. It is a no-op here.
+
+  const completedAt = new Date().toISOString();
+  const status: "completed" | "partial" = budgetHit ? "partial" : "completed";
+
+  finishReconciliationRun(
+    graph,
+    runId,
+    completedAt,
+    status,
+    assessed,
+    softRefreshed,
+    superseded,
+  );
+
+  return {
+    run_id: runId,
+    status,
+    assessed,
+    superseded,
+    soft_refreshed: softRefreshed,
+    started_at: startedAt,
+    completed_at: completedAt,
+  };
+}
+
+// ─── Internal: build newData for supersedeProjection ─────────────────────────
+
+/**
+ * Extracts frontmatter values from a generated body and builds the newData
+ * argument for supersedeProjection(). Falls back to the original projection's
+ * metadata when frontmatter values are not present.
+ */
+function buildNewProjectionData(
+  original: Projection,
+  body: string,
+  confidence: number,
+  _inputs: ResolvedInput[],
+): {
+  kind: string;
+  anchor_type: import("./projections-types.js").AnchorType;
+  anchor_id: string | null;
+  title: string;
+  body: string;
+  model: string;
+  prompt_template_id: string | null;
+  prompt_hash: string | null;
+  input_fingerprint: string;
+  confidence: number;
+  owner_id: string | null;
+} {
+  const title = extractFrontmatterValue(body, "title") ?? original.title;
+  const model = extractFrontmatterValue(body, "model") ?? original.model;
+  const prompt_template_id =
+    extractFrontmatterValue(body, "prompt_template_id") ??
+    original.prompt_template_id;
+  const prompt_hash =
+    extractFrontmatterValue(body, "prompt_hash") ?? original.prompt_hash;
+  const input_fingerprint =
+    extractFrontmatterValue(body, "input_fingerprint") ??
+    original.input_fingerprint;
+
+  return {
+    kind: original.kind,
+    anchor_type: original.anchor_type,
+    anchor_id: original.anchor_id,
+    title,
+    body,
+    model,
+    prompt_template_id,
+    prompt_hash,
+    input_fingerprint,
+    confidence,
+    owner_id: original.owner_id,
+  };
+}
+
+/**
+ * Extracts a scalar value from a YAML frontmatter block.
+ * Returns null if not found or body has no valid frontmatter.
+ */
+function extractFrontmatterValue(body: string, key: string): string | null {
+  if (!body.startsWith("---\n")) return null;
+  const endIdx = body.indexOf("\n---", 4);
+  if (endIdx === -1) return null;
+  const frontmatter = body.slice(4, endIdx);
+  const safeKey = key.replace(/[^a-zA-Z0-9_]/g, "");
+  const regex = new RegExp(`^${safeKey}:\\s*["']?([^"'\\n]+?)["']?\\s*$`, "m");
+  const match = frontmatter.match(regex);
+  if (!match) return null;
+  return match[1].trim().replace(/^["']|["']$/g, "");
+}

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -4,6 +4,7 @@
  * Public API surface. All consumer-facing types and functions are re-exported from here.
  */
 
+export { Budget } from "./ai/budget.js";
 export type { AIConfig, AIProvider, EntityHint } from "./ai/index.js";
 export {
   createProvider,
@@ -65,6 +66,8 @@ export type {
   ProjectionInput,
   ProjectionInputType,
   ProjectionOpts,
+  ReconcileOpts,
+  ReconciliationRunResult,
   SimilarResult,
   StoredEmbedding,
 } from "./graph/index.js";
@@ -75,6 +78,7 @@ export {
   addEpisode,
   computeBatchedStaleness,
   cosineSimilarity,
+  currentInputState,
   EdgeNotFoundError,
   EntityNotFoundError,
   EvidenceRequiredError,
@@ -92,8 +96,10 @@ export {
   ProjectionFrontmatterError,
   ProjectionInputMissingError,
   project,
+  reconcile,
   resolveEntity,
   searchProjections,
+  softRefresh,
   storeEmbedding,
   supersedeProjection,
 } from "./graph/index.js";

--- a/packages/engram-core/test/graph/reconcile.test.ts
+++ b/packages/engram-core/test/graph/reconcile.test.ts
@@ -1,0 +1,644 @@
+/**
+ * reconcile.test.ts — tests for reconcile(), softRefresh(), and currentInputState().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type {
+  AssessVerdict,
+  EngramGraph,
+  Projection,
+  ProjectionGenerator,
+  ResolvedInput,
+} from "../../src/index.js";
+import {
+  addEpisode,
+  closeGraph,
+  createGraph,
+  currentInputState,
+  project,
+  reconcile,
+  softRefresh,
+} from "../../src/index.js";
+
+// ─── MockGenerator ────────────────────────────────────────────────────────────
+
+interface MockGeneratorCall {
+  method: "generate" | "assess" | "regenerate";
+  projectionId?: string;
+}
+
+function makeMockGenerator(opts?: {
+  assessVerdict?: AssessVerdict;
+  regenerateBody?: string;
+  tokensPerCall?: number;
+}): ProjectionGenerator & { calls: MockGeneratorCall[] } {
+  const calls: MockGeneratorCall[] = [];
+
+  return {
+    calls,
+
+    async generate(
+      inputs: ResolvedInput[],
+    ): Promise<{ body: string; confidence: number }> {
+      calls.push({ method: "generate" });
+      const inputList = inputs.map((i) => `  - ${i.type}:${i.id}`).join("\n");
+      const now = new Date().toISOString();
+      const body =
+        `---\n` +
+        `id: mock-id\n` +
+        `kind: entity_summary\n` +
+        `anchor: none\n` +
+        `title: "Mock Projection"\n` +
+        `model: mock\n` +
+        `prompt_template_id: mock.v1\n` +
+        `prompt_hash: mockhash\n` +
+        `input_fingerprint: mockfp\n` +
+        `valid_from: ${now}\n` +
+        `valid_until: null\n` +
+        `inputs:\n${inputList || "  []"}\n` +
+        `---\n\n# Mock Projection\n\nContent.\n`;
+      return { body, confidence: 1.0 };
+    },
+
+    async assess(
+      projection: Projection,
+      _currentInputs: ResolvedInput[],
+    ): Promise<AssessVerdict> {
+      calls.push({ method: "assess", projectionId: projection.id });
+      return opts?.assessVerdict ?? { verdict: "still_accurate" };
+    },
+
+    async regenerate(
+      projection: Projection,
+      inputs: ResolvedInput[],
+    ): Promise<{ body: string; confidence: number }> {
+      calls.push({ method: "regenerate", projectionId: projection.id });
+      const body =
+        opts?.regenerateBody ??
+        (await (this as ProjectionGenerator).generate(inputs)).body;
+      return { body, confidence: 0.9 };
+    },
+  };
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+function makeEpisode(content = "test content") {
+  return addEpisode(graph, {
+    source_type: "manual",
+    content,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+async function makeProjection(
+  episodeId: string,
+  gen: ProjectionGenerator,
+  kind = "entity_summary",
+  anchorId = "ent-test",
+) {
+  return project(graph, {
+    kind,
+    anchor: { type: "entity", id: anchorId },
+    inputs: [{ type: "episode", id: episodeId }],
+    generator: gen,
+  });
+}
+
+// ─── reconcile() — no stale projections ──────────────────────────────────────
+
+describe("reconcile() — no stale projections", () => {
+  test("returns 0 assessed when there are no projections", async () => {
+    const gen = makeMockGenerator();
+    const result = await reconcile(graph, gen);
+
+    expect(result.assessed).toBe(0);
+    expect(result.superseded).toBe(0);
+    expect(result.soft_refreshed).toBe(0);
+    expect(result.status).toBe("completed");
+    expect(result.run_id).toBeDefined();
+    expect(result.started_at).toBeDefined();
+    expect(result.completed_at).toBeDefined();
+  });
+
+  test("skips non-stale projections", async () => {
+    const ep = makeEpisode("stable");
+    const gen = makeMockGenerator();
+    await makeProjection(ep.id, gen);
+
+    const result = await reconcile(graph, gen);
+
+    expect(result.assessed).toBe(0);
+    expect(gen.calls.filter((c) => c.method === "assess").length).toBe(0);
+  });
+});
+
+// ─── reconcile() — still_accurate verdict ────────────────────────────────────
+
+describe("reconcile() assess — still_accurate verdict", () => {
+  test("calls softRefresh: updates fingerprint and last_assessed_at", async () => {
+    const ep = makeEpisode("original");
+    const gen = makeMockGenerator({
+      assessVerdict: { verdict: "still_accurate" },
+    });
+    const proj = await makeProjection(ep.id, gen);
+
+    // Make the projection stale by changing episode content
+    const { createHash } = await import("node:crypto");
+    const newHash = createHash("sha256").update("modified").digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'modified', content_hash = ? WHERE id = ?",
+      [newHash, ep.id],
+    );
+
+    const result = await reconcile(graph, gen, { phases: ["assess"] });
+
+    expect(result.assessed).toBe(1);
+    expect(result.soft_refreshed).toBe(1);
+    expect(result.superseded).toBe(0);
+    expect(result.status).toBe("completed");
+
+    // last_assessed_at should now be set
+    const row = graph.db
+      .query<{ last_assessed_at: string | null; id: string }, [string]>(
+        "SELECT id, last_assessed_at FROM projections WHERE id = ?",
+      )
+      .get(proj.id);
+    expect(row?.last_assessed_at).not.toBeNull();
+
+    // input_fingerprint should have been updated (no supersession)
+    const row2 = graph.db
+      .query<
+        { input_fingerprint: string; invalidated_at: string | null },
+        [string]
+      >(
+        "SELECT input_fingerprint, invalidated_at FROM projections WHERE id = ?",
+      )
+      .get(proj.id);
+    expect(row2?.invalidated_at).toBeNull(); // not superseded
+    expect(row2?.input_fingerprint).not.toBe(proj.input_fingerprint); // fingerprint updated
+  });
+
+  test("assess() is called with the correct projection", async () => {
+    const ep = makeEpisode("text");
+    const gen = makeMockGenerator({
+      assessVerdict: { verdict: "still_accurate" },
+    });
+    const proj = await makeProjection(ep.id, gen);
+
+    // Make stale
+    const { createHash } = await import("node:crypto");
+    const h = createHash("sha256").update("changed").digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'changed', content_hash = ? WHERE id = ?",
+      [h, ep.id],
+    );
+
+    await reconcile(graph, gen, { phases: ["assess"] });
+
+    const assessCalls = gen.calls.filter((c) => c.method === "assess");
+    expect(assessCalls.length).toBe(1);
+    expect(assessCalls[0].projectionId).toBe(proj.id);
+  });
+});
+
+// ─── reconcile() — needs_update verdict ──────────────────────────────────────
+
+describe("reconcile() assess — needs_update verdict", () => {
+  test("calls supersedeProjection: old projection is invalidated, new one is created", async () => {
+    const ep = makeEpisode("original");
+    const gen = makeMockGenerator({
+      assessVerdict: {
+        verdict: "needs_update",
+        reason: "content changed significantly",
+      },
+    });
+    const proj = await makeProjection(ep.id, gen);
+
+    // Make stale
+    const { createHash } = await import("node:crypto");
+    const h = createHash("sha256").update("new content").digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'new content', content_hash = ? WHERE id = ?",
+      [h, ep.id],
+    );
+
+    const result = await reconcile(graph, gen, { phases: ["assess"] });
+
+    expect(result.assessed).toBe(1);
+    expect(result.superseded).toBe(1);
+    expect(result.soft_refreshed).toBe(0);
+
+    // Old projection should be invalidated
+    const oldRow = graph.db
+      .query<{ invalidated_at: string | null }, [string]>(
+        "SELECT invalidated_at FROM projections WHERE id = ?",
+      )
+      .get(proj.id);
+    expect(oldRow?.invalidated_at).not.toBeNull();
+
+    // A new active projection should exist
+    const activeRows = graph.db
+      .query<{ id: string }, []>(
+        "SELECT id FROM projections WHERE invalidated_at IS NULL",
+      )
+      .all();
+    expect(activeRows.length).toBe(1);
+    expect(activeRows[0].id).not.toBe(proj.id);
+  });
+});
+
+// ─── reconcile() — contradicted verdict ──────────────────────────────────────
+
+describe("reconcile() assess — contradicted verdict", () => {
+  test("behaves same as needs_update: supersedes the projection", async () => {
+    const ep = makeEpisode("original");
+    const gen = makeMockGenerator({
+      assessVerdict: {
+        verdict: "contradicted",
+        reason: "PR reverted the change",
+      },
+    });
+    const proj = await makeProjection(ep.id, gen);
+
+    // Make stale
+    const { createHash } = await import("node:crypto");
+    const h = createHash("sha256").update("reverted").digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'reverted', content_hash = ? WHERE id = ?",
+      [h, ep.id],
+    );
+
+    const result = await reconcile(graph, gen, { phases: ["assess"] });
+
+    expect(result.assessed).toBe(1);
+    expect(result.superseded).toBe(1);
+    expect(result.soft_refreshed).toBe(0);
+
+    const oldRow = graph.db
+      .query<{ invalidated_at: string | null }, [string]>(
+        "SELECT invalidated_at FROM projections WHERE id = ?",
+      )
+      .get(proj.id);
+    expect(oldRow?.invalidated_at).not.toBeNull();
+  });
+});
+
+// ─── reconcile() — dryRun ─────────────────────────────────────────────────────
+
+describe("reconcile() — dryRun", () => {
+  test("counts are correct but no writes happen (still_accurate)", async () => {
+    const ep = makeEpisode("original");
+    const gen = makeMockGenerator({
+      assessVerdict: { verdict: "still_accurate" },
+    });
+    const proj = await makeProjection(ep.id, gen);
+    const originalFingerprint = proj.input_fingerprint;
+
+    // Make stale
+    const { createHash } = await import("node:crypto");
+    const h = createHash("sha256").update("changed").digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'changed', content_hash = ? WHERE id = ?",
+      [h, ep.id],
+    );
+
+    const result = await reconcile(graph, gen, {
+      phases: ["assess"],
+      dryRun: true,
+    });
+
+    expect(result.assessed).toBe(1);
+    expect(result.soft_refreshed).toBe(1);
+
+    // Projection should NOT be updated (dry run)
+    const row = graph.db
+      .query<
+        { input_fingerprint: string; last_assessed_at: string | null },
+        [string]
+      >(
+        "SELECT input_fingerprint, last_assessed_at FROM projections WHERE id = ?",
+      )
+      .get(proj.id);
+    expect(row?.input_fingerprint).toBe(originalFingerprint);
+    expect(row?.last_assessed_at).toBeNull();
+  });
+
+  test("counts are correct but no writes happen (needs_update)", async () => {
+    const ep = makeEpisode("original");
+    const gen = makeMockGenerator({
+      assessVerdict: { verdict: "needs_update", reason: "changed" },
+    });
+    const proj = await makeProjection(ep.id, gen);
+
+    // Make stale
+    const { createHash } = await import("node:crypto");
+    const h = createHash("sha256").update("changed").digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'changed', content_hash = ? WHERE id = ?",
+      [h, ep.id],
+    );
+
+    const result = await reconcile(graph, gen, {
+      phases: ["assess"],
+      dryRun: true,
+    });
+
+    expect(result.assessed).toBe(1);
+    expect(result.superseded).toBe(1);
+
+    // Original projection must still be active
+    const row = graph.db
+      .query<{ invalidated_at: string | null }, [string]>(
+        "SELECT invalidated_at FROM projections WHERE id = ?",
+      )
+      .get(proj.id);
+    expect(row?.invalidated_at).toBeNull();
+
+    // Only one projection should exist
+    const all = graph.db
+      .query<{ id: string }, []>("SELECT id FROM projections")
+      .all();
+    expect(all.length).toBe(1);
+  });
+});
+
+// ─── reconcile() — budget exhaustion ─────────────────────────────────────────
+
+describe("reconcile() — budget exhaustion", () => {
+  test("stops early when budget is exhausted, status=partial", async () => {
+    const ep1 = makeEpisode("first");
+    const ep2 = makeEpisode("second");
+    const gen = makeMockGenerator({
+      assessVerdict: { verdict: "still_accurate" },
+    });
+
+    await makeProjection(ep1.id, gen, "entity_summary", "ent-1");
+    await makeProjection(ep2.id, gen, "entity_summary", "ent-2");
+
+    // Make both stale
+    const { createHash } = await import("node:crypto");
+    const h1 = createHash("sha256").update("changed1").digest("hex");
+    const h2 = createHash("sha256").update("changed2").digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'changed1', content_hash = ? WHERE id = ?",
+      [h1, ep1.id],
+    );
+    graph.db.run(
+      "UPDATE episodes SET content = 'changed2', content_hash = ? WHERE id = ?",
+      [h2, ep2.id],
+    );
+
+    // Budget of 1 token — allows exactly 1 assess call before exhaustion
+    // (budget.consume(1) is called after each assess, then checked)
+    const result = await reconcile(graph, gen, {
+      phases: ["assess"],
+      maxCost: 1,
+    });
+
+    expect(result.status).toBe("partial");
+    // assessed count depends on where budget hits: at least 1 was checked
+    expect(result.assessed).toBeGreaterThan(0);
+    expect(result.assessed).toBeLessThan(2);
+  });
+});
+
+// ─── reconcile() — reconciliation_runs row ────────────────────────────────────
+
+describe("reconcile() — reconciliation_runs table", () => {
+  test("inserts and completes reconciliation_runs row", async () => {
+    const gen = makeMockGenerator();
+    const result = await reconcile(graph, gen);
+
+    const row = graph.db
+      .query<
+        {
+          id: string;
+          started_at: string;
+          completed_at: string | null;
+          status: string;
+          projections_checked: number;
+          projections_refreshed: number;
+          projections_superseded: number;
+          dry_run: number;
+        },
+        [string]
+      >("SELECT * FROM reconciliation_runs WHERE id = ?")
+      .get(result.run_id);
+
+    expect(row).not.toBeNull();
+    expect(row?.status).toBe("completed");
+    expect(row?.completed_at).not.toBeNull();
+    expect(row?.started_at).toBeDefined();
+    expect(row?.projections_checked).toBe(0);
+    expect(row?.dry_run).toBe(0);
+  });
+
+  test("sets dry_run=1 in reconciliation_runs when dryRun=true", async () => {
+    const gen = makeMockGenerator();
+    const result = await reconcile(graph, gen, { dryRun: true });
+
+    const row = graph.db
+      .query<{ dry_run: number }, [string]>(
+        "SELECT dry_run FROM reconciliation_runs WHERE id = ?",
+      )
+      .get(result.run_id);
+
+    expect(row?.dry_run).toBe(1);
+  });
+
+  test("records correct counts in reconciliation_runs", async () => {
+    const ep = makeEpisode("original");
+    const gen = makeMockGenerator({
+      assessVerdict: { verdict: "still_accurate" },
+    });
+    await makeProjection(ep.id, gen);
+
+    // Make stale
+    const { createHash } = await import("node:crypto");
+    const h = createHash("sha256").update("changed").digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = 'changed', content_hash = ? WHERE id = ?",
+      [h, ep.id],
+    );
+
+    const result = await reconcile(graph, gen, { phases: ["assess"] });
+
+    const row = graph.db
+      .query<
+        {
+          projections_checked: number;
+          projections_refreshed: number;
+          projections_superseded: number;
+        },
+        [string]
+      >(
+        "SELECT projections_checked, projections_refreshed, projections_superseded FROM reconciliation_runs WHERE id = ?",
+      )
+      .get(result.run_id);
+
+    expect(row?.projections_checked).toBe(1);
+    expect(row?.projections_refreshed).toBe(1);
+    expect(row?.projections_superseded).toBe(0);
+  });
+
+  test("sets status=partial in reconciliation_runs when budget exhausted", async () => {
+    const ep1 = makeEpisode("a");
+    const ep2 = makeEpisode("b");
+    const gen = makeMockGenerator({
+      assessVerdict: { verdict: "still_accurate" },
+    });
+
+    await makeProjection(ep1.id, gen, "entity_summary", "ent-a");
+    await makeProjection(ep2.id, gen, "entity_summary", "ent-b");
+
+    // Make both stale
+    const { createHash } = await import("node:crypto");
+    graph.db.run(
+      "UPDATE episodes SET content = 'x', content_hash = ? WHERE id = ?",
+      [createHash("sha256").update("x").digest("hex"), ep1.id],
+    );
+    graph.db.run(
+      "UPDATE episodes SET content = 'y', content_hash = ? WHERE id = ?",
+      [createHash("sha256").update("y").digest("hex"), ep2.id],
+    );
+
+    const result = await reconcile(graph, gen, {
+      phases: ["assess"],
+      maxCost: 1,
+    });
+
+    const row = graph.db
+      .query<{ status: string }, [string]>(
+        "SELECT status FROM reconciliation_runs WHERE id = ?",
+      )
+      .get(result.run_id);
+
+    expect(row?.status).toBe("partial");
+  });
+});
+
+// ─── softRefresh() ────────────────────────────────────────────────────────────
+
+describe("softRefresh()", () => {
+  test("updates input_fingerprint and last_assessed_at without supersession", async () => {
+    const ep = makeEpisode("original");
+    const gen = makeMockGenerator();
+    const proj = await makeProjection(ep.id, gen);
+
+    const now = new Date().toISOString();
+    const newFp = "new-fingerprint-value";
+    const inputs = currentInputState(graph, proj.id);
+
+    softRefresh(graph, proj.id, newFp, now, inputs);
+
+    const row = graph.db
+      .query<
+        {
+          input_fingerprint: string;
+          last_assessed_at: string | null;
+          invalidated_at: string | null;
+          superseded_by: string | null;
+          valid_from: string;
+        },
+        [string]
+      >(
+        "SELECT input_fingerprint, last_assessed_at, invalidated_at, superseded_by, valid_from FROM projections WHERE id = ?",
+      )
+      .get(proj.id);
+
+    expect(row?.input_fingerprint).toBe(newFp);
+    expect(row?.last_assessed_at).toBe(now);
+    expect(row?.invalidated_at).toBeNull();
+    expect(row?.superseded_by).toBeNull();
+    expect(row?.valid_from).toBe(proj.valid_from); // valid_from unchanged
+  });
+
+  test("updates content_hash values in projection_evidence", async () => {
+    const ep = makeEpisode("original content");
+    const gen = makeMockGenerator();
+    const proj = await makeProjection(ep.id, gen);
+
+    // Simulate new content hash
+    const { createHash } = await import("node:crypto");
+    const newContent = "new content for hash";
+    const newHash = createHash("sha256").update(newContent).digest("hex");
+    graph.db.run(
+      "UPDATE episodes SET content = ?, content_hash = ? WHERE id = ?",
+      [newContent, newHash, ep.id],
+    );
+
+    const inputs = currentInputState(graph, proj.id);
+    const now = new Date().toISOString();
+    softRefresh(graph, proj.id, "new-fp", now, inputs);
+
+    const evidenceRow = graph.db
+      .query<{ content_hash: string | null }, [string, string]>(
+        "SELECT content_hash FROM projection_evidence WHERE projection_id = ? AND target_id = ?",
+      )
+      .get(proj.id, ep.id);
+
+    expect(evidenceRow?.content_hash).toBe(newHash);
+  });
+});
+
+// ─── currentInputState() ─────────────────────────────────────────────────────
+
+describe("currentInputState()", () => {
+  test("resolves episode content from the substrate", async () => {
+    const ep = makeEpisode("hello world");
+    const gen = makeMockGenerator();
+    const proj = await makeProjection(ep.id, gen);
+
+    const inputs = currentInputState(graph, proj.id);
+
+    expect(inputs.length).toBe(1);
+    expect(inputs[0].type).toBe("episode");
+    expect(inputs[0].id).toBe(ep.id);
+    expect(inputs[0].content).toBe("hello world");
+    expect(inputs[0].content_hash).toBeDefined();
+  });
+
+  test("returns null content for redacted episode", async () => {
+    const ep = makeEpisode("sensitive");
+    const gen = makeMockGenerator();
+    const proj = await makeProjection(ep.id, gen);
+
+    graph.db.run("UPDATE episodes SET status = 'redacted' WHERE id = ?", [
+      ep.id,
+    ]);
+
+    const inputs = currentInputState(graph, proj.id);
+
+    expect(inputs[0].content).toBeNull();
+    expect(inputs[0].content_hash).toBeNull();
+  });
+
+  test("returns empty array for projection with no evidence", () => {
+    // Insert a bare projection row without evidence
+    const now = new Date().toISOString();
+    graph.db.run(
+      `INSERT INTO projections
+         (id, kind, anchor_type, anchor_id, title, body, body_format,
+          model, prompt_template_id, prompt_hash, input_fingerprint,
+          confidence, valid_from, valid_until, last_assessed_at,
+          invalidated_at, superseded_by, created_at, owner_id)
+       VALUES ('bare-id', 'test', 'none', NULL, 'T', '---\nid: x\nkind: test\nanchor: none\ntitle: T\nmodel: m\ninput_fingerprint: f\nvalid_from: 2026-01-01T00:00:00Z\ninputs:\n  []\n---\n', 'markdown',
+               'm', NULL, NULL, 'fp', 1.0, ?, NULL, NULL, NULL, NULL, ?, NULL)`,
+      [now, now],
+    );
+
+    const inputs = currentInputState(graph, "bare-id");
+    expect(inputs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the assess phase of `reconcile()` per the spec in `docs/internal/specs/projections.md` § Operation 2
- Adds `Budget` — a simple token budget tracker with `consume()`, `exhausted()`, and `remaining()`
- Adds `softRefresh()` — updates `input_fingerprint` and `last_assessed_at` without supersession
- Adds `currentInputState()` — resolves all projection evidence inputs from the substrate for use in assess/regenerate calls
- The discover phase is a no-op stub (out of scope for this issue)
- Exports all new symbols from `graph/index.ts` and `src/index.ts`

## Acceptance Criteria

- [x] `Budget` class with `maxTokens` optional, `exhausted()` always false when unlimited
- [x] `reconcile()` assess phase: loops over stale projections, calls `generator.assess()`
- [x] `still_accurate` → `softRefresh()` (fingerprint + evidence hashes updated, no supersession)
- [x] `needs_update` | `contradicted` → `generator.regenerate()` + `supersedeProjection()`
- [x] `dryRun=true` → counts tracked, no writes
- [x] Budget exhaustion → stops early, `status='partial'`
- [x] `reconciliation_runs` row inserted at start, updated at completion
- [x] Non-stale projections are skipped (0 LLM calls)
- [x] All 18 tests pass

## Test plan

- `bun test packages/engram-core/test/graph/reconcile.test.ts` — 18/18 pass
- `bun test packages/engram-core` — 406/406 pass

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)