### PR TITLE
feat: reconcile discover phase with emergent projection authoring

### DIFF
--- a/packages/engram-core/src/ai/projection-generator.ts
+++ b/packages/engram-core/src/ai/projection-generator.ts
@@ -75,7 +75,13 @@ export interface ProjectionProposal {
   kind: string;
   /**
    * Optional anchor entity/edge/episode for the projection.
-   * Null means anchor_type='none' (graph-wide projections).
+   *
+   * `null` means graph-wide (no specific anchor). When null, the projection will
+   * be stored with anchor_type='none' and anchor_id=null.
+   *
+   * NOTE: Do NOT use `{ type: 'none', id: '...' }` in proposals — `type: 'none'`
+   * is an internal database storage value only and is not valid as proposal input.
+   * Use `anchor: null` for graph-wide projections.
    */
   anchor: { type: string; id: string } | null;
   /**

--- a/packages/engram-core/src/ai/projection-generator.ts
+++ b/packages/engram-core/src/ai/projection-generator.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Projection } from "../graph/projections.js";
+import type { KindCatalog } from "./kinds.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -23,6 +24,67 @@ export interface ResolvedInput {
   content: string | null;
   /** SHA-256 hash of the content at resolution time. */
   content_hash: string | null;
+}
+
+/**
+ * A summary of one active projection used as input to the discover phase.
+ * Contains identity and recency metadata — not the projection body.
+ */
+export interface ActiveProjectionSummary {
+  id: string;
+  kind: string;
+  title: string;
+  anchor_type: string;
+  anchor_id: string | null;
+  last_assessed_at: string | null;
+}
+
+/**
+ * A single substrate element (episode, entity, or edge) included in the
+ * substrate delta passed to ProjectionGenerator.discover().
+ */
+export interface SubstrateDeltaItem {
+  type: "episode" | "entity" | "edge";
+  id: string;
+  /** Short summary of the item's content (not the full content). */
+  summary: string;
+  /** ISO8601 UTC timestamp when this item was added or last modified. */
+  changed_at: string;
+}
+
+/**
+ * The substrate delta since the last non-dry-run reconcile for the same scope.
+ * Passed to ProjectionGenerator.discover() as context for new proposals.
+ */
+export interface SubstrateDelta {
+  since: string | null;
+  episodes: SubstrateDeltaItem[];
+  entities: SubstrateDeltaItem[];
+  edges: SubstrateDeltaItem[];
+}
+
+/**
+ * A proposal from ProjectionGenerator.discover() for a new projection to author.
+ *
+ * Each proposal contains the kind, optional anchor, list of input IDs, and a
+ * rationale explaining why the generator believes this projection is worth
+ * authoring. The authoring loop calls project() for each accepted proposal.
+ */
+export interface ProjectionProposal {
+  /** Projection kind identifier (must match a KindEntry.name from the catalog). */
+  kind: string;
+  /**
+   * Optional anchor entity/edge/episode for the projection.
+   * Null means anchor_type='none' (graph-wide projections).
+   */
+  anchor: { type: string; id: string } | null;
+  /**
+   * List of substrate inputs the projection should summarise.
+   * Each entry must be a resolvable {type, id} pair from the substrate.
+   */
+  inputs: Array<{ type: string; id: string }>;
+  /** Short explanation of why this projection is worth authoring now. */
+  rationale: string;
 }
 
 /**
@@ -79,6 +141,29 @@ export interface ProjectionGenerator {
     projection: Projection,
     currentInputs: ResolvedInput[],
   ): Promise<{ body: string; confidence: number }>;
+
+  /**
+   * Discover new projections to author from the substrate delta.
+   *
+   * Called during the reconcile() discover phase. The generator is given:
+   * - `delta`: substrate items added or changed since the last non-dry-run
+   *   reconcile for the same scope (episodes, entities, edges).
+   * - `catalog`: active projection summaries — what projections already exist,
+   *   used to avoid proposing duplicates and to identify coverage gaps.
+   * - `kinds`: the full KindCatalog, so the generator knows which kinds are
+   *   available, when to use each, and what inputs are expected.
+   *
+   * Returns an ordered array of ProjectionProposal objects. The authoring loop
+   * calls project() for each proposal that passes validation. Returning [] is
+   * valid (the generator believes no new projections are warranted).
+   *
+   * Must never throw. On internal error, return [].
+   */
+  discover(ctx: {
+    delta: SubstrateDelta;
+    catalog: ActiveProjectionSummary[];
+    kinds: KindCatalog;
+  }): Promise<ProjectionProposal[]>;
 }
 
 // ─── NullGenerator ───────────────────────────────────────────────────────────
@@ -88,6 +173,7 @@ export interface ProjectionGenerator {
  *
  * generate() always throws — projections require an AI generator.
  * assess() and regenerate() also throw for consistency.
+ * discover() returns [] — no proposals without an AI provider.
  */
 export class NullGenerator implements ProjectionGenerator {
   async generate(
@@ -115,6 +201,17 @@ export class NullGenerator implements ProjectionGenerator {
     throw new Error(
       "NullGenerator: no AI provider configured — cannot regenerate projections.",
     );
+  }
+
+  /**
+   * NullGenerator.discover() always returns [] — no AI provider means no proposals.
+   */
+  async discover(_ctx: {
+    delta: SubstrateDelta;
+    catalog: ActiveProjectionSummary[];
+    kinds: KindCatalog;
+  }): Promise<ProjectionProposal[]> {
+    return [];
   }
 }
 
@@ -196,5 +293,22 @@ export class AnthropicGenerator implements ProjectionGenerator {
     // Production would call Anthropic with the old body as context.
     void projection;
     return this.generate(inputs);
+  }
+
+  /**
+   * AnthropicGenerator.discover() stub — returns [] in this placeholder.
+   *
+   * Production implementation would call the Anthropic API with a structured
+   * prompt built from the substrate delta, coverage catalog, and kind catalog,
+   * then parse the response into ProjectionProposal[].
+   */
+  async discover(_ctx: {
+    delta: SubstrateDelta;
+    catalog: ActiveProjectionSummary[];
+    kinds: KindCatalog;
+  }): Promise<ProjectionProposal[]> {
+    // Stub: in production this would issue a structured LLM call to propose
+    // new projections. For now return [] so the pipeline works end-to-end.
+    return [];
   }
 }

--- a/packages/engram-core/src/graph/reconcile.ts
+++ b/packages/engram-core/src/graph/reconcile.ts
@@ -1,8 +1,25 @@
 /**
- * reconcile.ts — reconcile() assess phase and softRefresh() helper.
+ * reconcile.ts — reconcile() assess + discover phases and softRefresh() helper.
  *
  * Implements Operation 2 from docs/internal/specs/projections.md.
- * The discover phase is stubbed as a no-op (out of scope for this issue).
+ *
+ * ## Assess phase
+ * Re-evaluates every stale active projection whose input_fingerprint has drifted.
+ * For each stale projection the generator verdict determines whether to
+ * softRefresh (still_accurate) or supersedeProjection (needs_update/contradicted).
+ *
+ * ## Discover phase
+ * Computes the substrate delta since the last non-dry-run reconcile run (same
+ * scope), loads the active-projection catalog and kind catalog, then calls
+ * generator.discover() to obtain ProjectionProposal[]. Each accepted proposal
+ * is authored via project(). Dry runs count proposals but skip authoring.
+ * Partial runs (budget exhausted) record what was authored and advance the cursor.
+ *
+ * Cursor semantics:
+ * - Dry runs do NOT advance the cursor (projections_discovered stays 0 for dry runs).
+ * - Partial runs advance the cursor to what was successfully authored.
+ * - The cursor is the `completed_at` timestamp of the last non-dry-run
+ *   reconciliation_runs row with the same scope.
  *
  * Exported: reconcile, softRefresh, currentInputState, ReconcileOpts, ReconciliationRunResult
  */
@@ -10,14 +27,20 @@
 import { createHash } from "node:crypto";
 import { ulid } from "ulid";
 import { Budget } from "../ai/budget.js";
+import { loadKindCatalog } from "../ai/kinds.js";
 import type {
+  ActiveProjectionSummary,
   ProjectionGenerator,
+  ProjectionProposal,
   ResolvedInput,
+  SubstrateDelta,
+  SubstrateDeltaItem,
 } from "../ai/projection-generator.js";
 import type { EngramGraph } from "../format/index.js";
-import { supersedeProjection } from "./projections.js";
+import { project, supersedeProjection } from "./projections.js";
 import { listActiveProjections } from "./projections-list.js";
 import type {
+  AnchorType,
   Projection,
   ProjectionEvidenceRow,
   ProjectionInputType,
@@ -42,8 +65,12 @@ export interface ReconciliationRunResult {
   assessed: number;
   superseded: number;
   soft_refreshed: number;
+  /** Number of new projections authored during the discover phase. */
+  discovered: number;
   started_at: string;
   completed_at: string;
+  /** Set when status='partial' to explain why the run did not complete. */
+  error?: string;
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
@@ -70,7 +97,7 @@ function startReconciliationRun(
 }
 
 /**
- * Updates the reconciliation_runs row with final counts and status.
+ * Updates the reconciliation_runs row with final counts, status, and optional error.
  */
 function finishReconciliationRun(
   graph: EngramGraph,
@@ -80,6 +107,8 @@ function finishReconciliationRun(
   assessed: number,
   refreshed: number,
   superseded: number,
+  discovered: number,
+  error?: string,
 ): void {
   graph.db
     .prepare(
@@ -88,10 +117,21 @@ function finishReconciliationRun(
               status = ?,
               projections_checked = ?,
               projections_refreshed = ?,
-              projections_superseded = ?
+              projections_superseded = ?,
+              projections_discovered = ?,
+              error = ?
         WHERE id = ?`,
     )
-    .run(completedAt, status, assessed, refreshed, superseded, runId);
+    .run(
+      completedAt,
+      status,
+      assessed,
+      refreshed,
+      superseded,
+      discovered,
+      error ?? null,
+      runId,
+    );
 }
 
 /**
@@ -293,6 +333,208 @@ export function softRefresh(
   })();
 }
 
+// ─── Discover phase helpers ───────────────────────────────────────────────────
+
+/**
+ * Returns the completed_at timestamp of the last non-dry-run reconciliation run
+ * for the given scope. Returns null if no such run exists (fresh database).
+ *
+ * This is the cursor for the discover phase: episodes/entities/edges added or
+ * changed after this timestamp are included in the substrate delta.
+ */
+function lastNonDryRunCompletedAt(
+  graph: EngramGraph,
+  scope?: string,
+): string | null {
+  const row = graph.db
+    .query<{ completed_at: string | null }, [number, string | null]>(
+      `SELECT completed_at FROM reconciliation_runs
+        WHERE dry_run = ? AND scope IS ? AND status != 'running'
+          AND completed_at IS NOT NULL
+        ORDER BY completed_at DESC
+        LIMIT 1`,
+    )
+    .get(0, scope ?? null);
+  return row?.completed_at ?? null;
+}
+
+/**
+ * Computes the substrate delta since the given cursor timestamp (or all rows if
+ * cursor is null). Returns a SubstrateDelta with short summaries for each item.
+ *
+ * Only includes non-redacted episodes, non-archived entities, and non-invalidated
+ * edges to avoid surfacing deleted substrate in discover proposals.
+ *
+ * Column mapping:
+ * - episodes: cursor column is `ingested_at` (episodes have no `created_at`)
+ * - entities: cursor column is `created_at`
+ * - edges: cursor column is `created_at`
+ */
+function computeSubstrateDelta(
+  graph: EngramGraph,
+  since: string | null,
+): SubstrateDelta {
+  // Episodes — use ingested_at as the timestamp column
+  const episodeRows = since
+    ? graph.db
+        .query<{ id: string; content: string; ingested_at: string }, [string]>(
+          `SELECT id, content, ingested_at FROM episodes
+            WHERE status != 'redacted' AND ingested_at > ?
+            ORDER BY ingested_at ASC`,
+        )
+        .all(since)
+    : graph.db
+        .query<{ id: string; content: string; ingested_at: string }, []>(
+          `SELECT id, content, ingested_at FROM episodes
+            WHERE status != 'redacted'
+            ORDER BY ingested_at ASC`,
+        )
+        .all();
+
+  const episodes: SubstrateDeltaItem[] = episodeRows.map((row) => ({
+    type: "episode" as const,
+    id: row.id,
+    summary: row.content.slice(0, 200),
+    changed_at: row.ingested_at,
+  }));
+
+  // Entities — use created_at
+  const entityRows = since
+    ? graph.db
+        .query<
+          {
+            id: string;
+            canonical_name: string;
+            summary: string | null;
+            created_at: string;
+          },
+          [string]
+        >(
+          `SELECT id, canonical_name, summary, created_at FROM entities
+            WHERE status != 'archived' AND created_at > ?
+            ORDER BY created_at ASC`,
+        )
+        .all(since)
+    : graph.db
+        .query<
+          {
+            id: string;
+            canonical_name: string;
+            summary: string | null;
+            created_at: string;
+          },
+          []
+        >(
+          `SELECT id, canonical_name, summary, created_at FROM entities
+            WHERE status != 'archived'
+            ORDER BY created_at ASC`,
+        )
+        .all();
+
+  const entities: SubstrateDeltaItem[] = entityRows.map((row) => ({
+    type: "entity" as const,
+    id: row.id,
+    summary: `${row.canonical_name}${row.summary ? `: ${row.summary}` : ""}`,
+    changed_at: row.created_at,
+  }));
+
+  // Edges — use created_at, non-invalidated only
+  const edgeRows = since
+    ? graph.db
+        .query<{ id: string; fact: string; created_at: string }, [string]>(
+          `SELECT id, fact, created_at FROM edges
+            WHERE invalidated_at IS NULL AND created_at > ?
+            ORDER BY created_at ASC`,
+        )
+        .all(since)
+    : graph.db
+        .query<{ id: string; fact: string; created_at: string }, []>(
+          `SELECT id, fact, created_at FROM edges
+            WHERE invalidated_at IS NULL
+            ORDER BY created_at ASC`,
+        )
+        .all();
+
+  const edges: SubstrateDeltaItem[] = edgeRows.map((row) => ({
+    type: "edge" as const,
+    id: row.id,
+    summary: row.fact.slice(0, 200),
+    changed_at: row.created_at,
+  }));
+
+  return { since, episodes, entities, edges };
+}
+
+/**
+ * Loads the active-projection catalog for the discover phase.
+ * Returns lightweight summaries — no projection bodies — to keep context small.
+ */
+function loadActiveProjectionCatalog(
+  graph: EngramGraph,
+  scope?: string,
+): ActiveProjectionSummary[] {
+  const scopeOpts = parseScopeToOpts(scope);
+  const results = listActiveProjections(graph, scopeOpts);
+  return results.map((r) => ({
+    id: r.projection.id,
+    kind: r.projection.kind,
+    title: r.projection.title,
+    anchor_type: r.projection.anchor_type,
+    anchor_id: r.projection.anchor_id,
+    last_assessed_at: r.projection.last_assessed_at,
+  }));
+}
+
+/**
+ * Validates a ProjectionProposal from the generator before calling project().
+ *
+ * Returns an error string if the proposal is malformed, or null if valid.
+ *
+ * Checks:
+ * - kind must be a non-empty string matching a known KindCatalog entry
+ * - inputs must be a non-empty array with valid type strings
+ * - anchor.type (if provided) must be a valid AnchorType
+ */
+function validateProposal(
+  proposal: ProjectionProposal,
+  knownKinds: Set<string>,
+): string | null {
+  if (!proposal.kind || typeof proposal.kind !== "string") {
+    return "proposal.kind must be a non-empty string";
+  }
+  if (!knownKinds.has(proposal.kind)) {
+    return `proposal.kind '${proposal.kind}' is not in the kind catalog`;
+  }
+  if (!Array.isArray(proposal.inputs) || proposal.inputs.length === 0) {
+    return "proposal.inputs must be a non-empty array";
+  }
+  const validInputTypes = new Set(["episode", "entity", "edge", "projection"]);
+  for (const inp of proposal.inputs) {
+    if (!inp.type || !validInputTypes.has(inp.type)) {
+      return `proposal.inputs entry has invalid type '${inp.type}'`;
+    }
+    if (!inp.id || typeof inp.id !== "string") {
+      return `proposal.inputs entry missing id`;
+    }
+  }
+  if (proposal.anchor !== null) {
+    const validAnchorTypes = new Set([
+      "entity",
+      "edge",
+      "episode",
+      "projection",
+      "none",
+    ]);
+    if (!proposal.anchor.type || !validAnchorTypes.has(proposal.anchor.type)) {
+      return `proposal.anchor.type '${proposal.anchor.type}' is not a valid AnchorType`;
+    }
+    if (!proposal.anchor.id || typeof proposal.anchor.id !== "string") {
+      return `proposal.anchor.id must be a non-empty string when anchor is provided`;
+    }
+  }
+  return null;
+}
+
 // ─── Scope filter helper ──────────────────────────────────────────────────────
 
 /**
@@ -316,14 +558,24 @@ function parseScopeToOpts(scope?: string): {
 // ─── reconcile() ─────────────────────────────────────────────────────────────
 
 /**
- * Reconciliation loop — assess phase (discover phase is a no-op stub).
+ * Reconciliation loop — assess phase and discover phase.
  *
+ * ## Assess phase
  * For each stale active projection whose input_fingerprint has drifted:
  * - Calls generator.assess() to determine the verdict.
  * - 'still_accurate': calls softRefresh() to update fingerprint + evidence hashes.
  * - 'needs_update' | 'contradicted': calls generator.regenerate() then supersedeProjection().
- * - If dryRun=true, tracks counts but skips writes.
- * - Stops early if the budget is exhausted (status='partial').
+ *
+ * ## Discover phase
+ * Computes the substrate delta since the last non-dry-run reconcile (same scope),
+ * loads the active-projection catalog and kind catalog, then calls
+ * generator.discover() to get ProjectionProposal[]. Each proposal is validated
+ * then authored via project(). Dry runs count proposals but skip authoring.
+ *
+ * Both phases:
+ * - If dryRun=true, track counts but skip all database writes.
+ * - Stop early if the budget is exhausted (status='partial').
+ * - Dry runs do NOT advance the discover cursor.
  *
  * Inserts a reconciliation_runs row at start and updates it at completion.
  */
@@ -343,7 +595,9 @@ export async function reconcile(
   let assessed = 0;
   let superseded = 0;
   let softRefreshed = 0;
+  let discovered = 0;
   let budgetHit = false;
+  let partialReason: string | undefined;
 
   // ── Phase 1: assess existing active projections ────────────────────────────
   if (phases.includes("assess")) {
@@ -356,6 +610,7 @@ export async function reconcile(
     for (const result of staleResults) {
       if (budget.exhausted()) {
         budgetHit = true;
+        partialReason = "budget exhausted during assess phase";
         break;
       }
 
@@ -393,6 +648,7 @@ export async function reconcile(
         case "contradicted": {
           if (budget.exhausted()) {
             budgetHit = true;
+            partialReason = "budget exhausted during assess phase (regenerate)";
             break;
           }
 
@@ -422,13 +678,90 @@ export async function reconcile(
 
       if (budget.exhausted()) {
         budgetHit = true;
+        partialReason = "budget exhausted during assess phase";
         break;
       }
     }
   }
 
-  // ── Phase 2: discover new projections (stub — out of scope) ───────────────
-  // The discover phase is not implemented in this issue. It is a no-op here.
+  // ── Phase 2: discover new projections from the substrate delta ─────────────
+  //
+  // Flow:
+  // 1. Resolve cursor: completed_at of last non-dry-run reconcile (same scope).
+  // 2. Compute substrate delta since cursor (episodes, entities, edges).
+  // 3. Load active-projection catalog (titles, kinds, anchors — not bodies).
+  // 4. Load kind catalog via loadKindCatalog().
+  // 5. Call generator.discover({ delta, catalog, kinds }) → ProjectionProposal[].
+  // 6. For each proposal: validate → project() → increment discovered.
+  // 7. Budget exhaustion mid-phase sets status='partial' and records reason.
+  //
+  // Dry runs count proposals but skip project() authoring and do not advance cursor.
+  if (phases.includes("discover") && !budgetHit) {
+    const kindCatalog = loadKindCatalog();
+    const knownKinds = new Set(kindCatalog.map((k) => k.name));
+
+    const cursor = lastNonDryRunCompletedAt(graph, opts?.scope);
+    const delta = computeSubstrateDelta(graph, cursor);
+    const catalog = loadActiveProjectionCatalog(graph, opts?.scope);
+
+    // Single structured LLM call to propose new projections
+    const proposals = await generator.discover({
+      delta,
+      catalog,
+      kinds: kindCatalog,
+    });
+    budget.consume(1); // one discover call counts as one budget unit
+
+    for (const proposal of proposals) {
+      if (budget.exhausted()) {
+        budgetHit = true;
+        partialReason = "budget exhausted during discover phase";
+        break;
+      }
+
+      // Validate proposal structure before attempting project()
+      const validationError = validateProposal(proposal, knownKinds);
+      if (validationError) {
+        // Skip malformed proposals — log-worthy but not fatal
+        // In production this would be a warn() call; for now just skip.
+        continue;
+      }
+
+      if (!dryRun) {
+        try {
+          await project(graph, {
+            kind: proposal.kind,
+            anchor: proposal.anchor
+              ? {
+                  type: proposal.anchor.type as AnchorType,
+                  id: proposal.anchor.id,
+                }
+              : { type: "none" as AnchorType },
+            inputs: proposal.inputs.map((i) => ({
+              type: i.type as "episode" | "entity" | "edge" | "projection",
+              id: i.id,
+            })),
+            generator,
+          });
+          discovered++;
+        } catch (_err) {
+          // project() throws on cycle detection, missing inputs, etc.
+          // Skip this proposal and continue — partial authoring is valid.
+          continue;
+        }
+      } else {
+        // Dry run: count the proposal but don't author it
+        discovered++;
+      }
+
+      budget.consume(1); // one project() call counts as one budget unit
+    }
+
+    if (budget.exhausted() && !budgetHit) {
+      budgetHit = true;
+      partialReason = "budget exhausted during discover phase";
+    }
+  }
 
   const completedAt = new Date().toISOString();
   const status: "completed" | "partial" = budgetHit ? "partial" : "completed";
@@ -441,6 +774,8 @@ export async function reconcile(
     assessed,
     softRefreshed,
     superseded,
+    discovered,
+    partialReason,
   );
 
   return {
@@ -449,8 +784,10 @@ export async function reconcile(
     assessed,
     superseded,
     soft_refreshed: softRefreshed,
+    discovered,
     started_at: startedAt,
     completed_at: completedAt,
+    error: partialReason,
   };
 }
 

--- a/packages/engram-core/src/graph/reconcile.ts
+++ b/packages/engram-core/src/graph/reconcile.ts
@@ -16,7 +16,8 @@
  * Partial runs (budget exhausted) record what was authored and advance the cursor.
  *
  * Cursor semantics:
- * - Dry runs do NOT advance the cursor (projections_discovered stays 0 for dry runs).
+ * - Dry runs count proposals (discovered > 0 is possible) but do NOT author them
+ *   and do NOT advance the cursor.
  * - Partial runs advance the cursor to what was successfully authored.
  * - The cursor is the `completed_at` timestamp of the last non-dry-run
  *   reconciliation_runs row with the same scope.
@@ -517,7 +518,7 @@ function validateProposal(
       return `proposal.inputs entry missing id`;
     }
   }
-  if (proposal.anchor !== null) {
+  if (proposal.anchor != null) {
     const validAnchorTypes = new Set([
       "entity",
       "edge",

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -18,9 +18,13 @@ export {
   loadKindCatalog,
 } from "./ai/kinds.js";
 export type {
+  ActiveProjectionSummary,
   AssessVerdict,
   ProjectionGenerator,
+  ProjectionProposal,
   ResolvedInput,
+  SubstrateDelta,
+  SubstrateDeltaItem,
 } from "./ai/projection-generator.js";
 export {
   AnthropicGenerator,

--- a/packages/engram-core/test/graph/reconcile.test.ts
+++ b/packages/engram-core/test/graph/reconcile.test.ts
@@ -4,17 +4,23 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type {
+  ActiveProjectionSummary,
   AssessVerdict,
   EngramGraph,
   Projection,
   ProjectionGenerator,
+  ProjectionProposal,
   ResolvedInput,
+  SubstrateDelta,
 } from "../../src/index.js";
 import {
+  addEdge,
+  addEntity,
   addEpisode,
   closeGraph,
   createGraph,
   currentInputState,
+  listActiveProjections,
   project,
   reconcile,
   softRefresh,
@@ -23,7 +29,7 @@ import {
 // ─── MockGenerator ────────────────────────────────────────────────────────────
 
 interface MockGeneratorCall {
-  method: "generate" | "assess" | "regenerate";
+  method: "generate" | "assess" | "regenerate" | "discover";
   projectionId?: string;
 }
 
@@ -31,6 +37,7 @@ function makeMockGenerator(opts?: {
   assessVerdict?: AssessVerdict;
   regenerateBody?: string;
   tokensPerCall?: number;
+  discoverProposals?: ProjectionProposal[];
 }): ProjectionGenerator & { calls: MockGeneratorCall[] } {
   const calls: MockGeneratorCall[] = [];
 
@@ -77,6 +84,15 @@ function makeMockGenerator(opts?: {
         opts?.regenerateBody ??
         (await (this as ProjectionGenerator).generate(inputs)).body;
       return { body, confidence: 0.9 };
+    },
+
+    async discover(_ctx: {
+      delta: SubstrateDelta;
+      catalog: ActiveProjectionSummary[];
+      kinds: import("../../src/index.js").KindCatalog;
+    }): Promise<ProjectionProposal[]> {
+      calls.push({ method: "discover" });
+      return opts?.discoverProposals ?? [];
     },
   };
 }
@@ -640,5 +656,406 @@ describe("currentInputState()", () => {
 
     const inputs = currentInputState(graph, "bare-id");
     expect(inputs).toEqual([]);
+  });
+});
+
+// ─── reconcile() — discover phase ────────────────────────────────────────────
+
+describe("reconcile() — discover phase — integration", () => {
+  test("seeds substrate, discover proposals are authored, projections_discovered updated", async () => {
+    // Seed substrate with an episode
+    const ep = makeEpisode("some important event happened");
+
+    // Generator returns one valid proposal for the episode
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep.id }],
+          rationale: "This episode describes an important event",
+        },
+      ],
+    });
+
+    const result = await reconcile(graph, gen, { phases: ["discover"] });
+
+    expect(result.discovered).toBe(1);
+    expect(result.assessed).toBe(0);
+    expect(result.status).toBe("completed");
+
+    // Verify a projection was actually written
+    const projections = listActiveProjections(graph, {});
+    expect(projections.length).toBe(1);
+    expect(projections[0].projection.kind).toBe("entity_summary");
+
+    // Verify projections_discovered in reconciliation_runs
+    const row = graph.db
+      .query<{ projections_discovered: number }, [string]>(
+        "SELECT projections_discovered FROM reconciliation_runs WHERE id = ?",
+      )
+      .get(result.run_id);
+    expect(row?.projections_discovered).toBe(1);
+  });
+
+  test("discover phase is skipped when phases = ['assess'] only", async () => {
+    const ep = makeEpisode("some episode");
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep.id }],
+          rationale: "should not be called",
+        },
+      ],
+    });
+
+    const result = await reconcile(graph, gen, { phases: ["assess"] });
+
+    expect(result.discovered).toBe(0);
+    // No projections should have been authored
+    const projections = listActiveProjections(graph, {});
+    expect(projections.length).toBe(0);
+    // discover() should not have been called
+    const discoverCalls = gen.calls.filter((c) => c.method === "discover");
+    expect(discoverCalls.length).toBe(0);
+  });
+
+  test("discover phase runs when phases = ['discover'] only", async () => {
+    const ep = makeEpisode("discover only test");
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep.id }],
+          rationale: "a good reason",
+        },
+      ],
+    });
+
+    const result = await reconcile(graph, gen, { phases: ["discover"] });
+
+    expect(result.discovered).toBe(1);
+    const discoverCalls = gen.calls.filter((c) => c.method === "discover");
+    expect(discoverCalls.length).toBe(1);
+  });
+
+  test("cursor: dry run does not persist or advance cursor", async () => {
+    const ep = makeEpisode("ephemeral");
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep.id }],
+          rationale: "dry run proposal",
+        },
+      ],
+    });
+
+    // Run a dry run
+    const dryResult = await reconcile(graph, gen, {
+      phases: ["discover"],
+      dryRun: true,
+    });
+
+    // Dry run counts the proposal but does NOT author the projection
+    expect(dryResult.discovered).toBe(1);
+    const projections = listActiveProjections(graph, {});
+    expect(projections.length).toBe(0);
+
+    // Dry run row is marked dry_run=1
+    const runRow = graph.db
+      .query<{ dry_run: number; status: string }, [string]>(
+        "SELECT dry_run, status FROM reconciliation_runs WHERE id = ?",
+      )
+      .get(dryResult.run_id);
+    expect(runRow?.dry_run).toBe(1);
+    expect(runRow?.status).toBe("completed");
+
+    // Cursor for subsequent non-dry-run discover phase should still be null
+    // (no non-dry-run run has completed yet)
+    const lastNonDryRun = graph.db
+      .query<{ completed_at: string | null }, [number]>(
+        "SELECT completed_at FROM reconciliation_runs WHERE dry_run = ? AND completed_at IS NOT NULL ORDER BY completed_at DESC LIMIT 1",
+      )
+      .get(0);
+    expect(lastNonDryRun).toBeNull();
+  });
+
+  test("cursor: second run only sees delta since first run completed", async () => {
+    const ep1 = makeEpisode("first episode before cursor");
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep1.id }],
+          rationale: "first run proposal",
+        },
+      ],
+    });
+
+    // First non-dry-run discover
+    const firstResult = await reconcile(graph, gen, { phases: ["discover"] });
+    expect(firstResult.discovered).toBe(1);
+    expect(firstResult.status).toBe("completed");
+
+    // Second run — generator returns empty proposals
+    // The delta since first run completed should be empty (no new substrate)
+    let capturedDelta: SubstrateDelta | null = null;
+    const gen2 = makeMockGenerator({ discoverProposals: [] });
+    // Monkey-patch discover to capture the delta
+    const originalDiscover = gen2.discover.bind(gen2);
+    gen2.discover = async (ctx) => {
+      capturedDelta = ctx.delta;
+      return originalDiscover(ctx);
+    };
+
+    const secondResult = await reconcile(graph, gen2, { phases: ["discover"] });
+    expect(secondResult.discovered).toBe(0);
+
+    // Delta should have a non-null `since` (the first run's completed_at)
+    expect(capturedDelta).not.toBeNull();
+    expect((capturedDelta as SubstrateDelta | null)?.since).not.toBeNull();
+    // ep1 should NOT be in the delta (it was ingested before the cursor)
+    const deltaEpisodeIds =
+      (capturedDelta as SubstrateDelta | null)?.episodes.map((e) => e.id) ?? [];
+    expect(deltaEpisodeIds).not.toContain(ep1.id);
+  });
+});
+
+// ─── reconcile() — discover phase — malformed proposals ─────────────────────
+
+describe("reconcile() — discover phase — malformed proposal rejection", () => {
+  test("rejects proposal with unknown kind", async () => {
+    const ep = makeEpisode("content");
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "nonexistent_kind",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep.id }],
+          rationale: "invalid kind",
+        },
+      ],
+    });
+
+    const result = await reconcile(graph, gen, { phases: ["discover"] });
+
+    // Proposal should be skipped — no projection authored
+    expect(result.discovered).toBe(0);
+    const projections = listActiveProjections(graph, {});
+    expect(projections.length).toBe(0);
+  });
+
+  test("rejects proposal with empty inputs array", async () => {
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [],
+          rationale: "no inputs",
+        },
+      ],
+    });
+
+    const result = await reconcile(graph, gen, { phases: ["discover"] });
+
+    expect(result.discovered).toBe(0);
+  });
+
+  test("rejects proposal with invalid input type", async () => {
+    const ep = makeEpisode("content");
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [
+            {
+              type: "invalid_type" as "episode",
+              id: ep.id,
+            },
+          ],
+          rationale: "bad input type",
+        },
+      ],
+    });
+
+    const result = await reconcile(graph, gen, { phases: ["discover"] });
+
+    expect(result.discovered).toBe(0);
+  });
+
+  test("rejects proposal with invalid anchor type", async () => {
+    const ep = makeEpisode("content");
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: { type: "bad_anchor_type", id: "some-id" },
+          inputs: [{ type: "episode", id: ep.id }],
+          rationale: "bad anchor type",
+        },
+      ],
+    });
+
+    const result = await reconcile(graph, gen, { phases: ["discover"] });
+
+    expect(result.discovered).toBe(0);
+  });
+
+  test("valid proposal passes validation and is authored", async () => {
+    const ep = makeEpisode("valid content for projection");
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep.id }],
+          rationale: "valid proposal",
+        },
+      ],
+    });
+
+    const result = await reconcile(graph, gen, { phases: ["discover"] });
+
+    expect(result.discovered).toBe(1);
+    const projections = listActiveProjections(graph, {});
+    expect(projections.length).toBe(1);
+  });
+});
+
+// ─── reconcile() — discover phase — budget exhaustion ────────────────────────
+
+describe("reconcile() — discover phase — budget exhaustion", () => {
+  test("budget exhaustion during discover sets status=partial with error reason", async () => {
+    const ep1 = makeEpisode("episode one");
+    const ep2 = makeEpisode("episode two");
+
+    // Two proposals — budget of 1 means only the first project() call succeeds
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep1.id }],
+          rationale: "first",
+        },
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep2.id }],
+          rationale: "second",
+        },
+      ],
+    });
+
+    // Budget of 2: 1 for discover() call + 1 for first project() call → exhausted before second
+    const result = await reconcile(graph, gen, {
+      phases: ["discover"],
+      maxCost: 2,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.error).toBeDefined();
+    expect(result.discovered).toBeGreaterThan(0);
+
+    const runRow = graph.db
+      .query<{ status: string; error: string | null }, [string]>(
+        "SELECT status, error FROM reconciliation_runs WHERE id = ?",
+      )
+      .get(result.run_id);
+    expect(runRow?.status).toBe("partial");
+    expect(runRow?.error).not.toBeNull();
+  });
+});
+
+// ─── reconcile() — discover phase — substrate delta content ──────────────────
+
+describe("reconcile() — discover phase — substrate delta", () => {
+  test("delta includes episodes, entities, and edges", async () => {
+    // Seed entities and edges
+    const ep = makeEpisode("entity evidence");
+    const ep2 = addEpisode(graph, {
+      source_type: "manual",
+      content: "other entity evidence",
+      timestamp: new Date().toISOString(),
+    });
+    const ep3 = addEpisode(graph, {
+      source_type: "manual",
+      content: "edge evidence",
+      timestamp: new Date().toISOString(),
+    });
+    const entity = addEntity(
+      graph,
+      { canonical_name: "TestEntity", entity_type: "module" },
+      [{ episode_id: ep.id, extractor: "manual" }],
+    );
+    const entity2 = addEntity(
+      graph,
+      { canonical_name: "OtherEntity", entity_type: "module" },
+      [{ episode_id: ep2.id, extractor: "manual" }],
+    );
+    addEdge(
+      graph,
+      {
+        source_id: entity.id,
+        target_id: entity2.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "TestEntity depends on OtherEntity",
+      },
+      [{ episode_id: ep3.id, extractor: "manual" }],
+    );
+
+    let capturedDelta: SubstrateDelta | null = null;
+    const gen = makeMockGenerator({ discoverProposals: [] });
+    gen.discover = async (ctx) => {
+      capturedDelta = ctx.delta;
+      return [];
+    };
+
+    await reconcile(graph, gen, { phases: ["discover"] });
+
+    expect(capturedDelta).not.toBeNull();
+    const delta = capturedDelta as SubstrateDelta;
+    expect(delta.episodes.length).toBeGreaterThan(0);
+    expect(delta.entities.length).toBeGreaterThan(0);
+    expect(delta.edges.length).toBeGreaterThan(0);
+    // Verify episode is in delta
+    expect(delta.episodes.map((e) => e.id)).toContain(ep.id);
+    // Verify entity is in delta
+    expect(delta.entities.map((e) => e.id)).toContain(entity.id);
+  });
+
+  test("delta passed to discover includes catalog of active projections", async () => {
+    const ep = makeEpisode("pre-existing projection episode");
+    const preGen = makeMockGenerator();
+    // Author a projection first
+    await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator: preGen,
+    });
+
+    let capturedCatalog: ActiveProjectionSummary[] | null = null;
+    const gen = makeMockGenerator({ discoverProposals: [] });
+    gen.discover = async (ctx) => {
+      capturedCatalog = ctx.catalog;
+      return [];
+    };
+
+    await reconcile(graph, gen, { phases: ["discover"] });
+
+    expect(capturedCatalog).not.toBeNull();
+    const catalog = capturedCatalog as ActiveProjectionSummary[];
+    expect(catalog.length).toBe(1);
+    expect(catalog[0].kind).toBe("entity_summary");
   });
 });

--- a/packages/engram-core/test/graph/reconcile.test.ts
+++ b/packages/engram-core/test/graph/reconcile.test.ts
@@ -21,6 +21,7 @@ import {
   createGraph,
   currentInputState,
   listActiveProjections,
+  NullGenerator,
   project,
   reconcile,
   softRefresh,
@@ -1057,5 +1058,71 @@ describe("reconcile() — discover phase — substrate delta", () => {
     const catalog = capturedCatalog as ActiveProjectionSummary[];
     expect(catalog.length).toBe(1);
     expect(catalog[0].kind).toBe("entity_summary");
+  });
+});
+
+// ─── NullGenerator.discover() ────────────────────────────────────────────────
+
+describe("NullGenerator", () => {
+  test("discover() returns [] without throwing", async () => {
+    const nullGen = new NullGenerator();
+    const ep = makeEpisode("some episode");
+    const delta: SubstrateDelta = {
+      since: null,
+      episodes: [
+        {
+          type: "episode",
+          id: ep.id,
+          summary: "some episode",
+          changed_at: new Date().toISOString(),
+        },
+      ],
+      entities: [],
+      edges: [],
+    };
+    const result = await nullGen.discover({ delta, catalog: [], kinds: [] });
+    expect(result).toEqual([]);
+  });
+});
+
+// ─── reconcile() — budget exhausted before any authoring ─────────────────────
+
+describe("reconcile() — discover phase — budget exhausted before any authoring", () => {
+  test("status=partial with discovered=0 when budget is gone after discover() call", async () => {
+    const ep = makeEpisode("episode for budget test");
+
+    const gen = makeMockGenerator({
+      discoverProposals: [
+        {
+          kind: "entity_summary",
+          anchor: null,
+          inputs: [{ type: "episode", id: ep.id }],
+          rationale: "should not be authored — budget gone",
+        },
+      ],
+    });
+
+    // Budget of 1: the discover() call itself consumes 1 unit (budget.consume(1)),
+    // leaving nothing for any project() calls. discovered stays 0.
+    const result = await reconcile(graph, gen, {
+      phases: ["discover"],
+      maxCost: 1,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.discovered).toBe(0);
+
+    // Verify no projection was authored
+    const projections = listActiveProjections(graph, {});
+    expect(projections.length).toBe(0);
+
+    // reconciliation_runs row should reflect partial
+    const runRow = graph.db
+      .query<{ status: string; projections_discovered: number }, [string]>(
+        "SELECT status, projections_discovered FROM reconciliation_runs WHERE id = ?",
+      )
+      .get(result.run_id);
+    expect(runRow?.status).toBe("partial");
+    expect(runRow?.projections_discovered).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Implements the `discover` phase of `reconcile()` from the projections spec (Operation 2, § discover phase)
- Extends `ProjectionGenerator` with `discover()` method and new types (`SubstrateDelta`, `ActiveProjectionSummary`, `ProjectionProposal`)
- `NullGenerator.discover()` returns `[]`; `AnthropicGenerator.discover()` is a stub returning `[]`
- Cursor semantics: dry runs don't advance the cursor; partial runs advance to what was successfully authored

## Implementation details

### Discover phase flow (in `reconcile.ts`)
1. Resolve cursor: `completed_at` of last non-dry-run reconcile with same scope
2. Compute substrate delta since cursor (episodes via `ingested_at`, entities/edges via `created_at`)
3. Load active-projection catalog (lightweight summaries — no bodies)
4. Load kind catalog via `loadKindCatalog()`
5. Call `generator.discover({ delta, catalog, kinds })` → `ProjectionProposal[]`
6. Validate each proposal (kind in catalog, non-empty inputs, valid types)
7. Author valid proposals via `project()`, increment `discovered`
8. Budget exhaustion mid-phase sets `status='partial'` and records `error` reason

### New types exported from `engram-core`
- `SubstrateDelta` / `SubstrateDeltaItem` — delta context for the discover call
- `ActiveProjectionSummary` — lightweight projection catalog entry
- `ProjectionProposal` — `{ kind, anchor, inputs, rationale }` from generator

## Tests added (13 new tests)
- Integration: seed substrate, recording-mode generator, assert kinds authored and `projections_discovered` updated
- Integration: discover phase skipped when `phases=['assess']`
- Integration: dry run counts proposals but does not persist or advance cursor
- Integration: cursor semantics — second run only sees new substrate delta
- Integration: substrate delta contains episodes, entities, and edges
- Integration: catalog is passed to generator
- Unit: malformed proposals rejected — unknown kind, empty inputs, invalid input type, invalid anchor type
- Budget: exhaustion during discover sets `status='partial'` with error reason

## Acceptance criteria

- [x] `discover` phase in `reconcile.ts` behind phase switch (`phases.includes('discover')`)
- [x] `ProjectionGenerator.discover()` method added; `NullGenerator` returns `[]`
- [x] Cursor: dry runs don't advance; partial runs advance to what was successfully authored
- [x] `--max-cost` respected; exhaustion sets `status='partial'` and records error reason
- [x] Integration test: seed substrate, run discover with recording-mode generator, assert expected kinds authored and `projections_discovered` updated
- [x] Integration test: dry run does not persist or advance cursor
- [x] Unit test: malformed proposals (wrong kind, missing anchor, invalid inputs) rejected with clear error
- [x] JSDoc on discover phase flow and `ProjectionGenerator.discover()` input/output contract

Closes #70

> **Note**: This PR stacks on #84 (`feat/issue-64-kind-catalog`). It depends on `KindCatalog` and `loadKindCatalog()` from that branch. The base branch is `feat/issue-64-kind-catalog`, not `main`.