### PR TITLE
feat: kind catalog for projection layer (v0.2 initial kinds)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,8 @@ When creating a PR that implements a GitHub issue:
 | `packages/engram-core/src/graph/` | Entity, edge, alias, evidence CRUD |
 | `packages/engram-core/src/temporal/` | Temporal logic (validity, supersession, snapshots) |
 | `packages/engram-core/src/ai/` | AI provider layer (NullProvider, OllamaProvider, GeminiProvider) |
+| `packages/engram-core/src/ai/kinds/` | Built-in projection kind catalog files (YAML). User overrides via `$XDG_CONFIG_HOME/engram/kinds/` (fallback `~/.config/engram/kinds/`). |
+| `packages/engram-core/src/ai/kinds.ts` | Kind catalog loader — `loadKindCatalog()`, `KindEntry`, `KindCatalog` |
 | `packages/engram-core/src/ingest/git.ts` | Git VCS ingestion (the "money command" engine) |
 | `packages/engram-core/src/ingest/adapter.ts` | EnrichmentAdapter interface |
 

--- a/docs/internal/specs/projection-kinds.md
+++ b/docs/internal/specs/projection-kinds.md
@@ -1,0 +1,168 @@
+# Projection Kind Catalog — Spec
+
+**Phase**: 2 (projection layer)
+**Status**: Accepted
+**Proposed**: 2026-04-10
+**Companion specs**: [`projections.md`](projections.md), [`format-v0.2.md`](format-v0.2.md)
+
+This spec defines the kind catalog for the projection layer introduced in ADR-002.
+A **kind** is a named template type that tells the discover phase what category of
+projection to author and what substrate inputs to assemble. The kind catalog ships
+with `engram-core` and may be extended via XDG user overrides.
+
+## Catalog Format: YAML
+
+Each kind is defined in its own YAML file. The format is a flat document with a
+fixed set of required fields plus optional notes.
+
+**Rationale for YAML over alternatives:**
+
+- *Markdown frontmatter* — frontmatter is good for hybrid docs/data, but kind
+  definitions are pure structured data with no freeform prose body. A standalone
+  YAML file is simpler to parse and easier to validate with a schema.
+- *JSON* — equivalent expressiveness, but less human-readable for the
+  `when_to_use` and `example_title_pattern` fields that contain prose. YAML
+  multiline strings (`|` block scalar) are significantly more readable.
+- *TOML* — reasonable choice but less idiomatic in the TypeScript/Node ecosystem
+  than YAML. No existing YAML parsing dependency to introduce.
+- *TypeScript objects* — coupling the catalog format to the runtime language
+  prevents user overrides from being plain text files. The XDG override path
+  requires a format a user can edit without a compiler.
+
+YAML wins because it combines easy-to-read multiline strings, zero new runtime
+dependencies (standard YAML parsing is available via Bun's built-in or a tiny
+library), and file-based editability for user overrides.
+
+## Location Convention
+
+Built-in kinds ship with `engram-core`:
+
+```
+packages/engram-core/src/ai/kinds/<kind-name>.yaml
+```
+
+User overrides are loaded from XDG config at runtime:
+
+```
+$XDG_CONFIG_HOME/engram/kinds/<kind-name>.yaml
+```
+
+The fallback when `$XDG_CONFIG_HOME` is not set:
+
+```
+~/.config/engram/kinds/<kind-name>.yaml
+```
+
+Override resolution is by **name match**: a user file whose `name` field matches a
+built-in kind replaces the built-in entirely. Partial overrides are not supported —
+the user file must supply all required fields.
+
+## Required Fields Per Kind
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Canonical kind identifier. Matches the `kind` column in `projections`. Snake_case. |
+| `description` | string | One sentence: what this kind of projection IS. |
+| `when_to_use` | string | Concrete guidance for the discover prompt: when to propose this kind, what conditions must be present. Multiline YAML string. |
+| `anchor_types` | string[] | Valid `anchor_type` values for this kind. Subset of `['entity', 'edge', 'episode', 'projection', 'none']`. |
+| `expected_inputs` | string[] | Human-readable list of substrate element types typically included in the input set. Not enforced at write time — guidance for the generator and discover prompt. |
+| `example_title_pattern` | string | Pattern for a representative projection title. Used in listings and the discover prompt's coverage catalog. May contain `{placeholder}` tokens. |
+
+All six fields are required. The loader validates at startup and refuses to serve a
+catalog with missing fields; a `KindValidationError` is thrown with the kind name
+and missing field(s).
+
+## Catalog Loading Semantics
+
+`loadKindCatalog()` is called once at process start (or lazily on first use) and
+cached in module scope. It:
+
+1. Reads all `*.yaml` files from the built-in directory
+   (`packages/engram-core/src/ai/kinds/`).
+2. Reads all `*.yaml` files from `$XDG_CONFIG_HOME/engram/kinds/` (or the
+   fallback path). Missing directory is silently ignored.
+3. Merges the two sets: for any `name` present in both, the XDG copy replaces
+   the built-in.
+4. Validates every entry against the required-field contract. Throws
+   `KindValidationError` for any invalid entry.
+5. Returns the merged, validated array.
+
+The result is a `KindCatalog` (an array of `KindEntry` objects) — see
+`packages/engram-core/src/ai/kinds.ts` for the TypeScript interface.
+
+### Loading in tests
+
+Tests may call `loadKindCatalog()` with an explicit override directory path
+(second argument) to inject test fixtures without touching the filesystem. The
+built-in directory is always the package-relative path; the XDG path is the
+overridable parameter.
+
+## Built-In Kinds (v0.2)
+
+### `entity_summary`
+
+A synthesis of what a given entity is: what it does, who works on it, how it
+relates to neighboring entities in the graph. The primary "wiki page" kind.
+
+### `decision_page`
+
+Documents a technical or process decision: what was decided, why, who made it,
+what alternatives were considered. Anchors to a decision-typed entity or to no
+anchor (for decisions that don't map to a single entity).
+
+### `contradiction_report`
+
+Identifies facts in the substrate or across projections that contradict each
+other. No anchor — this is a global or scoped analysis. The LLM cites the
+conflicting substrate elements as evidence.
+
+### `topic_cluster`
+
+Groups entities, edges, and episodes that share a common theme the LLM identifies
+as coherent but which may not have a single named entity as a hub. Useful for
+cross-cutting concerns (e.g. "authentication", "performance", "release infra").
+
+## Discover-Phase Prompt Integration
+
+The discover phase of `reconcile()` receives the kind catalog as a structured
+input:
+
+```ts
+const kindCatalog = loadKindCatalog();
+const proposals = await discoverer.propose({ delta, coverage, kindCatalog, budget });
+```
+
+The LLM reads the `name`, `description`, `when_to_use`, and `anchor_types` fields
+to decide which kinds apply to which parts of the substrate delta. It does **not**
+invent new kind names — all proposals reference a kind from the catalog. Unknown
+kinds are rejected at `project()` validation time.
+
+The `example_title_pattern` field is used when building the coverage catalog
+summary — it gives the LLM a sense of what a title for this kind looks like, which
+helps it avoid proposing projections that are functionally identical to existing
+ones.
+
+## Schema Validation
+
+The TypeScript loader (`kinds.ts`) validates each loaded entry against the
+`KindEntry` interface using a runtime check. The check is exhaustive:
+
+- All six required fields must be present and non-empty strings / non-empty arrays.
+- `anchor_types` entries must be a subset of valid anchor type strings.
+- `name` must match `^[a-z][a-z0-9_]*$` (snake_case, no hyphens).
+
+Validation happens at load time, not at projection-write time. The projection layer
+trusts that any `kind` string that passes the `project()` call is valid (it was
+proposed by the discover phase which only picks from the catalog). A secondary
+validation that `kind` is in the catalog may be added as a lint invariant in a
+future `verifyGraph()` extension.
+
+## Future Extensions
+
+- **Custom kinds from user config.** The XDG override path already supports adding
+  entirely new kinds (not just overriding built-ins). No code changes needed.
+- **Kind versioning.** A `version` field may be added to detect when a built-in
+  changes under an existing projection's `prompt_template_id`.
+- **Prompt template binding.** A `prompt_template_id` field may be added to
+  explicitly link a kind to a prompt file in `src/ai/prompts/`. Currently the
+  binding is by convention (same stem name).

--- a/packages/engram-core/src/ai/kinds.ts
+++ b/packages/engram-core/src/ai/kinds.ts
@@ -303,7 +303,7 @@ function loadKindsFromDir(dir: string): KindEntry[] {
   let files: string[];
 
   try {
-    files = readdirSync(dir).filter((f) => f.endsWith(".yaml"));
+    files = readdirSync(dir).filter((f) => f.endsWith(".yaml")).sort();
   } catch {
     return [];
   }

--- a/packages/engram-core/src/ai/kinds.ts
+++ b/packages/engram-core/src/ai/kinds.ts
@@ -1,0 +1,345 @@
+/**
+ * kinds.ts — KindCatalog loader for the projection layer.
+ *
+ * Loads projection kind definitions from:
+ *   1. Built-in kinds in packages/engram-core/src/ai/kinds/*.yaml
+ *   2. User overrides at $XDG_CONFIG_HOME/engram/kinds/*.yaml
+ *      (fallback: ~/.config/engram/kinds/*.yaml)
+ *
+ * Override resolution: XDG file whose `name` matches a built-in replaces it.
+ * New kinds in XDG are appended to the catalog.
+ *
+ * Validation: all required fields must be present and non-empty. Throws
+ * KindValidationError on any invalid entry.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * Valid anchor type strings for a projection kind.
+ * Mirrors the anchor_type column in the projections table.
+ */
+export type AnchorTypeName =
+  | "entity"
+  | "edge"
+  | "episode"
+  | "projection"
+  | "none";
+
+/**
+ * A single projection kind definition as loaded from a YAML catalog file.
+ */
+export interface KindEntry {
+  /** Canonical kind identifier. Snake_case. Matches projections.kind column. */
+  name: string;
+  /** One-sentence description of what this kind of projection IS. */
+  description: string;
+  /**
+   * Concrete guidance for the discover prompt: when to propose this kind,
+   * what conditions must be present in the substrate.
+   */
+  when_to_use: string;
+  /** Valid anchor_type values for this kind. */
+  anchor_types: AnchorTypeName[];
+  /**
+   * Human-readable list of substrate element types typically in the input set.
+   * Guidance for the generator and discover prompt; not enforced at write time.
+   */
+  expected_inputs: string[];
+  /**
+   * Pattern for a representative projection title.
+   * May contain {placeholder} tokens. Used in discover-phase coverage catalog.
+   */
+  example_title_pattern: string;
+}
+
+/** The full catalog: an ordered array of KindEntry objects. */
+export type KindCatalog = KindEntry[];
+
+// ─── Errors ──────────────────────────────────────────────────────────────────
+
+/** Thrown when a kind file fails validation (missing or invalid required fields). */
+export class KindValidationError extends Error {
+  constructor(
+    public readonly kindName: string,
+    public readonly missingFields: string[],
+    public readonly filePath: string,
+  ) {
+    super(
+      `KindValidationError: kind '${kindName}' in ${filePath} is missing required fields: ${missingFields.join(", ")}`,
+    );
+    this.name = "KindValidationError";
+  }
+}
+
+// ─── Valid anchor types ───────────────────────────────────────────────────────
+
+const VALID_ANCHOR_TYPES = new Set<string>([
+  "entity",
+  "edge",
+  "episode",
+  "projection",
+  "none",
+]);
+
+const KIND_NAME_RE = /^[a-z][a-z0-9_]*$/;
+
+// ─── YAML parser ─────────────────────────────────────────────────────────────
+
+/**
+ * Minimal YAML parser for the flat kind-definition format.
+ *
+ * Supported features (sufficient for kind files):
+ *   - Scalar string values: `key: value`
+ *   - Block scalars: `key: |` or `key: >` (folded/literal multiline strings)
+ *   - Block sequences: `key:\n  - item`
+ *   - Quoted strings: double-quote only
+ *
+ * Does NOT support: anchors, aliases, inline objects/arrays, complex types.
+ */
+function parseKindYaml(
+  text: string,
+  filePath: string,
+): Record<string, unknown> {
+  const lines = text.split("\n");
+  const result: Record<string, unknown> = {};
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Skip blank lines and comments
+    if (line.trim() === "" || line.trim().startsWith("#")) {
+      i++;
+      continue;
+    }
+
+    // Match a top-level key
+    const keyMatch = line.match(/^([a-z_][a-z0-9_]*):\s*(.*)/);
+    if (!keyMatch) {
+      i++;
+      continue;
+    }
+
+    const key = keyMatch[1];
+    const rest = keyMatch[2].trim();
+
+    // Block sequence (key:\n  - item)
+    if (rest === "") {
+      i++;
+      const items: string[] = [];
+      while (i < lines.length && lines[i].match(/^\s+-\s/)) {
+        const itemMatch = lines[i].match(/^\s+-\s+(.*)/);
+        if (itemMatch) {
+          items.push(stripQuotes(itemMatch[1].trim()));
+        }
+        i++;
+      }
+      result[key] = items;
+      continue;
+    }
+
+    // Block scalar: literal `|` or folded `>`
+    if (rest === "|" || rest === ">") {
+      const fold = rest === ">";
+      i++;
+      // Detect indentation from first non-empty line
+      let indent = -1;
+      const bodyLines: string[] = [];
+      while (i < lines.length) {
+        const bl = lines[i];
+        if (bl.trim() === "") {
+          bodyLines.push("");
+          i++;
+          continue;
+        }
+        const leadingSpaces = bl.match(/^(\s*)/)?.[1].length ?? 0;
+        if (indent === -1) indent = leadingSpaces;
+        if (leadingSpaces < indent) break;
+        bodyLines.push(bl.slice(indent));
+        i++;
+      }
+      // Remove trailing blank lines
+      while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === "") {
+        bodyLines.pop();
+      }
+      result[key] = fold
+        ? bodyLines.join(" ").replace(/\s+/g, " ").trim()
+        : bodyLines.join("\n");
+      continue;
+    }
+
+    // Inline value (possibly quoted)
+    result[key] = stripQuotes(rest);
+    i++;
+  }
+
+  // Unused — kept for context
+  void filePath;
+  return result;
+}
+
+function stripQuotes(s: string): string {
+  if (s.startsWith('"') && s.endsWith('"')) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+function validateEntry(
+  raw: Record<string, unknown>,
+  filePath: string,
+): KindEntry {
+  const missing: string[] = [];
+  const name = typeof raw.name === "string" ? raw.name.trim() : "";
+  const description =
+    typeof raw.description === "string" ? raw.description.trim() : "";
+  const when_to_use =
+    typeof raw.when_to_use === "string" ? raw.when_to_use.trim() : "";
+  const example_title_pattern =
+    typeof raw.example_title_pattern === "string"
+      ? raw.example_title_pattern.trim()
+      : "";
+
+  if (!name) missing.push("name");
+  if (!description) missing.push("description");
+  if (!when_to_use) missing.push("when_to_use");
+  if (!example_title_pattern) missing.push("example_title_pattern");
+
+  const rawAnchorTypes = raw.anchor_types;
+  if (!Array.isArray(rawAnchorTypes) || rawAnchorTypes.length === 0) {
+    missing.push("anchor_types");
+  }
+
+  const rawExpectedInputs = raw.expected_inputs;
+  if (!Array.isArray(rawExpectedInputs) || rawExpectedInputs.length === 0) {
+    missing.push("expected_inputs");
+  }
+
+  if (missing.length > 0) {
+    throw new KindValidationError(name || "(unknown)", missing, filePath);
+  }
+
+  // Validate name pattern
+  if (!KIND_NAME_RE.test(name)) {
+    throw new KindValidationError(
+      name,
+      [`name must match ${KIND_NAME_RE} (snake_case, no hyphens)`],
+      filePath,
+    );
+  }
+
+  // Validate anchor_types values
+  const anchor_types = rawAnchorTypes as string[];
+  const invalidAnchors = anchor_types.filter((a) => !VALID_ANCHOR_TYPES.has(a));
+  if (invalidAnchors.length > 0) {
+    throw new KindValidationError(
+      name,
+      [`invalid anchor_types: ${invalidAnchors.join(", ")}`],
+      filePath,
+    );
+  }
+
+  return {
+    name,
+    description,
+    when_to_use,
+    anchor_types: anchor_types as AnchorTypeName[],
+    expected_inputs: (rawExpectedInputs as string[]).map((s) => String(s)),
+    example_title_pattern,
+  };
+}
+
+// ─── Loader ──────────────────────────────────────────────────────────────────
+
+/** Resolve the built-in kinds directory relative to this module. */
+function builtInKindsDir(): string {
+  // Works both from source (src/ai/kinds.ts → src/ai/kinds/) and compiled
+  // (dist/kinds.js → dist/kinds/ won't exist, but src is what ships).
+  const thisFile = fileURLToPath(import.meta.url);
+  return resolve(thisFile, "..", "kinds");
+}
+
+/** Resolve the XDG override directory. */
+function xdgKindsDir(): string {
+  const xdgHome = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  return join(xdgHome, "engram", "kinds");
+}
+
+/**
+ * Load all YAML files from a directory and parse them into KindEntry objects.
+ * Returns an empty array if the directory does not exist.
+ */
+function loadKindsFromDir(dir: string): KindEntry[] {
+  if (!existsSync(dir)) return [];
+
+  const entries: KindEntry[] = [];
+  let files: string[];
+
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith(".yaml"));
+  } catch {
+    return [];
+  }
+
+  for (const file of files) {
+    const filePath = join(dir, file);
+    const text = readFileSync(filePath, "utf-8");
+    const raw = parseKindYaml(text, filePath);
+    const entry = validateEntry(raw, filePath);
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+/** Module-level cache. Reset in tests via the overrideDir parameter. */
+let _cache: KindCatalog | null = null;
+
+/**
+ * Load and return the merged kind catalog.
+ *
+ * Built-in kinds are loaded first. XDG override files whose `name` matches a
+ * built-in replace the built-in; unknown names are appended.
+ *
+ * @param overrideXdgDir - Optional path to use instead of the XDG directory.
+ *   Intended for tests only.
+ * @param useCache - Whether to return a cached result (default true). Pass
+ *   false in tests to force a fresh load.
+ */
+export function loadKindCatalog(
+  overrideXdgDir?: string,
+  useCache = true,
+): KindCatalog {
+  if (useCache && _cache !== null && overrideXdgDir === undefined) {
+    return _cache;
+  }
+
+  const builtIns = loadKindsFromDir(builtInKindsDir());
+  const xdgDir = overrideXdgDir ?? xdgKindsDir();
+  const overrides = loadKindsFromDir(xdgDir);
+
+  // Merge: XDG overrides by name match; new names are appended.
+  const catalog = new Map<string, KindEntry>();
+  for (const entry of builtIns) {
+    catalog.set(entry.name, entry);
+  }
+  for (const entry of overrides) {
+    catalog.set(entry.name, entry); // replaces or appends
+  }
+
+  const result: KindCatalog = Array.from(catalog.values());
+
+  if (useCache && overrideXdgDir === undefined) {
+    _cache = result;
+  }
+
+  return result;
+}

--- a/packages/engram-core/src/ai/kinds.ts
+++ b/packages/engram-core/src/ai/kinds.ts
@@ -102,10 +102,7 @@ const KIND_NAME_RE = /^[a-z][a-z0-9_]*$/;
  *
  * Does NOT support: anchors, aliases, inline objects/arrays, complex types.
  */
-function parseKindYaml(
-  text: string,
-  filePath: string,
-): Record<string, unknown> {
+function parseKindYaml(text: string): Record<string, unknown> {
   const lines = text.split("\n");
   const result: Record<string, unknown> = {};
   let i = 0;
@@ -168,9 +165,33 @@ function parseKindYaml(
       while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === "") {
         bodyLines.pop();
       }
-      result[key] = fold
-        ? bodyLines.join(" ").replace(/\s+/g, " ").trim()
-        : bodyLines.join("\n");
+      if (fold) {
+        // Folded scalar (`>`): blank lines become paragraph breaks (\n\n),
+        // non-blank lines within a paragraph are joined with a space.
+        // Per YAML spec, a blank line in the body is preserved as a newline.
+        const paragraphs: string[] = [];
+        let current: string[] = [];
+        for (const bl of bodyLines) {
+          if (bl === "") {
+            if (current.length > 0) {
+              paragraphs.push(current.join(" "));
+              current = [];
+            }
+            paragraphs.push("");
+          } else {
+            current.push(bl.trim());
+          }
+        }
+        if (current.length > 0) {
+          paragraphs.push(current.join(" "));
+        }
+        result[key] = paragraphs
+          .join("\n")
+          .replace(/\n{3,}/g, "\n\n")
+          .trim();
+      } else {
+        result[key] = bodyLines.join("\n");
+      }
       continue;
     }
 
@@ -179,8 +200,6 @@ function parseKindYaml(
     i++;
   }
 
-  // Unused — kept for context
-  void filePath;
   return result;
 }
 
@@ -291,8 +310,15 @@ function loadKindsFromDir(dir: string): KindEntry[] {
 
   for (const file of files) {
     const filePath = join(dir, file);
-    const text = readFileSync(filePath, "utf-8");
-    const raw = parseKindYaml(text, filePath);
+    let text: string;
+    try {
+      text = readFileSync(filePath, "utf-8");
+    } catch (err) {
+      throw new Error(
+        `Failed to read kind file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    const raw = parseKindYaml(text);
     const entry = validateEntry(raw, filePath);
     entries.push(entry);
   }

--- a/packages/engram-core/src/ai/kinds/contradiction_report.yaml
+++ b/packages/engram-core/src/ai/kinds/contradiction_report.yaml
@@ -1,0 +1,34 @@
+name: contradiction_report
+description: >
+  Identifies facts in the substrate or across projections that directly
+  contradict each other, explaining what each source claims and why the
+  claims are incompatible.
+when_to_use: |
+  Propose a contradiction_report when:
+  - Two or more active edges with the same source and target entities carry
+    conflicting relation_type or edge_kind values (e.g. both 'owns' and
+    'does_not_own' with overlapping validity windows, or two 'observed' edges
+    asserting opposite facts).
+  - Two active entity_summary projections make contradictory claims about the
+    same entity or the same fact (detectable when the discover prompt finds
+    body text that logically conflicts across projections).
+  - An episode explicitly documents a disagreement or reversal ("this
+    contradicts the earlier decision", "PR reverted because", "issue: conflicting
+    behavior") and no contradiction_report yet captures it.
+  - An edge was superseded with a 'contradicted' verdict in the most recent
+    reconcile assess phase — the supersession event is evidence of a conflict
+    worth documenting.
+  Use anchor_type='none' unless the contradiction is tightly scoped to a single
+  entity or projection (in which case anchor to that entity or projection).
+  Do not propose a contradiction_report for stale projections that merely have
+  different fingerprints — staleness is not contradiction.
+anchor_types:
+  - none
+  - projection
+expected_inputs:
+  - Pairs of edges with conflicting facts (same source/target, overlapping
+    validity, contradictory relation or content)
+  - Entity_summary projections whose bodies assert conflicting facts
+  - Episodes that document disagreements, reversals, or issue reports
+  - The superseded edge or projection rows that record the contradiction event
+example_title_pattern: "Contradiction: {subject}"

--- a/packages/engram-core/src/ai/kinds/decision_page.yaml
+++ b/packages/engram-core/src/ai/kinds/decision_page.yaml
@@ -1,0 +1,31 @@
+name: decision_page
+description: >
+  A record of a technical or process decision: what was decided, why it was
+  made, who participated, and what alternatives were considered and rejected.
+when_to_use: |
+  Propose a decision_page when:
+  - A cluster of PR and issue episodes (2 or more) reference a named technical
+    decision or architectural choice and no decision_page projection exists for
+    it yet.
+  - An entity of type 'decision' or 'adr' appears in the substrate with
+    supporting episode evidence but no decision_page projection.
+  - Commit or PR bodies include explicit decision language ("we decided to",
+    "rejected because", "chosen over", "trade-off") and the decision is
+    significant enough to warrant its own page (affects ≥2 other entities or
+    spans ≥1 week of discussion).
+  - An existing decision_page's anchor entity has new edges superseding
+    previously recorded alternatives or rationale.
+  Anchor to the decision entity if one exists. Use anchor_type='none' only if
+  the decision is emergent from episodes (e.g. a migration choice spread across
+  multiple PRs with no single entity).
+anchor_types:
+  - entity
+  - none
+expected_inputs:
+  - PR episodes that describe or discuss the decision
+  - Issue episodes that document the problem motivating the decision
+  - Commit episodes that implement the decision
+  - Entities representing alternatives that were considered
+  - Edges encoding the rationale relationship ('decided_because', 'supersedes',
+    'rejected_in_favor_of')
+example_title_pattern: "Decision: {decision_name}"

--- a/packages/engram-core/src/ai/kinds/entity_summary.yaml
+++ b/packages/engram-core/src/ai/kinds/entity_summary.yaml
@@ -1,0 +1,25 @@
+name: entity_summary
+description: >
+  A synthesis of what a single entity is — what it does, who works on it, its
+  key relationships to neighboring entities, and how it has changed over time.
+when_to_use: |
+  Propose an entity_summary when:
+  - A new entity has appeared in the substrate with 3 or more distinct evidence
+    episodes and no active entity_summary projection yet.
+  - An existing entity_summary is stale because 5 or more new episodes have been
+    added since it was last generated.
+  - An entity's edges have been substantially superseded (≥2 active edges
+    replaced) and the existing entity_summary does not reflect the new structure.
+  - An entity is referenced by multiple other projections but lacks its own
+    entity_summary — it is a "hub node" in the coverage graph.
+  Do NOT propose a new entity_summary if the existing one is marked stale but
+  the stale_reason is only 'input_content_changed' for minor commits (e.g.
+  formatting-only changes). The assess phase handles those.
+anchor_types:
+  - entity
+expected_inputs:
+  - Episodes that cite the anchor entity (commits, PRs, manual notes)
+  - Active edges where the anchor entity is source or target
+  - Related entity rows (name, entity_type, description) for neighbors
+  - Any existing projections anchored to the same entity
+example_title_pattern: "{entity_name}"

--- a/packages/engram-core/src/ai/kinds/topic_cluster.yaml
+++ b/packages/engram-core/src/ai/kinds/topic_cluster.yaml
@@ -1,0 +1,29 @@
+name: topic_cluster
+description: >
+  A named cluster of entities, edges, and episodes that share a common theme
+  identified by the LLM as coherent, even when no single hub entity represents
+  the theme.
+when_to_use: |
+  Propose a topic_cluster when:
+  - 4 or more entities and/or episodes in the substrate delta share a common
+    theme (e.g. "authentication", "database migrations", "CI/CD pipeline") that
+    is not captured by any existing entity, entity_summary, or topic_cluster.
+  - A cross-cutting concern touches many unrelated parts of the codebase and a
+    topic_cluster would serve as the index page linking them (think: Obsidian
+    map-of-content page).
+  - The substrate contains a coherent "storyline" across multiple PRs and
+    commits (e.g. a multi-week refactor) that lacks a single anchor entity.
+  - An existing topic_cluster is stale because new episodes significantly
+    expand or contract the theme.
+  Do NOT propose a topic_cluster that duplicates an entity_summary — if a
+  single named entity adequately represents the cluster, use entity_summary
+  instead. Topic clusters are for emergent themes, not for named components.
+  Anchor type is always 'none' — the cluster itself is the organizing artifact.
+anchor_types:
+  - none
+expected_inputs:
+  - Entities thematically linked by the cluster topic
+  - Edges connecting cluster members to each other
+  - Episodes (commits, PRs) that reference the theme across multiple entities
+  - Existing projections (entity_summaries, decision_pages) for cluster members
+example_title_pattern: "Topic: {theme_name}"

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -12,6 +12,11 @@ export {
   NullProvider,
   OllamaProvider,
 } from "./ai/index.js";
+export type { AnchorTypeName, KindCatalog, KindEntry } from "./ai/kinds.js";
+export {
+  KindValidationError,
+  loadKindCatalog,
+} from "./ai/kinds.js";
 export type {
   AssessVerdict,
   ProjectionGenerator,

--- a/packages/engram-core/test/ai/kinds.test.ts
+++ b/packages/engram-core/test/ai/kinds.test.ts
@@ -1,0 +1,405 @@
+/**
+ * kinds.test.ts — Unit tests for the KindCatalog loader.
+ *
+ * Tests cover:
+ *   - Happy path: built-in kinds load with all required fields
+ *   - XDG override: custom kind file merges in and can override a built-in
+ *   - Validation error: YAML missing required fields throws KindValidationError
+ *   - Cache behavior: calling loadKindCatalog() twice returns same reference
+ *   - Non-existent override dir: returns just built-ins without error
+ *   - Folded block scalar: blank lines preserved as paragraph breaks
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { KindValidationError, loadKindCatalog } from "../../src/ai/kinds.js";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+const BUILTIN_NAMES = [
+  "entity_summary",
+  "decision_page",
+  "topic_cluster",
+  "contradiction_report",
+];
+
+const REQUIRED_FIELDS = [
+  "name",
+  "description",
+  "when_to_use",
+  "anchor_types",
+  "expected_inputs",
+  "example_title_pattern",
+] as const;
+
+/** Create a temp directory, returning its path. Cleaned up by the test. */
+function makeTempDir(): string {
+  const dir = join(
+    tmpdir(),
+    `kinds-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Write a minimal valid kind YAML file into a directory. */
+function writeKindYaml(dir: string, filename: string, content: string): string {
+  const filePath = join(dir, filename);
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+const MINIMAL_VALID_YAML = `
+name: test_kind
+description: A test projection kind.
+when_to_use: Use this kind in tests.
+anchor_types:
+  - entity
+expected_inputs:
+  - Episodes referencing the anchor entity
+example_title_pattern: "Test: {name}"
+`.trim();
+
+// ─── Built-in kinds ───────────────────────────────────────────────────────────
+
+describe("loadKindCatalog — built-in kinds", () => {
+  test("loads exactly four built-in kinds", () => {
+    const catalog = loadKindCatalog(undefined, false);
+    expect(catalog).toHaveLength(4);
+  });
+
+  test("all four built-in kinds are present by name", () => {
+    const catalog = loadKindCatalog(undefined, false);
+    const names = catalog.map((k) => k.name);
+    for (const expected of BUILTIN_NAMES) {
+      expect(names).toContain(expected);
+    }
+  });
+
+  test("every built-in kind has all required fields populated", () => {
+    const catalog = loadKindCatalog(undefined, false);
+    for (const entry of catalog) {
+      for (const field of REQUIRED_FIELDS) {
+        expect(entry[field]).toBeTruthy();
+      }
+    }
+  });
+
+  test("every built-in kind has non-empty anchor_types array", () => {
+    const catalog = loadKindCatalog(undefined, false);
+    for (const entry of catalog) {
+      expect(Array.isArray(entry.anchor_types)).toBe(true);
+      expect(entry.anchor_types.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every built-in kind has non-empty expected_inputs array", () => {
+    const catalog = loadKindCatalog(undefined, false);
+    for (const entry of catalog) {
+      expect(Array.isArray(entry.expected_inputs)).toBe(true);
+      expect(entry.expected_inputs.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── XDG override ─────────────────────────────────────────────────────────────
+
+describe("loadKindCatalog — XDG override", () => {
+  let xdgDir: string;
+
+  beforeEach(() => {
+    xdgDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(xdgDir, { recursive: true, force: true });
+  });
+
+  test("appends a new custom kind from the override directory", () => {
+    writeKindYaml(xdgDir, "test_kind.yaml", MINIMAL_VALID_YAML);
+    const catalog = loadKindCatalog(xdgDir, false);
+    // four built-ins + one custom
+    expect(catalog).toHaveLength(5);
+    const names = catalog.map((k) => k.name);
+    expect(names).toContain("test_kind");
+  });
+
+  test("override kind with matching name replaces the built-in", () => {
+    const overrideYaml = `
+name: entity_summary
+description: Custom overridden entity summary kind.
+when_to_use: Use this overridden kind.
+anchor_types:
+  - entity
+  - projection
+expected_inputs:
+  - Custom input type
+example_title_pattern: "Override: {entity_name}"
+`.trim();
+
+    writeKindYaml(xdgDir, "entity_summary.yaml", overrideYaml);
+    const catalog = loadKindCatalog(xdgDir, false);
+
+    // Still four total — the override replaced, not appended
+    expect(catalog).toHaveLength(4);
+
+    const entry = catalog.find((k) => k.name === "entity_summary");
+    expect(entry).toBeDefined();
+    expect(entry?.description).toBe("Custom overridden entity summary kind.");
+    expect(entry?.anchor_types).toContain("projection");
+  });
+
+  test("custom kind fields are fully populated", () => {
+    writeKindYaml(xdgDir, "test_kind.yaml", MINIMAL_VALID_YAML);
+    const catalog = loadKindCatalog(xdgDir, false);
+    const entry = catalog.find((k) => k.name === "test_kind");
+    expect(entry).toBeDefined();
+    expect(entry?.description).toBe("A test projection kind.");
+    expect(entry?.when_to_use).toBe("Use this kind in tests.");
+    expect(entry?.anchor_types).toEqual(["entity"]);
+    expect(entry?.expected_inputs).toEqual([
+      "Episodes referencing the anchor entity",
+    ]);
+    expect(entry?.example_title_pattern).toBe("Test: {name}");
+  });
+});
+
+// ─── Validation errors ────────────────────────────────────────────────────────
+
+describe("loadKindCatalog — validation errors", () => {
+  let xdgDir: string;
+
+  beforeEach(() => {
+    xdgDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(xdgDir, { recursive: true, force: true });
+  });
+
+  test("throws KindValidationError when required scalar fields are missing", () => {
+    const badYaml = `
+name: bad_kind
+anchor_types:
+  - entity
+expected_inputs:
+  - something
+`.trim();
+    // description, when_to_use, example_title_pattern all missing
+    writeKindYaml(xdgDir, "bad_kind.yaml", badYaml);
+    expect(() => loadKindCatalog(xdgDir, false)).toThrow(KindValidationError);
+  });
+
+  test("KindValidationError message includes kind name and missing field names", () => {
+    const badYaml = `
+name: incomplete_kind
+description: Has a description.
+anchor_types:
+  - entity
+expected_inputs:
+  - something
+`.trim();
+    // when_to_use and example_title_pattern missing
+    writeKindYaml(xdgDir, "incomplete_kind.yaml", badYaml);
+    try {
+      loadKindCatalog(xdgDir, false);
+      expect(true).toBe(false); // should not reach here
+    } catch (err) {
+      expect(err).toBeInstanceOf(KindValidationError);
+      const kve = err as KindValidationError;
+      expect(kve.kindName).toBe("incomplete_kind");
+      expect(kve.missingFields).toContain("when_to_use");
+      expect(kve.missingFields).toContain("example_title_pattern");
+    }
+  });
+
+  test("throws KindValidationError when anchor_types array is empty", () => {
+    const badYaml = `
+name: no_anchors
+description: Missing anchors.
+when_to_use: Use it.
+anchor_types:
+expected_inputs:
+  - something
+example_title_pattern: "No anchors: {x}"
+`.trim();
+    writeKindYaml(xdgDir, "no_anchors.yaml", badYaml);
+    expect(() => loadKindCatalog(xdgDir, false)).toThrow(KindValidationError);
+  });
+
+  test("throws KindValidationError when expected_inputs array is empty", () => {
+    const badYaml = `
+name: no_inputs
+description: Missing inputs.
+when_to_use: Use it.
+anchor_types:
+  - entity
+expected_inputs:
+example_title_pattern: "No inputs: {x}"
+`.trim();
+    writeKindYaml(xdgDir, "no_inputs.yaml", badYaml);
+    expect(() => loadKindCatalog(xdgDir, false)).toThrow(KindValidationError);
+  });
+
+  test("KindValidationError includes the file path", () => {
+    const badYaml = `
+name: path_check_kind
+anchor_types:
+  - entity
+expected_inputs:
+  - something
+`.trim();
+    const fp = writeKindYaml(xdgDir, "path_check_kind.yaml", badYaml);
+    try {
+      loadKindCatalog(xdgDir, false);
+      expect(true).toBe(false); // should not reach here
+    } catch (err) {
+      expect(err).toBeInstanceOf(KindValidationError);
+      const kve = err as KindValidationError;
+      expect(kve.filePath).toBe(fp);
+    }
+  });
+});
+
+// ─── Cache behavior ───────────────────────────────────────────────────────────
+
+describe("loadKindCatalog — cache behavior", () => {
+  test("calling loadKindCatalog() twice without args returns same array reference", () => {
+    // Force a fresh load first to ensure cache is populated
+    const first = loadKindCatalog(undefined, false);
+    // Now call with default (useCache=true); the module cache should be set
+    const second = loadKindCatalog();
+    // Both should contain the same built-in kinds
+    expect(second.map((k) => k.name)).toEqual(first.map((k) => k.name));
+  });
+
+  test("useCache=false always returns a fresh load with the same content", () => {
+    const a = loadKindCatalog(undefined, false);
+    const b = loadKindCatalog(undefined, false);
+    expect(b.map((k) => k.name).sort()).toEqual(a.map((k) => k.name).sort());
+  });
+
+  test("overrideXdgDir bypasses cache but does not pollute module cache", () => {
+    const xdgDir = makeTempDir();
+    try {
+      writeKindYaml(xdgDir, "custom_kind.yaml", MINIMAL_VALID_YAML);
+      const withOverride = loadKindCatalog(xdgDir, false);
+      expect(withOverride).toHaveLength(5);
+
+      // Module cache (no overrideXdgDir) should not have the custom kind
+      const fromCache = loadKindCatalog();
+      expect(fromCache).toHaveLength(4);
+    } finally {
+      rmSync(xdgDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Non-existent override dir ────────────────────────────────────────────────
+
+describe("loadKindCatalog — non-existent override dir", () => {
+  test("returns only built-ins when override dir does not exist", () => {
+    const nonExistent = join(tmpdir(), "engram-kinds-does-not-exist-xyz123");
+    const catalog = loadKindCatalog(nonExistent, false);
+    expect(catalog).toHaveLength(4);
+    const names = catalog.map((k) => k.name);
+    for (const expected of BUILTIN_NAMES) {
+      expect(names).toContain(expected);
+    }
+  });
+
+  test("does not throw when override dir does not exist", () => {
+    const nonExistent = join(tmpdir(), "engram-kinds-does-not-exist-abc999");
+    expect(() => loadKindCatalog(nonExistent, false)).not.toThrow();
+  });
+});
+
+// ─── Folded block scalar (`>`) ────────────────────────────────────────────────
+
+describe("loadKindCatalog — folded block scalar paragraph breaks", () => {
+  let xdgDir: string;
+
+  beforeEach(() => {
+    xdgDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    rmSync(xdgDir, { recursive: true, force: true });
+  });
+
+  test("folded scalar with blank line separator produces two paragraphs", () => {
+    // Uses `>` block scalar with a blank line between two paragraphs
+    const yaml = `
+name: folded_test
+description: >
+  First paragraph line one
+  first paragraph line two.
+
+  Second paragraph line one
+  second paragraph line two.
+when_to_use: Use it.
+anchor_types:
+  - entity
+expected_inputs:
+  - something
+example_title_pattern: "Folded: {x}"
+`.trim();
+
+    writeKindYaml(xdgDir, "folded_test.yaml", yaml);
+    const catalog = loadKindCatalog(xdgDir, false);
+    const entry = catalog.find((k) => k.name === "folded_test");
+    expect(entry).toBeDefined();
+
+    // Blank line in folded scalar must produce a paragraph break, not be eaten
+    expect(entry?.description).toContain("\n\n");
+    expect(entry?.description).toContain("First paragraph");
+    expect(entry?.description).toContain("Second paragraph");
+  });
+
+  test("folded scalar without blank lines joins lines with single space", () => {
+    const yaml = `
+name: folded_single
+description: >
+  Line one
+  line two
+  line three.
+when_to_use: Use it.
+anchor_types:
+  - entity
+expected_inputs:
+  - something
+example_title_pattern: "Single: {x}"
+`.trim();
+
+    writeKindYaml(xdgDir, "folded_single.yaml", yaml);
+    const catalog = loadKindCatalog(xdgDir, false);
+    const entry = catalog.find((k) => k.name === "folded_single");
+    expect(entry).toBeDefined();
+    expect(entry?.description).toBe("Line one line two line three.");
+    expect(entry?.description).not.toContain("\n");
+  });
+
+  test("literal scalar (`|`) preserves newlines as-is", () => {
+    const yaml = `
+name: literal_test
+description: A literal kind.
+when_to_use: |
+  Step one.
+  Step two.
+  Step three.
+anchor_types:
+  - entity
+expected_inputs:
+  - something
+example_title_pattern: "Literal: {x}"
+`.trim();
+
+    writeKindYaml(xdgDir, "literal_test.yaml", yaml);
+    const catalog = loadKindCatalog(xdgDir, false);
+    const entry = catalog.find((k) => k.name === "literal_test");
+    expect(entry).toBeDefined();
+    expect(entry?.when_to_use).toBe("Step one.\nStep two.\nStep three.");
+  });
+});


### PR DESCRIPTION
## Summary

- **Spec doc** at `docs/internal/specs/projection-kinds.md`: documents the catalog format (YAML, with full justification), location convention, XDG override path, required fields, loading semantics, and discover-phase prompt integration
- **Four built-in kind files** at `packages/engram-core/src/ai/kinds/`: `entity_summary`, `decision_page`, `contradiction_report`, `topic_cluster` — each with all required fields and concrete `when_to_use` guidance
- **TypeScript loader** at `packages/engram-core/src/ai/kinds.ts`: `loadKindCatalog()` function, `KindEntry` interface, `KindCatalog` type, `KindValidationError`, built-in YAML parser (no new dependencies), XDG override merge
- **`packages/engram-core/src/index.ts`** updated to export `KindCatalog`, `KindEntry`, `KindValidationError`, `loadKindCatalog`, and `AnchorTypeName`
- **`CLAUDE.md`** updated with `packages/engram-core/src/ai/kinds/` and `packages/engram-core/src/ai/kinds.ts` in the Key Files table, including XDG override path documentation

## Acceptance Criteria

- [x] Spec doc exists at `docs/internal/specs/projection-kinds.md`
- [x] Catalog format justified (YAML: flat structure, human-editable, multiline strings, no new runtime dependency)
- [x] All four kinds have catalog files with all required fields populated
- [x] `when_to_use` guidance is concrete enough for the discover prompt to use directly (each entry has 4–5 specific triggering conditions)
- [x] CLAUDE.md updated with `packages/engram-core/src/ai/kinds/` in Key Files table
- [x] CLAUDE.md mentions XDG override path (`$XDG_CONFIG_HOME/engram/kinds/`)

## Test plan

- [x] `bun run lint` — passes (0 errors)
- [x] `bun run build` — all packages build successfully
- [x] `bun test` — 570 tests pass, 0 failures

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)