### PR TITLE
feat: add engram export wiki subcommand

### DIFF
--- a/packages/engram-cli/src/commands/export.ts
+++ b/packages/engram-cli/src/commands/export.ts
@@ -36,15 +36,32 @@ interface EpisodeRow {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Sanitize a string to be filesystem-safe.
- * Replaces non-alphanumeric chars with '-', truncates to 64 chars.
+ * Sanitize an anchor string to be filesystem-safe.
+ * Replaces non-alphanumeric chars (except underscores) with '-', truncates to 64 chars.
  */
 function toSlug(value: string): string {
   return value
-    .replace(/[^a-zA-Z0-9]/g, "-")
+    .replace(/[^a-zA-Z0-9_]/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 64);
+}
+
+/**
+ * Sanitize a kind string for use as a directory path component.
+ * Strips path-traversal chars (../, slashes, null) while preserving underscores
+ * so that kind names like "entity_summary" remain readable.
+ */
+function toKindPath(kind: string): string {
+  return (
+    kind
+      .replace(/[/\\]/g, "-")
+      .replace(/\.\./g, "-")
+      .replace(/\0/g, "")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 64) || "unknown"
+  );
 }
 
 /**
@@ -59,11 +76,11 @@ function shortId(id: string): string {
  * Pattern: <kind>/<anchor-slug>__<short-id>.md
  */
 function projectionFilename(projection: Projection): string {
+  // Sanitize kind as a path component — prevents directory traversal
+  // if a malicious DB row contains kind = "../evil".
+  const kindSlug = toKindPath(projection.kind);
   const anchorSlug = toSlug(projection.anchor_id ?? projection.anchor_type);
-  return path.join(
-    projection.kind,
-    `${anchorSlug}__${shortId(projection.id)}.md`,
-  );
+  return path.join(kindSlug, `${anchorSlug}__${shortId(projection.id)}.md`);
 }
 
 // ─── Wiki subcommand ──────────────────────────────────────────────────────────
@@ -131,7 +148,7 @@ function registerWiki(exportCmd: Command): void {
         for (const projection of projections) {
           const relPath = projectionFilename(projection);
           const absPath = path.join(outDir, relPath);
-          const kindDir = path.join(outDir, projection.kind);
+          const kindDir = path.join(outDir, toKindPath(projection.kind));
 
           fs.mkdirSync(kindDir, { recursive: true });
 

--- a/packages/engram-cli/src/commands/export.ts
+++ b/packages/engram-cli/src/commands/export.ts
@@ -2,13 +2,20 @@
  * export.ts — `engram export` command.
  *
  * Exports the graph as deterministic JSONL (one object per line, sorted by ID)
- * or as markdown summaries.
+ * or as markdown summaries. Includes `engram export wiki` subcommand.
  */
 
+import * as fs from "node:fs";
 import * as path from "node:path";
 import type { Command } from "commander";
-import type { EngramGraph } from "engram-core";
-import { closeGraph, findEdges, findEntities, openGraph } from "engram-core";
+import type { EngramGraph, Projection } from "engram-core";
+import {
+  closeGraph,
+  findEdges,
+  findEntities,
+  listActiveProjections,
+  openGraph,
+} from "engram-core";
 
 interface ExportOpts {
   format: string;
@@ -26,10 +33,173 @@ interface EpisodeRow {
   ingested_at: string;
 }
 
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Sanitize a string to be filesystem-safe.
+ * Replaces non-alphanumeric chars with '-', truncates to 64 chars.
+ */
+function toSlug(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 64);
+}
+
+/**
+ * Return the last 8 chars of a projection id as a short id.
+ */
+function shortId(id: string): string {
+  return id.slice(-8);
+}
+
+/**
+ * Build the output filename for a projection.
+ * Pattern: <kind>/<anchor-slug>__<short-id>.md
+ */
+function projectionFilename(projection: Projection): string {
+  const anchorSlug = toSlug(projection.anchor_id ?? projection.anchor_type);
+  return path.join(
+    projection.kind,
+    `${anchorSlug}__${shortId(projection.id)}.md`,
+  );
+}
+
+// ─── Wiki subcommand ──────────────────────────────────────────────────────────
+
+interface WikiOpts {
+  out: string;
+  scope?: string;
+  includeSuperseded: boolean;
+}
+
+interface WikiGlobalOpts {
+  db: string;
+}
+
+function registerWiki(exportCmd: Command): void {
+  exportCmd
+    .command("wiki")
+    .description("Materialize projections to a markdown folder (wiki export)")
+    .requiredOption("--out <dir>", "output directory for wiki files")
+    .option("--scope <kind>", "filter by projection kind (e.g. entity_summary)")
+    .option("--include-superseded", "include invalidated projections", false)
+    .action(function (this: Command, opts: WikiOpts) {
+      const globalOpts = this.optsWithGlobals<WikiGlobalOpts & WikiOpts>();
+      const dbPath = path.resolve(globalOpts.db ?? ".engram");
+      const outDir = path.resolve(opts.out);
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        console.error(
+          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      try {
+        // Query projections
+        let projections: Projection[];
+        if (opts.includeSuperseded) {
+          const kindFilter = opts.scope ? "WHERE kind = ?" : "";
+          const params = opts.scope ? [opts.scope] : [];
+          projections = graph.db
+            .query<Projection, string[]>(
+              `SELECT * FROM projections ${kindFilter} ORDER BY created_at DESC`,
+            )
+            .all(...params);
+        } else {
+          const results = listActiveProjections(graph, {
+            kind: opts.scope,
+          });
+          projections = results.map((r) => r.projection);
+        }
+
+        // Create output dir
+        fs.mkdirSync(outDir, { recursive: true });
+
+        // Track written files for index
+        const writtenByKind = new Map<
+          string,
+          Array<{ filename: string; anchorSlug: string }>
+        >();
+        let filesWritten = 0;
+
+        for (const projection of projections) {
+          const relPath = projectionFilename(projection);
+          const absPath = path.join(outDir, relPath);
+          const kindDir = path.join(outDir, projection.kind);
+
+          fs.mkdirSync(kindDir, { recursive: true });
+
+          if (fs.existsSync(absPath)) {
+            console.warn(`warn: overwriting existing file ${relPath}`);
+          }
+
+          // Write body verbatim (round-trip property)
+          fs.writeFileSync(absPath, projection.body, { encoding: "utf8" });
+          filesWritten++;
+
+          const anchorSlug = toSlug(
+            projection.anchor_id ?? projection.anchor_type,
+          );
+          const kindEntry = writtenByKind.get(projection.kind) ?? [];
+          kindEntry.push({ filename: relPath, anchorSlug });
+          writtenByKind.set(projection.kind, kindEntry);
+        }
+
+        // Write index.md
+        const now = new Date().toISOString();
+        const indexLines: string[] = [
+          "# Engram Wiki Export",
+          "",
+          `Generated: ${now}`,
+          "",
+        ];
+
+        for (const [kind, entries] of [...writtenByKind.entries()].sort()) {
+          indexLines.push(`## ${kind} (${entries.length})`);
+          for (const entry of entries) {
+            indexLines.push(
+              `- [${entry.anchorSlug}](${entry.filename.replace(/\\/g, "/")})`,
+            );
+          }
+          indexLines.push("");
+        }
+
+        const indexPath = path.join(outDir, "index.md");
+        if (fs.existsSync(indexPath)) {
+          console.warn("warn: overwriting existing file index.md");
+        }
+        fs.writeFileSync(indexPath, indexLines.join("\n"), {
+          encoding: "utf8",
+        });
+
+        console.log(`Wrote ${filesWritten} projection file(s) to ${outDir}`);
+        console.log(`Index: ${indexPath}`);
+      } catch (err) {
+        console.error(
+          `Wiki export failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        if (graph) closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+    });
+}
+
+// ─── Main export command ──────────────────────────────────────────────────────
+
 export function registerExport(program: Command): void {
-  program
+  const exportCmd = program
     .command("export")
-    .description("Export the knowledge graph to JSONL or markdown")
+    .description(
+      "Export the knowledge graph to JSONL, markdown, or wiki folder",
+    )
     .option("--format <fmt>", "output format: jsonl or md", "jsonl")
     .option("--db <path>", "path to .engram file", ".engram")
     .action((opts: ExportOpts) => {
@@ -122,4 +292,6 @@ export function registerExport(program: Command): void {
 
       closeGraph(graph);
     });
+
+  registerWiki(exportCmd);
 }

--- a/packages/engram-cli/test/commands/export-wiki.test.ts
+++ b/packages/engram-cli/test/commands/export-wiki.test.ts
@@ -1,0 +1,366 @@
+/**
+ * export-wiki.test.ts — Integration tests for `engram export wiki`.
+ *
+ * Projections are inserted via raw SQL to bypass the AI requirement of project().
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import type { EngramGraph } from "engram-core";
+import { closeGraph, createGraph } from "engram-core";
+import { registerExport } from "../../src/commands/export.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  registerExport(program);
+  return program;
+}
+
+interface TmpEnv {
+  tmpDir: string;
+  dbPath: string;
+  outDir: string;
+  graph: EngramGraph;
+}
+
+function makeTmpEnv(): TmpEnv {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-wiki-test-"));
+  const dbPath = path.join(tmpDir, "test.engram");
+  const outDir = path.join(tmpDir, "wiki-out");
+  const graph = createGraph(dbPath);
+  return { tmpDir, dbPath, outDir, graph };
+}
+
+/**
+ * Insert a projection row directly via raw SQL, bypassing the AI layer.
+ */
+function insertProjection(
+  graph: EngramGraph,
+  opts: {
+    kind: string;
+    anchor_type?: string;
+    anchor_id?: string | null;
+    title?: string;
+    body?: string;
+    invalidated_at?: string | null;
+  },
+): string {
+  const id = randomUUID().replace(/-/g, "").toUpperCase();
+  const now = new Date().toISOString();
+  graph.db.run(
+    `INSERT INTO projections
+       (id, kind, anchor_type, anchor_id, title, body, body_format, model,
+        input_fingerprint, confidence, valid_from, created_at, invalidated_at)
+     VALUES (?, ?, ?, ?, ?, ?, 'markdown', 'test-model', 'fp-test', 1.0, ?, ?, ?)`,
+    [
+      id,
+      opts.kind,
+      opts.anchor_type ?? "none",
+      opts.anchor_id ?? null,
+      opts.title ?? "Test Projection",
+      opts.body ?? `# ${opts.title ?? "Test Projection"}\n\nContent here.\n`,
+      now,
+      now,
+      opts.invalidated_at ?? null,
+    ],
+  );
+  return id;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("engram export wiki", () => {
+  let env: TmpEnv;
+
+  beforeEach(() => {
+    env = makeTmpEnv();
+  });
+
+  afterEach(() => {
+    try {
+      closeGraph(env.graph);
+    } catch {
+      // already closed in test body
+    }
+    fs.rmSync(env.tmpDir, { recursive: true, force: true });
+  });
+
+  it("command is registered under export", () => {
+    const program = makeProgram();
+    const exportCmd = program.commands.find((c) => c.name() === "export");
+    expect(exportCmd).toBeDefined();
+    const subNames = exportCmd?.commands.map((c) => c.name()) ?? [];
+    expect(subNames).toContain("wiki");
+  });
+
+  it("creates output dir and files for active projections", () => {
+    insertProjection(env.graph, {
+      kind: "entity_summary",
+      anchor_id: "alice-chen",
+      anchor_type: "entity",
+      body: "# Alice Chen\n\nSome content.\n",
+    });
+    closeGraph(env.graph);
+
+    const program = makeProgram();
+    program.parse([
+      "node",
+      "engram",
+      "export",
+      "wiki",
+      "--db",
+      env.dbPath,
+      "--out",
+      env.outDir,
+    ]);
+
+    expect(fs.existsSync(env.outDir)).toBe(true);
+    const kindDir = path.join(env.outDir, "entity_summary");
+    expect(fs.existsSync(kindDir)).toBe(true);
+
+    const files = fs.readdirSync(kindDir);
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/^alice-chen__[A-Z0-9]{8}\.md$/);
+  });
+
+  it("round-trip: exported body equals projection.body byte-for-byte", () => {
+    const body = "# My Projection\n\nExact content.\nWith newlines.\n";
+    insertProjection(env.graph, {
+      kind: "decision_page",
+      anchor_id: "auth-decision",
+      anchor_type: "entity",
+      body,
+    });
+    closeGraph(env.graph);
+
+    const program = makeProgram();
+    program.parse([
+      "node",
+      "engram",
+      "export",
+      "wiki",
+      "--db",
+      env.dbPath,
+      "--out",
+      env.outDir,
+    ]);
+
+    const kindDir = path.join(env.outDir, "decision_page");
+    const files = fs.readdirSync(kindDir);
+    expect(files.length).toBe(1);
+
+    const written = fs.readFileSync(path.join(kindDir, files[0]), "utf8");
+    expect(written).toBe(body);
+  });
+
+  it("default excludes invalidated projections", () => {
+    insertProjection(env.graph, {
+      kind: "entity_summary",
+      anchor_id: "active-entity",
+      anchor_type: "entity",
+    });
+    insertProjection(env.graph, {
+      kind: "entity_summary",
+      anchor_id: "old-entity",
+      anchor_type: "entity",
+      invalidated_at: new Date().toISOString(),
+    });
+    closeGraph(env.graph);
+
+    const program = makeProgram();
+    program.parse([
+      "node",
+      "engram",
+      "export",
+      "wiki",
+      "--db",
+      env.dbPath,
+      "--out",
+      env.outDir,
+    ]);
+
+    const kindDir = path.join(env.outDir, "entity_summary");
+    const files = fs.readdirSync(kindDir);
+    // Only the active projection should be exported
+    expect(files.length).toBe(1);
+  });
+
+  it("--include-superseded includes invalidated projections", () => {
+    insertProjection(env.graph, {
+      kind: "entity_summary",
+      anchor_id: "active-entity",
+      anchor_type: "entity",
+    });
+    // Insert superseded (invalidated) without anchor_id conflict (different anchor_id)
+    // by using a different kind to avoid unique constraint
+    insertProjection(env.graph, {
+      kind: "decision_page",
+      anchor_id: "old-decision",
+      anchor_type: "entity",
+      invalidated_at: new Date().toISOString(),
+    });
+    closeGraph(env.graph);
+
+    const program = makeProgram();
+    program.parse([
+      "node",
+      "engram",
+      "export",
+      "wiki",
+      "--db",
+      env.dbPath,
+      "--out",
+      env.outDir,
+      "--include-superseded",
+    ]);
+
+    // Should have files in both kind dirs
+    const entitySummaryFiles = fs.readdirSync(
+      path.join(env.outDir, "entity_summary"),
+    );
+    const decisionPageFiles = fs.readdirSync(
+      path.join(env.outDir, "decision_page"),
+    );
+    expect(entitySummaryFiles.length).toBe(1);
+    expect(decisionPageFiles.length).toBe(1);
+  });
+
+  it("--scope filters to only the specified kind", () => {
+    insertProjection(env.graph, {
+      kind: "entity_summary",
+      anchor_id: "entity-a",
+      anchor_type: "entity",
+    });
+    // Different anchor to avoid unique constraint
+    insertProjection(env.graph, {
+      kind: "decision_page",
+      anchor_id: "decision-b",
+      anchor_type: "entity",
+    });
+    closeGraph(env.graph);
+
+    const program = makeProgram();
+    program.parse([
+      "node",
+      "engram",
+      "export",
+      "wiki",
+      "--db",
+      env.dbPath,
+      "--out",
+      env.outDir,
+      "--scope",
+      "entity_summary",
+    ]);
+
+    expect(fs.existsSync(path.join(env.outDir, "entity_summary"))).toBe(true);
+    // decision_page should not be exported
+    expect(fs.existsSync(path.join(env.outDir, "decision_page"))).toBe(false);
+  });
+
+  it("creates output dir if missing", () => {
+    // Close graph so the action can open it
+    closeGraph(env.graph);
+    const nestedOut = path.join(env.outDir, "deep", "nested");
+
+    const program = makeProgram();
+    program.parse([
+      "node",
+      "engram",
+      "export",
+      "wiki",
+      "--db",
+      env.dbPath,
+      "--out",
+      nestedOut,
+    ]);
+
+    expect(fs.existsSync(nestedOut)).toBe(true);
+    expect(fs.existsSync(path.join(nestedOut, "index.md"))).toBe(true);
+  });
+
+  it("writes index.md grouping projections by kind", () => {
+    insertProjection(env.graph, {
+      kind: "entity_summary",
+      anchor_id: "person-a",
+      anchor_type: "entity",
+    });
+    insertProjection(env.graph, {
+      kind: "decision_page",
+      anchor_id: "decision-x",
+      anchor_type: "entity",
+    });
+    closeGraph(env.graph);
+
+    const program = makeProgram();
+    program.parse([
+      "node",
+      "engram",
+      "export",
+      "wiki",
+      "--db",
+      env.dbPath,
+      "--out",
+      env.outDir,
+    ]);
+
+    const indexContent = fs.readFileSync(
+      path.join(env.outDir, "index.md"),
+      "utf8",
+    );
+    expect(indexContent).toContain("# Engram Wiki Export");
+    expect(indexContent).toContain("## entity_summary (1)");
+    expect(indexContent).toContain("## decision_page (1)");
+    expect(indexContent).toContain("person-a");
+    expect(indexContent).toContain("decision-x");
+  });
+
+  it("overwrite existing file emits warn and does not error", () => {
+    insertProjection(env.graph, {
+      kind: "entity_summary",
+      anchor_id: "some-entity",
+      anchor_type: "entity",
+      body: "First write.\n",
+    });
+    closeGraph(env.graph);
+
+    // First export
+    const program1 = makeProgram();
+    program1.parse([
+      "node",
+      "engram",
+      "export",
+      "wiki",
+      "--db",
+      env.dbPath,
+      "--out",
+      env.outDir,
+    ]);
+
+    // Second export (should overwrite, not throw)
+    const program2 = makeProgram();
+    expect(() => {
+      program2.parse([
+        "node",
+        "engram",
+        "export",
+        "wiki",
+        "--db",
+        env.dbPath,
+        "--out",
+        env.outDir,
+      ]);
+    }).not.toThrow();
+
+    // File should still be readable
+    const kindDir = path.join(env.outDir, "entity_summary");
+    const files = fs.readdirSync(kindDir);
+    expect(files.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `engram export` with a `wiki` subcommand that materializes projections
  to a markdown folder structure
- Each projection body is written verbatim to `<out>/<kind>/<anchor-slug>__<short-id>.md`
- Generates an `index.md` listing all exported projections grouped by kind
- Supports `--scope <kind>` to filter by projection kind and `--include-superseded`
  to include invalidated projections (default: active only)

## Acceptance Criteria

- [x] Command registered: `engram export wiki`
- [x] Integration test: export seeds projections, checks file tree exists
- [x] Integration test: `--include-superseded` includes invalidated projections; default excludes them
- [x] Integration test: `--scope entity_summary` filters to only that kind
- [x] Integration test: round-trip — exported body equals `projection.body` byte-for-byte
- [x] Output dir created if missing; overwrite with warn
- [x] `index.md` lists projections grouped by kind

## Test plan

- [x] All 9 integration tests in `packages/engram-cli/test/commands/export-wiki.test.ts` pass
- [x] Full test suite: 547 pass, 4 fail (4 pre-existing `engram-web` failures unrelated to this PR)
- [x] Lint passes (`bun run lint` exits 0)

## Implementation notes

The wiki subcommand uses `this.optsWithGlobals()` to inherit the `--db` option from
the parent `export` command, avoiding a Commander option-shadowing issue where a
child `--db` option would be ignored in favour of the parent's.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)