### PR TITLE
feat(core): add projection invariant checks to verifyGraph()

### DIFF
--- a/packages/engram-core/src/format/verify.ts
+++ b/packages/engram-core/src/format/verify.ts
@@ -277,7 +277,7 @@ function checkProjectionSupersessionCycles(graph: EngramGraph): Violation[] {
          SELECT c.start_id, p.superseded_by,
                 c.path || ',' || p.id,
                 c.depth + 1,
-                CASE WHEN instr(c.path, p.id) > 0 THEN 1 ELSE 0 END
+                CASE WHEN instr(',' || c.path || ',', ',' || p.id || ',') > 0 THEN 1 ELSE 0 END
          FROM chain c
          JOIN projections p ON p.id = c.current_id
          WHERE c.current_id IS NOT NULL
@@ -315,7 +315,7 @@ function checkProjectionDependencyCycles(graph: EngramGraph): Violation[] {
          SELECT d.start_id, pe.target_id,
                 d.path || ',' || pe.target_id,
                 d.depth + 1,
-                CASE WHEN instr(d.path, pe.target_id) > 0 THEN 1 ELSE 0 END
+                CASE WHEN instr(',' || d.path || ',', ',' || pe.target_id || ',') > 0 THEN 1 ELSE 0 END
          FROM dep d
          JOIN projection_evidence pe ON pe.projection_id = d.current_id
          WHERE pe.target_type = 'projection'
@@ -334,7 +334,8 @@ function checkProjectionDependencyCycles(graph: EngramGraph): Violation[] {
   for (const row of rows) {
     // Normalise the cycle path to the smallest rotation for dedup
     const parts = row.cycle_path.split(",");
-    const key = [...parts].sort().join(",");
+    // Dedup on sorted unique node set — a cycle A→B→A and B→A→B are the same cycle
+    const key = [...new Set(parts)].sort().join(",");
     if (!seen.has(key)) {
       seen.add(key);
       violations.push({

--- a/packages/engram-core/src/format/verify.ts
+++ b/packages/engram-core/src/format/verify.ts
@@ -227,6 +227,126 @@ function checkEmbeddingTargets(graph: EngramGraph): Violation[] {
   return violations;
 }
 
+/**
+ * Returns true if the projections table exists in this database.
+ * Used to skip projection checks on v0.1 files that lack projection tables.
+ */
+function hasProjectionsTable(graph: EngramGraph): boolean {
+  const row = graph.db
+    .query<{ cnt: number }, []>(
+      `SELECT COUNT(*) AS cnt FROM sqlite_master
+       WHERE type='table' AND name='projections'`,
+    )
+    .get();
+  return (row?.cnt ?? 0) > 0;
+}
+
+function checkProjectionEvidence(graph: EngramGraph): Violation[] {
+  if (!hasProjectionsTable(graph)) return [];
+
+  const rows = graph.db
+    .query<{ id: string }, []>(
+      `SELECT p.id FROM projections p
+       LEFT JOIN projection_evidence pe
+         ON p.id = pe.projection_id AND pe.role = 'input'
+       WHERE pe.projection_id IS NULL`,
+    )
+    .all();
+
+  return rows.map((row) => ({
+    check: "checkProjectionEvidence",
+    entity_or_edge_id: row.id,
+    message: `Projection '${row.id}' has no evidence rows with role='input'`,
+    severity: "error" as ViolationSeverity,
+  }));
+}
+
+function checkProjectionSupersessionCycles(graph: EngramGraph): Violation[] {
+  if (!hasProjectionsTable(graph)) return [];
+
+  // Use a recursive CTE with a depth guard to detect cycles in superseded_by chains.
+  // A cycle is detected when we visit a projection_id we have already seen in the chain
+  // (path contains it), or the depth exceeds the guard.
+  const rows = graph.db
+    .query<{ start_id: string; cycle_path: string }, []>(
+      `WITH RECURSIVE chain(start_id, current_id, path, depth, cycle) AS (
+         SELECT id, superseded_by, id, 1, 0
+         FROM projections
+         WHERE superseded_by IS NOT NULL
+         UNION ALL
+         SELECT c.start_id, p.superseded_by,
+                c.path || ',' || p.id,
+                c.depth + 1,
+                CASE WHEN instr(c.path, p.id) > 0 THEN 1 ELSE 0 END
+         FROM chain c
+         JOIN projections p ON p.id = c.current_id
+         WHERE c.current_id IS NOT NULL
+           AND c.cycle = 0
+           AND c.depth < 10000
+       )
+       SELECT start_id, path AS cycle_path
+       FROM chain
+       WHERE cycle = 1`,
+    )
+    .all();
+
+  return rows.map((row) => ({
+    check: "checkProjectionSupersessionCycles",
+    entity_or_edge_id: row.start_id,
+    message: `Projection supersession cycle detected starting from '${row.start_id}': ${row.cycle_path}`,
+    severity: "error" as ViolationSeverity,
+  }));
+}
+
+function checkProjectionDependencyCycles(graph: EngramGraph): Violation[] {
+  if (!hasProjectionsTable(graph)) return [];
+
+  // Walk the projection→projection dependency graph (via projection_evidence where
+  // target_type='projection') using a recursive CTE. Detect cycles.
+  const rows = graph.db
+    .query<{ start_id: string; cycle_path: string }, []>(
+      `WITH RECURSIVE dep(start_id, current_id, path, depth, cycle) AS (
+         SELECT DISTINCT pe.projection_id, pe.target_id,
+                pe.projection_id || ',' || pe.target_id,
+                1, 0
+         FROM projection_evidence pe
+         WHERE pe.target_type = 'projection'
+         UNION ALL
+         SELECT d.start_id, pe.target_id,
+                d.path || ',' || pe.target_id,
+                d.depth + 1,
+                CASE WHEN instr(d.path, pe.target_id) > 0 THEN 1 ELSE 0 END
+         FROM dep d
+         JOIN projection_evidence pe ON pe.projection_id = d.current_id
+         WHERE pe.target_type = 'projection'
+           AND d.cycle = 0
+           AND d.depth < 10000
+       )
+       SELECT start_id, path AS cycle_path
+       FROM dep
+       WHERE cycle = 1`,
+    )
+    .all();
+
+  // Deduplicate: a single cycle may be reported from multiple starting nodes.
+  const seen = new Set<string>();
+  const violations: Violation[] = [];
+  for (const row of rows) {
+    // Normalise the cycle path to the smallest rotation for dedup
+    const parts = row.cycle_path.split(",");
+    const key = [...parts].sort().join(",");
+    if (!seen.has(key)) {
+      seen.add(key);
+      violations.push({
+        check: "checkProjectionDependencyCycles",
+        message: `Projection dependency cycle detected: ${row.cycle_path}`,
+        severity: "error" as ViolationSeverity,
+      });
+    }
+  }
+  return violations;
+}
+
 function checkActiveEdgeOverlaps(graph: EngramGraph): Violation[] {
   // Find pairs of active edges (no invalidated_at) sharing the same
   // (source_id, target_id, relation_type, edge_kind) with overlapping validity windows.
@@ -274,6 +394,9 @@ export function verifyGraph(graph: EngramGraph): VerifyResult {
   violations.push(...checkEvidenceEpisodeRefs(graph));
   violations.push(...checkEmbeddingTargets(graph));
   violations.push(...checkActiveEdgeOverlaps(graph));
+  violations.push(...checkProjectionEvidence(graph));
+  violations.push(...checkProjectionSupersessionCycles(graph));
+  violations.push(...checkProjectionDependencyCycles(graph));
 
   const valid = !violations.some((v) => v.severity === "error");
   return { valid, violations };

--- a/packages/engram-core/test/format/verify-projections.test.ts
+++ b/packages/engram-core/test/format/verify-projections.test.ts
@@ -1,0 +1,362 @@
+/**
+ * verify-projections.test.ts — projection invariant checks in verifyGraph().
+ *
+ * Tests:
+ *  1. Healthy projection graph → no violations
+ *  2. Projection without evidence → ProjectionMissingEvidenceError (checkProjectionEvidence)
+ *  3. Supersession cycle (A→B→A via superseded_by) → checkProjectionSupersessionCycles
+ *  4. Projection-dependency cycle via evidence (A depends on B depends on A) →
+ *     checkProjectionDependencyCycles
+ *  5. v0.1 file (no projection tables) → checks skip cleanly, no error
+ */
+
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ulid } from "ulid";
+import { SCHEMA_DDL } from "../../src/format/schema.js";
+import type { EngramGraph } from "../../src/index.js";
+import { closeGraph, createGraph, verifyGraph } from "../../src/index.js";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Insert a minimal projection row (bypassing the public API so we can
+ * create deliberately broken states).
+ */
+function insertProjection(
+  graph: EngramGraph,
+  id: string,
+  superseded_by: string | null = null,
+): void {
+  graph.db.run(
+    `INSERT INTO projections
+       (id, kind, anchor_type, title, body, model,
+        input_fingerprint, confidence, valid_from, created_at,
+        superseded_by)
+     VALUES (?, 'entity_summary', 'none', 'Test', 'body', 'human',
+             'fp', 1.0, ?, ?, ?)`,
+    [id, now(), now(), superseded_by],
+  );
+}
+
+/**
+ * Insert a projection_evidence row linking projection_id → target.
+ */
+function insertEvidence(
+  graph: EngramGraph,
+  projectionId: string,
+  targetType: string,
+  targetId: string,
+  role = "input",
+): void {
+  graph.db.run(
+    `INSERT INTO projection_evidence (projection_id, target_type, target_id, role)
+     VALUES (?, ?, ?, ?)`,
+    [projectionId, targetType, targetId, role],
+  );
+}
+
+// ─── fixture ─────────────────────────────────────────────────────────────────
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ─── 1. Healthy projection graph ─────────────────────────────────────────────
+
+describe("healthy projection graph", () => {
+  test("single projection with one input evidence → no violations", () => {
+    const pid = ulid();
+    insertProjection(graph, pid);
+    // Add a minimal episode so it can be referenced
+    const epId = ulid();
+    graph.db.run(
+      `INSERT INTO episodes
+         (id, source_type, source_ref, content, content_hash,
+          status, timestamp, ingested_at, extractor_version)
+       VALUES (?, 'manual', ?, 'content', 'hash', 'active', ?, ?, '1.0')`,
+      [epId, ulid(), now(), now()],
+    );
+    insertEvidence(graph, pid, "episode", epId, "input");
+
+    const result = verifyGraph(graph);
+    const projViolations = result.violations.filter((v) =>
+      v.check.startsWith("checkProjection"),
+    );
+    expect(projViolations).toHaveLength(0);
+  });
+
+  test("linear supersession chain A→B → no cycle violation", () => {
+    const [pidA, pidB] = [ulid(), ulid()];
+    const epId = ulid();
+    graph.db.run(
+      `INSERT INTO episodes
+         (id, source_type, source_ref, content, content_hash,
+          status, timestamp, ingested_at, extractor_version)
+       VALUES (?, 'manual', ?, 'content', 'hash', 'active', ?, ?, '1.0')`,
+      [epId, ulid(), now(), now()],
+    );
+    // Insert B first (no superseded_by), then A pointing at B
+    graph.db.run("PRAGMA foreign_keys = OFF");
+    insertProjection(graph, pidB, null);
+    insertProjection(graph, pidA, pidB);
+    graph.db.run("PRAGMA foreign_keys = ON");
+    insertEvidence(graph, pidA, "episode", epId, "input");
+    insertEvidence(graph, pidB, "episode", epId, "input");
+
+    const result = verifyGraph(graph);
+    const cycleViolations = result.violations.filter(
+      (v) => v.check === "checkProjectionSupersessionCycles",
+    );
+    expect(cycleViolations).toHaveLength(0);
+  });
+});
+
+// ─── 2. Projection without evidence ──────────────────────────────────────────
+
+describe("checkProjectionEvidence", () => {
+  test("projection with no evidence rows produces error violation", () => {
+    const pid = ulid();
+    insertProjection(graph, pid);
+    // Deliberately insert no projection_evidence rows
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkProjectionEvidence" && x.entity_or_edge_id === pid,
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+
+  test("projection with only anchor evidence (role='anchor') still violates", () => {
+    const pid = ulid();
+    const epId = ulid();
+    graph.db.run(
+      `INSERT INTO episodes
+         (id, source_type, source_ref, content, content_hash,
+          status, timestamp, ingested_at, extractor_version)
+       VALUES (?, 'manual', ?, 'content', 'hash', 'active', ?, ?, '1.0')`,
+      [epId, ulid(), now(), now()],
+    );
+    insertProjection(graph, pid);
+    // Insert evidence with role='anchor', not 'input'
+    insertEvidence(graph, pid, "episode", epId, "anchor");
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+    const v = result.violations.find(
+      (x) =>
+        x.check === "checkProjectionEvidence" && x.entity_or_edge_id === pid,
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+  });
+
+  test("projection with role='input' evidence produces no violation", () => {
+    const pid = ulid();
+    const epId = ulid();
+    graph.db.run(
+      `INSERT INTO episodes
+         (id, source_type, source_ref, content, content_hash,
+          status, timestamp, ingested_at, extractor_version)
+       VALUES (?, 'manual', ?, 'content', 'hash', 'active', ?, ?, '1.0')`,
+      [epId, ulid(), now(), now()],
+    );
+    insertProjection(graph, pid);
+    insertEvidence(graph, pid, "episode", epId, "input");
+
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkProjectionEvidence",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ─── 3. Supersession cycle ────────────────────────────────────────────────────
+
+describe("checkProjectionSupersessionCycles", () => {
+  test("A→B→A supersession cycle is detected as error", () => {
+    const [pidA, pidB] = [ulid(), ulid()];
+    const epId = ulid();
+    graph.db.run(
+      `INSERT INTO episodes
+         (id, source_type, source_ref, content, content_hash,
+          status, timestamp, ingested_at, extractor_version)
+       VALUES (?, 'manual', ?, 'content', 'hash', 'active', ?, ?, '1.0')`,
+      [epId, ulid(), now(), now()],
+    );
+
+    // Disable FK checks to allow the cycle
+    graph.db.run("PRAGMA foreign_keys = OFF");
+    insertProjection(graph, pidA, pidB); // A superseded by B
+    insertProjection(graph, pidB, pidA); // B superseded by A → cycle!
+    graph.db.run("PRAGMA foreign_keys = ON");
+
+    // Both projections need evidence to avoid triggering that check too
+    insertEvidence(graph, pidA, "episode", epId, "input");
+    insertEvidence(graph, pidB, "episode", epId, "input");
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+
+    const v = result.violations.find(
+      (x) => x.check === "checkProjectionSupersessionCycles",
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+    expect(v?.message).toContain("cycle");
+  });
+
+  test("no superseded_by links → no cycle violations", () => {
+    const pid = ulid();
+    const epId = ulid();
+    graph.db.run(
+      `INSERT INTO episodes
+         (id, source_type, source_ref, content, content_hash,
+          status, timestamp, ingested_at, extractor_version)
+       VALUES (?, 'manual', ?, 'content', 'hash', 'active', ?, ?, '1.0')`,
+      [epId, ulid(), now(), now()],
+    );
+    insertProjection(graph, pid, null);
+    insertEvidence(graph, pid, "episode", epId, "input");
+
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkProjectionSupersessionCycles",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ─── 4. Projection-dependency DAG cycle ──────────────────────────────────────
+
+describe("checkProjectionDependencyCycles", () => {
+  test("A depends on B depends on A via evidence → cycle detected as error", () => {
+    const [pidA, pidB] = [ulid(), ulid()];
+    const epId = ulid();
+    graph.db.run(
+      `INSERT INTO episodes
+         (id, source_type, source_ref, content, content_hash,
+          status, timestamp, ingested_at, extractor_version)
+       VALUES (?, 'manual', ?, 'content', 'hash', 'active', ?, ?, '1.0')`,
+      [epId, ulid(), now(), now()],
+    );
+    insertProjection(graph, pidA);
+    insertProjection(graph, pidB);
+    // Give each an episode input (to avoid missing-evidence violations)
+    insertEvidence(graph, pidA, "episode", epId, "input");
+    insertEvidence(graph, pidB, "episode", epId, "input");
+    // Create the cycle: A depends on B and B depends on A
+    insertEvidence(graph, pidA, "projection", pidB, "input");
+    insertEvidence(graph, pidB, "projection", pidA, "input");
+
+    const result = verifyGraph(graph);
+    expect(result.valid).toBe(false);
+
+    const v = result.violations.find(
+      (x) => x.check === "checkProjectionDependencyCycles",
+    );
+    expect(v).toBeDefined();
+    expect(v?.severity).toBe("error");
+    expect(v?.message).toContain("cycle");
+  });
+
+  test("A depends on B (linear, acyclic) → no dependency cycle", () => {
+    const [pidA, pidB] = [ulid(), ulid()];
+    const epId = ulid();
+    graph.db.run(
+      `INSERT INTO episodes
+         (id, source_type, source_ref, content, content_hash,
+          status, timestamp, ingested_at, extractor_version)
+       VALUES (?, 'manual', ?, 'content', 'hash', 'active', ?, ?, '1.0')`,
+      [epId, ulid(), now(), now()],
+    );
+    insertProjection(graph, pidA);
+    insertProjection(graph, pidB);
+    insertEvidence(graph, pidA, "episode", epId, "input");
+    insertEvidence(graph, pidB, "episode", epId, "input");
+    // A depends on B, but B does NOT depend on A
+    insertEvidence(graph, pidA, "projection", pidB, "input");
+
+    const violations = verifyGraph(graph).violations.filter(
+      (v) => v.check === "checkProjectionDependencyCycles",
+    );
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ─── 5. v0.1 file (no projection tables) ─────────────────────────────────────
+
+describe("v0.1 compatibility", () => {
+  test("graph without projection tables skips projection checks cleanly", () => {
+    // Build a v0.1-like in-memory DB by starting from a full v0.2 graph and
+    // then dropping the projection-layer tables. This is simpler than trying
+    // to replay individual DDL strings (trigger DDL contains embedded semicolons
+    // that would confuse a naive splitter).
+    const rawDb = new Database(":memory:");
+    rawDb.run("PRAGMA journal_mode = WAL");
+    rawDb.run("PRAGMA foreign_keys = ON");
+
+    // Apply all DDL via exec (handles multi-statement strings correctly)
+    for (const stmt of SCHEMA_DDL) {
+      rawDb.exec(stmt);
+    }
+
+    // Now simulate a v0.1 file by dropping the v0.2 projection tables
+    rawDb.run("PRAGMA foreign_keys = OFF");
+    rawDb.run("DROP TABLE IF EXISTS projection_evidence");
+    rawDb.run("DROP TABLE IF EXISTS reconciliation_runs");
+    rawDb.run("DROP TABLE IF EXISTS projections_fts");
+    // Drop triggers that reference projections_fts before the table
+    rawDb.run("DROP TRIGGER IF EXISTS projections_ai");
+    rawDb.run("DROP TRIGGER IF EXISTS projections_ad");
+    rawDb.run("DROP TRIGGER IF EXISTS projections_au");
+    rawDb.run("DROP TABLE IF EXISTS projections");
+    rawDb.run("PRAGMA foreign_keys = ON");
+
+    // Seed required metadata
+    rawDb.run(
+      "INSERT INTO metadata (key, value) VALUES ('format_version', '0.1.0')",
+    );
+    rawDb.run(
+      "INSERT INTO metadata (key, value) VALUES ('engine_version', '0.1.0')",
+    );
+    rawDb.run("INSERT INTO metadata (key, value) VALUES ('created_at', ?)", [
+      now(),
+    ]);
+    rawDb.run(
+      "INSERT INTO metadata (key, value) VALUES ('owner_id', 'test-owner')",
+    );
+    rawDb.run(
+      "INSERT INTO metadata (key, value) VALUES ('default_timezone', 'UTC')",
+    );
+
+    // Wrap the raw DB in the EngramGraph shape expected by verifyGraph()
+    const v1Graph: EngramGraph = { db: rawDb } as EngramGraph;
+
+    let result: ReturnType<typeof verifyGraph> | undefined;
+    expect(() => {
+      result = verifyGraph(v1Graph);
+    }).not.toThrow();
+
+    // No projection-related violations
+    const projViolations = result?.violations.filter((v) =>
+      v.check.startsWith("checkProjection"),
+    );
+    expect(projViolations ?? []).toHaveLength(0);
+
+    rawDb.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `verifyGraph()` in `packages/engram-core/src/format/verify.ts` with three new projection-layer invariant checks
- `checkProjectionEvidence`: detects projections with no `role='input'` evidence rows
- `checkProjectionSupersessionCycles`: uses a recursive CTE (depth-guarded at 10 000) to detect cycles in `superseded_by` chains
- `checkProjectionDependencyCycles`: walks the projection→projection dependency graph (via `projection_evidence` where `target_type='projection'`) and detects DAG cycles
- All three checks skip cleanly on v0.1 files (no `projections` table) via an `sqlite_master` existence probe

## Acceptance Criteria

- [x] `checkProjectionEvidence` — projection with no `role='input'` evidence → error violation
- [x] `checkProjectionSupersessionCycles` — A→B→A cycle → error violation
- [x] `checkProjectionDependencyCycles` — A depends on B depends on A → error violation
- [x] v0.1 file (projection tables absent) → checks skip, no violations
- [x] Healthy projection graph → no violations
- [x] All checks are severity `error`

## Test plan

- `packages/engram-core/test/format/verify-projections.test.ts` — 10 tests, all passing
- Existing `verify.test.ts` suite — all passing (no regressions)
- `engram-core` package builds cleanly

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)