### PR TITLE
feat: MCP projection tools (get, search, list, project, reconcile)

### DIFF
--- a/packages/engram-cli/src/commands/reconcile.ts
+++ b/packages/engram-cli/src/commands/reconcile.ts
@@ -171,9 +171,6 @@ export function registerReconcile(program: Command): void {
         if (phases.includes("assess")) {
           printPhaseHeader("assess");
         }
-        if (phases.includes("discover")) {
-          printPhaseHeader("discover");
-        }
 
         result = await reconcile(graph, generator, {
           scope: opts.scope,
@@ -181,10 +178,21 @@ export function registerReconcile(program: Command): void {
           maxCost,
           dryRun: opts.dryRun,
         });
+
+        if (phases.includes("discover")) {
+          printPhaseHeader("discover");
+        }
       } catch (err) {
-        console.error(
-          `\n  Reconcile failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.error(`\n  Reconcile failed: ${errMsg}`);
+        if (
+          errMsg.includes("NullGenerator") ||
+          errMsg.includes("no AI provider configured")
+        ) {
+          console.error(
+            "\n  No AI provider configured. Set ENGRAM_AI_PROVIDER=anthropic and ANTHROPIC_API_KEY to enable projection authoring.",
+          );
+        }
         closeGraph(graph);
         process.exit(1);
       }

--- a/packages/engram-cli/test/commands/reconcile.test.ts
+++ b/packages/engram-cli/test/commands/reconcile.test.ts
@@ -409,6 +409,47 @@ describe("reconcile --max-cost 0", () => {
     }
   });
 
+  it("--max-cost 0 with seeded stale projection exits 0 and outputs partial/Budget exhausted", async () => {
+    // Seed a real graph: create an episode + projection, then make it stale
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "initial content",
+      timestamp: new Date().toISOString(),
+    });
+
+    const generator = makeRecordingGenerator();
+    await project(graph, {
+      kind: "entity_summary",
+      anchor: { type: "none" },
+      inputs: [{ type: "episode", id: ep.id }],
+      generator,
+    });
+
+    // Make the projection stale by changing the episode content
+    graph.db
+      .prepare(
+        "UPDATE episodes SET content = 'changed content', content_hash = 'differenthash' WHERE id = ?",
+      )
+      .run(ep.id);
+
+    closeGraph(graph);
+
+    const { exitCode, output } = await runCommand([
+      "reconcile",
+      "--phase",
+      "assess",
+      "--max-cost",
+      "0",
+      "--dry-run",
+      "--db",
+      dbPath,
+    ]);
+
+    expect(exitCode).toBe(0);
+    // Budget=0 with stale projection → partial run
+    expect(output.toLowerCase()).toMatch(/partial|budget exhausted/);
+  });
+
   it("budget=0 with stale projection records partial run via core reconcile()", async () => {
     // Test core behavior directly to verify budget=0 gives partial status
     const { reconcile: coreReconcile } = await import("engram-core");
@@ -522,6 +563,22 @@ describe("reconcile --scope", () => {
     ]);
     expect(exitCode).toBe(0);
     expect(output).toContain("Scope: anchor:entity");
+    expect(output).toContain("Reconciliation complete");
+  });
+
+  it("accepts anchor:type:id scope (colon in value) and does not truncate value", async () => {
+    // This tests the fix for split(':') truncating 'anchor:entity:01HX...' to 'entity'
+    closeGraph(graph);
+    const { exitCode, output } = await runCommand([
+      "reconcile",
+      "--scope",
+      "anchor:entity:01HXABC123",
+      "--dry-run",
+      "--db",
+      dbPath,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(output).toContain("Scope: anchor:entity:01HXABC123");
     expect(output).toContain("Reconciliation complete");
   });
 });

--- a/packages/engram-core/src/graph/projections-list.ts
+++ b/packages/engram-core/src/graph/projections-list.ts
@@ -21,6 +21,8 @@ export interface ListProjectionsOpts {
   kind?: string;
   anchor_type?: AnchorType;
   anchor_id?: string;
+  /** Include invalidated (superseded) projections. Default: false. */
+  include_superseded?: boolean;
 }
 
 // ─── Batched staleness helper ─────────────────────────────────────────────────
@@ -272,8 +274,12 @@ export function listActiveProjections(
   graph: EngramGraph,
   opts?: ListProjectionsOpts,
 ): GetProjectionResult[] {
-  const conditions: string[] = ["invalidated_at IS NULL"];
+  const conditions: string[] = [];
   const params: string[] = [];
+
+  if (!opts?.include_superseded) {
+    conditions.push("invalidated_at IS NULL");
+  }
 
   if (opts?.kind !== undefined) {
     conditions.push("kind = ?");
@@ -288,7 +294,7 @@ export function listActiveProjections(
     params.push(opts.anchor_id);
   }
 
-  const whereClause = conditions.join(" AND ");
+  const whereClause = conditions.length > 0 ? conditions.join(" AND ") : "1=1";
   const projections = graph.db
     .query<Projection, string[]>(
       `SELECT * FROM projections WHERE ${whereClause} ORDER BY created_at DESC`,
@@ -319,11 +325,12 @@ export function searchProjections(
   query: string,
   opts?: ListProjectionsOpts,
 ): GetProjectionResult[] {
-  const conditions: string[] = [
-    "p.invalidated_at IS NULL",
-    "projections_fts MATCH ?",
-  ];
+  const conditions: string[] = ["projections_fts MATCH ?"];
   const params: string[] = [query];
+
+  if (!opts?.include_superseded) {
+    conditions.push("p.invalidated_at IS NULL");
+  }
 
   if (opts?.kind !== undefined) {
     conditions.push("p.kind = ?");

--- a/packages/engram-core/src/graph/reconcile.ts
+++ b/packages/engram-core/src/graph/reconcile.ts
@@ -307,7 +307,10 @@ function parseScopeToOpts(scope?: string): {
   anchor_type?: string;
 } {
   if (!scope) return {};
-  const [key, value] = scope.split(":");
+  const colonIdx = scope.indexOf(":");
+  if (colonIdx === -1) return {};
+  const key = scope.slice(0, colonIdx);
+  const value = scope.slice(colonIdx + 1);
   if (key === "kind" && value) return { kind: value };
   if (key === "anchor" && value) return { anchor_type: value };
   return {};

--- a/packages/engram-mcp/src/server.ts
+++ b/packages/engram-mcp/src/server.ts
@@ -46,6 +46,23 @@ import {
   OWNERSHIP_TOOL,
   type OwnershipInput,
 } from "./tools/ownership.js";
+import {
+  GET_PROJECTION_TOOL,
+  type GetProjectionInput,
+  handleGetProjection,
+  handleListProjections,
+  handleProject,
+  handleReconcile,
+  handleSearchProjections,
+  LIST_PROJECTIONS_TOOL,
+  type ListProjectionsInput,
+  PROJECT_TOOL,
+  type ProjectInput,
+  RECONCILE_TOOL,
+  type ReconcileInput,
+  SEARCH_PROJECTIONS_TOOL,
+  type SearchProjectionsInput,
+} from "./tools/projections.js";
 import { handleSearch, SEARCH_TOOL, type SearchInput } from "./tools/search.js";
 import {
   FIND_EDGES_TOOL,
@@ -69,27 +86,51 @@ import {
 
 export const MCP_SERVER_NAME = "engram";
 
-const ALL_TOOLS = [
-  SEARCH_TOOL,
-  GET_ENTITY_TOOL,
-  GET_CONTEXT_TOOL,
-  GET_DECAY_TOOL,
-  GET_HISTORY_TOOL,
-  OWNERSHIP_TOOL,
-  GET_NEIGHBORS_TOOL,
-  FIND_EDGES_TOOL,
-  GET_PATH_TOOL,
-  ADD_EPISODE_TOOL,
-  ADD_ENTITY_TOOL,
-  ADD_EDGE_TOOL,
-];
+export interface ServerConfig {
+  /**
+   * Enable authoring tools (engram_project, engram_reconcile).
+   * These tools call the LLM and consume token budget.
+   * Default: false.
+   */
+  enableProjectionAuthoring?: boolean;
+}
+
+export function buildAllTools(config: ServerConfig) {
+  const tools = [
+    SEARCH_TOOL,
+    GET_ENTITY_TOOL,
+    GET_CONTEXT_TOOL,
+    GET_DECAY_TOOL,
+    GET_HISTORY_TOOL,
+    OWNERSHIP_TOOL,
+    GET_NEIGHBORS_TOOL,
+    FIND_EDGES_TOOL,
+    GET_PATH_TOOL,
+    ADD_EPISODE_TOOL,
+    ADD_ENTITY_TOOL,
+    ADD_EDGE_TOOL,
+    // Projection read tools — always enabled
+    GET_PROJECTION_TOOL,
+    SEARCH_PROJECTIONS_TOOL,
+    LIST_PROJECTIONS_TOOL,
+  ];
+
+  // Projection authoring tools — gated by config
+  if (config.enableProjectionAuthoring === true) {
+    tools.push(PROJECT_TOOL, RECONCILE_TOOL);
+  }
+
+  return tools;
+}
 
 /**
  * Creates and configures the engram MCP server.
  * Does not connect to transport — call server.connect(transport) to start.
  */
-export function createServer(dbPath: string) {
+export function createServer(dbPath: string, config: ServerConfig = {}) {
   const graph = openGraph(dbPath);
+  const enableProjectionAuthoring = config.enableProjectionAuthoring ?? false;
+  const allTools = buildAllTools(config);
 
   const server = new Server(
     { name: MCP_SERVER_NAME, version: "0.1.0" },
@@ -101,7 +142,7 @@ export function createServer(dbPath: string) {
   // ---------------------------------------------------------------------------
 
   server.setRequestHandler(ListToolsRequestSchema, () => ({
-    tools: ALL_TOOLS,
+    tools: allTools,
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -147,6 +188,32 @@ export function createServer(dbPath: string) {
           break;
         case "engram_get_path":
           result = handleGetPath(graph, input as GetPathInput);
+          break;
+        case "engram_get_projection":
+          result = handleGetProjection(graph, input as GetProjectionInput);
+          break;
+        case "engram_search_projections":
+          result = handleSearchProjections(
+            graph,
+            input as SearchProjectionsInput,
+          );
+          break;
+        case "engram_list_projections":
+          result = handleListProjections(graph, input as ListProjectionsInput);
+          break;
+        case "engram_project":
+          result = await handleProject(
+            graph,
+            input as ProjectInput,
+            enableProjectionAuthoring,
+          );
+          break;
+        case "engram_reconcile":
+          result = await handleReconcile(
+            graph,
+            input as ReconcileInput,
+            enableProjectionAuthoring,
+          );
           break;
         default:
           return {

--- a/packages/engram-mcp/src/tools/projections.ts
+++ b/packages/engram-mcp/src/tools/projections.ts
@@ -1,0 +1,401 @@
+/**
+ * tools/projections.ts — MCP tool implementations for projection read operations.
+ *
+ * Read tools (always available):
+ *   engram_get_projection   — wraps getProjection()
+ *   engram_search_projections — wraps searchProjections() with optional filters
+ *   engram_list_projections  — wraps listActiveProjections() with optional filters
+ *
+ * Authoring tools (gated by enableProjectionAuthoring config flag):
+ *   engram_project    — wraps project()
+ *   engram_reconcile  — wraps reconcile()
+ */
+
+import {
+  AnthropicGenerator,
+  type EngramGraph,
+  type GetProjectionResult,
+  getProjection,
+  type ListProjectionsOpts,
+  listActiveProjections,
+  project,
+  type ReconciliationRunResult,
+  reconcile,
+  searchProjections,
+} from "engram-core";
+
+// ---------------------------------------------------------------------------
+// engram_get_projection
+// ---------------------------------------------------------------------------
+
+export const GET_PROJECTION_TOOL = {
+  name: "engram_get_projection",
+  description:
+    "Retrieve a single projection by ID. Returns the projection row, body, and read-time staleness flag with reason.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      id: {
+        type: "string",
+        description: "ULID identifier of the projection",
+      },
+    },
+    required: ["id"],
+  },
+};
+
+export interface GetProjectionInput {
+  id: string;
+}
+
+export function handleGetProjection(
+  graph: EngramGraph,
+  input: GetProjectionInput,
+): GetProjectionResult | { error: string } {
+  const result = getProjection(graph, input.id);
+  if (!result) {
+    return { error: `Projection not found: ${input.id}` };
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// engram_search_projections
+// ---------------------------------------------------------------------------
+
+export const SEARCH_PROJECTIONS_TOOL = {
+  name: "engram_search_projections",
+  description:
+    "Search projections using full-text search. Returns ranked results with staleness flag per row.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      query: {
+        type: "string",
+        description: "Full-text search query string",
+      },
+      kind: {
+        type: "string",
+        description: "Filter results to projections of this kind",
+      },
+      anchor: {
+        type: "string",
+        description:
+          "Filter by anchor as 'type:id' (e.g. 'entity:01ABC'). Type alone (e.g. 'entity') filters by anchor_type only.",
+      },
+      include_superseded: {
+        type: "boolean",
+        description:
+          "Include superseded (invalidated) projections in results (default false)",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+export interface SearchProjectionsInput {
+  query: string;
+  kind?: string;
+  anchor?: string;
+  include_superseded?: boolean;
+}
+
+export function handleSearchProjections(
+  graph: EngramGraph,
+  input: SearchProjectionsInput,
+): GetProjectionResult[] {
+  const opts: ListProjectionsOpts = {};
+
+  if (input.kind !== undefined) {
+    opts.kind = input.kind;
+  }
+
+  if (input.anchor !== undefined) {
+    const colonIdx = input.anchor.indexOf(":");
+    if (colonIdx !== -1) {
+      opts.anchor_type = input.anchor.slice(
+        0,
+        colonIdx,
+      ) as ListProjectionsOpts["anchor_type"];
+      opts.anchor_id = input.anchor.slice(colonIdx + 1);
+    } else {
+      opts.anchor_type = input.anchor as ListProjectionsOpts["anchor_type"];
+    }
+  }
+
+  if (input.include_superseded !== undefined) {
+    opts.include_superseded = input.include_superseded;
+  }
+
+  return searchProjections(graph, input.query, opts);
+}
+
+// ---------------------------------------------------------------------------
+// engram_list_projections
+// ---------------------------------------------------------------------------
+
+export const LIST_PROJECTIONS_TOOL = {
+  name: "engram_list_projections",
+  description:
+    "List active projections with optional filters. Returns id, kind, title, anchor, last_assessed_at, and staleness flag per row.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      kind: {
+        type: "string",
+        description: "Filter projections by kind",
+      },
+      anchor_type: {
+        type: "string",
+        description: "Filter projections by anchor type (e.g. entity, edge)",
+      },
+      anchor_id: {
+        type: "string",
+        description: "Filter projections by anchor entity/edge/episode ID",
+      },
+      include_superseded: {
+        type: "boolean",
+        description:
+          "Include superseded (invalidated) projections (default false)",
+      },
+    },
+    required: [],
+  },
+};
+
+export interface ListProjectionsInput {
+  kind?: string;
+  anchor_type?: string;
+  anchor_id?: string;
+  include_superseded?: boolean;
+}
+
+export interface ListProjectionRow {
+  id: string;
+  kind: string;
+  title: string;
+  anchor_type: string;
+  anchor_id: string | null;
+  last_assessed_at: string | null;
+  stale: boolean;
+  stale_reason?: "input_content_changed" | "input_deleted";
+}
+
+export function handleListProjections(
+  graph: EngramGraph,
+  input: ListProjectionsInput,
+): ListProjectionRow[] {
+  const opts: ListProjectionsOpts = {};
+
+  if (input.kind !== undefined) {
+    opts.kind = input.kind;
+  }
+  if (input.anchor_type !== undefined) {
+    opts.anchor_type = input.anchor_type as ListProjectionsOpts["anchor_type"];
+  }
+  if (input.anchor_id !== undefined) {
+    opts.anchor_id = input.anchor_id;
+  }
+
+  if (input.include_superseded !== undefined) {
+    opts.include_superseded = input.include_superseded;
+  }
+
+  const results = listActiveProjections(graph, opts);
+
+  return results.map((r) => ({
+    id: r.projection.id,
+    kind: r.projection.kind,
+    title: r.projection.title,
+    anchor_type: r.projection.anchor_type,
+    anchor_id: r.projection.anchor_id,
+    last_assessed_at: r.last_assessed_at,
+    stale: r.stale,
+    stale_reason: r.stale_reason,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// engram_project (authoring — gated by enableProjectionAuthoring)
+// ---------------------------------------------------------------------------
+
+export const PROJECT_TOOL = {
+  name: "engram_project",
+  description:
+    "⚠️ This tool calls the LLM and consumes budget. Enable with enableProjectionAuthoring: true in server config.\n\nAuthor a new projection by synthesizing inputs with an AI generator. Wraps project() from engram-core.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      kind: {
+        type: "string",
+        description:
+          "Projection kind label (e.g. entity_summary, decision_record)",
+      },
+      anchor: {
+        type: "string",
+        description:
+          "Anchor as 'type:id' string (e.g. 'entity:01ABC') or 'none' for unanchored projections",
+      },
+      inputs: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Input substrate references as 'type:id' strings (e.g. ['episode:01ABC', 'entity:01DEF'])",
+      },
+      prompt_template_id: {
+        type: "string",
+        description: "Optional prompt template ID to use for generation",
+      },
+    },
+    required: ["kind", "anchor", "inputs"],
+  },
+};
+
+export interface ProjectInput {
+  kind: string;
+  anchor: string;
+  inputs: string[];
+  prompt_template_id?: string;
+}
+
+export async function handleProject(
+  graph: EngramGraph,
+  input: ProjectInput,
+  enableProjectionAuthoring: boolean,
+) {
+  if (!enableProjectionAuthoring) {
+    return {
+      error:
+        "Projection authoring is disabled. Enable with enableProjectionAuthoring: true in server config.",
+    };
+  }
+
+  // Parse anchor string 'type:id' or 'none'
+  let anchorType: import("engram-core").AnchorType;
+  let anchorId: string | undefined;
+
+  if (input.anchor === "none") {
+    anchorType = "none";
+    anchorId = undefined;
+  } else {
+    const colonIdx = input.anchor.indexOf(":");
+    if (colonIdx === -1) {
+      return {
+        error: `Invalid anchor format: '${input.anchor}'. Expected 'type:id' or 'none'.`,
+      };
+    }
+    anchorType = input.anchor.slice(
+      0,
+      colonIdx,
+    ) as import("engram-core").AnchorType;
+    anchorId = input.anchor.slice(colonIdx + 1);
+  }
+
+  // Parse input references 'type:id'
+  const parsedInputs: import("engram-core").ProjectionInput[] = [];
+  for (const ref of input.inputs) {
+    const colonIdx = ref.indexOf(":");
+    if (colonIdx === -1) {
+      return {
+        error: `Invalid input format: '${ref}'. Expected 'type:id' (e.g. 'episode:01ABC').`,
+      };
+    }
+    const type = ref.slice(
+      0,
+      colonIdx,
+    ) as import("engram-core").ProjectionInputType;
+    const id = ref.slice(colonIdx + 1);
+    parsedInputs.push({ type, id });
+  }
+
+  const generator = new AnthropicGenerator({
+    promptTemplateId: input.prompt_template_id,
+  });
+
+  try {
+    const projection = await project(graph, {
+      kind: input.kind,
+      anchor: { type: anchorType, id: anchorId },
+      inputs: parsedInputs,
+      generator,
+    });
+    return { projection };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { error: message };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// engram_reconcile (authoring — gated by enableProjectionAuthoring)
+// ---------------------------------------------------------------------------
+
+export const RECONCILE_TOOL = {
+  name: "engram_reconcile",
+  description:
+    "⚠️ This tool calls the LLM and consumes budget. Enable with enableProjectionAuthoring: true in server config.\n\nRun the reconcile loop to reassess and refresh stale projections. Returns a run summary with run ID.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      phase: {
+        type: "string",
+        enum: ["assess", "discover", "both"],
+        description:
+          "Which phase(s) to run: assess (check stale projections), discover (find new candidates), or both (default: both)",
+      },
+      scope: {
+        type: "string",
+        description:
+          "Optional scope filter (e.g. 'kind:entity_summary' or 'anchor:entity')",
+      },
+      max_cost: {
+        type: "number",
+        minimum: 0,
+        description: "Maximum token budget for LLM calls (required)",
+      },
+      dry_run: {
+        type: "boolean",
+        description:
+          "If true, assess but do not write any changes to the database (default false)",
+      },
+    },
+    required: ["max_cost"],
+  },
+};
+
+export interface ReconcileInput {
+  phase?: "assess" | "discover" | "both";
+  scope?: string;
+  max_cost: number;
+  dry_run?: boolean;
+}
+
+export async function handleReconcile(
+  graph: EngramGraph,
+  input: ReconcileInput,
+  enableProjectionAuthoring: boolean,
+): Promise<ReconciliationRunResult | { error: string }> {
+  if (!enableProjectionAuthoring) {
+    return {
+      error:
+        "Projection authoring is disabled. Enable with enableProjectionAuthoring: true in server config.",
+    };
+  }
+
+  const phase = input.phase ?? "both";
+  const phases: ("assess" | "discover")[] =
+    phase === "both"
+      ? ["assess", "discover"]
+      : phase === "assess"
+        ? ["assess"]
+        : ["discover"];
+
+  const generator = new AnthropicGenerator();
+
+  return reconcile(graph, generator, {
+    phases,
+    scope: input.scope,
+    maxCost: input.max_cost,
+    dryRun: input.dry_run ?? false,
+  });
+}

--- a/packages/engram-mcp/test/projections.test.ts
+++ b/packages/engram-mcp/test/projections.test.ts
@@ -1,0 +1,483 @@
+/**
+ * projections.test.ts — MCP projection tool handler tests.
+ *
+ * Tests tool handler functions directly using an in-memory SQLite graph.
+ * Uses AnthropicGenerator (stub) for authoring tools.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  AnthropicGenerator,
+  closeGraph,
+  createGraph,
+  type EngramGraph,
+  project,
+} from "engram-core";
+import { buildAllTools } from "../src/server.js";
+import { handleAddEntity } from "../src/tools/entity.js";
+import {
+  handleGetProjection,
+  handleListProjections,
+  handleProject,
+  handleReconcile,
+  handleSearchProjections,
+} from "../src/tools/projections.js";
+import { handleAddEpisode } from "../src/tools/write.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async function seedProjection(graph: EngramGraph) {
+  // Create an episode to use as input
+  const episode = handleAddEpisode(graph, {
+    source_type: "manual",
+    content: "Alice owns the authentication module",
+    actor: "test",
+    timestamp: new Date().toISOString(),
+  });
+
+  // Create a projection using the AnthropicGenerator stub
+  const generator = new AnthropicGenerator();
+  const projection = await project(graph, {
+    kind: "entity_summary",
+    anchor: { type: "none" },
+    inputs: [{ type: "episode", id: episode.id }],
+    generator,
+  });
+
+  return { episode, projection };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("engram MCP projection tool handlers", () => {
+  let graph: EngramGraph;
+
+  beforeEach(() => {
+    graph = createGraph(":memory:");
+  });
+
+  afterEach(() => {
+    if (graph) closeGraph(graph);
+  });
+
+  // -------------------------------------------------------------------------
+  // engram_get_projection
+  // -------------------------------------------------------------------------
+
+  describe("handleGetProjection", () => {
+    test("returns projection with stale flag", async () => {
+      const { projection } = await seedProjection(graph);
+
+      const result = handleGetProjection(graph, { id: projection.id });
+
+      expect(result).not.toHaveProperty("error");
+      const r = result as Exclude<typeof result, { error: string }>;
+      expect(r.projection.id).toBe(projection.id);
+      expect(r.projection.kind).toBe("entity_summary");
+      expect(typeof r.stale).toBe("boolean");
+      expect(r.stale).toBe(false);
+      expect(r.last_assessed_at).toBeDefined();
+    });
+
+    test("returns error for unknown projection ID", () => {
+      const result = handleGetProjection(graph, { id: "NONEXISTENT" });
+      expect(result).toHaveProperty("error");
+      const r = result as { error: string };
+      expect(r.error).toContain("NONEXISTENT");
+    });
+
+    test("staleness flag reflects current input state", async () => {
+      const { projection } = await seedProjection(graph);
+
+      // The projection was just created from the episode — should be fresh
+      const result = handleGetProjection(graph, { id: projection.id });
+      const r = result as Exclude<typeof result, { error: string }>;
+      expect(r.stale).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // engram_search_projections
+  // -------------------------------------------------------------------------
+
+  describe("handleSearchProjections", () => {
+    test("returns matching projections with staleness flag", async () => {
+      await seedProjection(graph);
+
+      const results = handleSearchProjections(graph, { query: "Generated" });
+
+      expect(Array.isArray(results)).toBe(true);
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]).toHaveProperty("projection");
+      expect(results[0]).toHaveProperty("stale");
+      expect(typeof results[0].stale).toBe("boolean");
+    });
+
+    test("returns empty array for no matches", async () => {
+      await seedProjection(graph);
+      const results = handleSearchProjections(graph, {
+        query: "zzznomatch999",
+      });
+      expect(results).toEqual([]);
+    });
+
+    test("filters by kind", async () => {
+      await seedProjection(graph);
+
+      const results = handleSearchProjections(graph, {
+        query: "Generated",
+        kind: "entity_summary",
+      });
+      expect(results.length).toBeGreaterThan(0);
+      for (const r of results) {
+        expect(r.projection.kind).toBe("entity_summary");
+      }
+    });
+
+    test("filters by kind — no match returns empty", async () => {
+      await seedProjection(graph);
+
+      const results = handleSearchProjections(graph, {
+        query: "Generated",
+        kind: "nonexistent_kind",
+      });
+      expect(results).toEqual([]);
+    });
+
+    test("parses anchor as type:id filter", async () => {
+      await seedProjection(graph);
+
+      // Search with a specific anchor that won't match (projection anchor is 'none')
+      const results = handleSearchProjections(graph, {
+        query: "Generated",
+        anchor: "entity:01ABC",
+      });
+      expect(Array.isArray(results)).toBe(true);
+      // No projections anchored to entity:01ABC, result should be empty
+      expect(results.length).toBe(0);
+    });
+
+    test("parses anchor as type-only filter", async () => {
+      await seedProjection(graph);
+
+      // Filter by anchor_type 'none' — our projection has anchor_type=none
+      const results = handleSearchProjections(graph, {
+        query: "Generated",
+        anchor: "none",
+      });
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // engram_list_projections
+  // -------------------------------------------------------------------------
+
+  describe("handleListProjections", () => {
+    test("returns list with summary fields and staleness flag", async () => {
+      const { projection } = await seedProjection(graph);
+
+      const rows = handleListProjections(graph, {});
+
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows.length).toBeGreaterThan(0);
+      const row = rows.find((r) => r.id === projection.id);
+      expect(row).toBeDefined();
+      expect(row?.kind).toBe("entity_summary");
+      expect(row?.title).toBeTruthy();
+      expect(row?.anchor_type).toBe("none");
+      expect(typeof row?.stale).toBe("boolean");
+    });
+
+    test("returns empty array when no projections exist", () => {
+      const rows = handleListProjections(graph, {});
+      expect(rows).toEqual([]);
+    });
+
+    test("filters by kind", async () => {
+      await seedProjection(graph);
+
+      const rows = handleListProjections(graph, { kind: "entity_summary" });
+      expect(rows.length).toBeGreaterThan(0);
+      for (const r of rows) {
+        expect(r.kind).toBe("entity_summary");
+      }
+    });
+
+    test("filters by kind — no match returns empty", async () => {
+      await seedProjection(graph);
+      const rows = handleListProjections(graph, { kind: "no_such_kind" });
+      expect(rows).toEqual([]);
+    });
+
+    test("filters by anchor_type", async () => {
+      await seedProjection(graph);
+
+      const rows = handleListProjections(graph, { anchor_type: "none" });
+      expect(rows.length).toBeGreaterThan(0);
+      for (const r of rows) {
+        expect(r.anchor_type).toBe("none");
+      }
+    });
+
+    test("row shape includes required fields", async () => {
+      const { projection } = await seedProjection(graph);
+
+      const rows = handleListProjections(graph, {});
+      const row = rows.find((r) => r.id === projection.id);
+      expect(row).toHaveProperty("id");
+      expect(row).toHaveProperty("kind");
+      expect(row).toHaveProperty("title");
+      expect(row).toHaveProperty("anchor_type");
+      expect(row).toHaveProperty("anchor_id");
+      expect(row).toHaveProperty("last_assessed_at");
+      expect(row).toHaveProperty("stale");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // engram_project (authoring — gated)
+  // -------------------------------------------------------------------------
+
+  describe("handleProject", () => {
+    test("returns error when authoring disabled", async () => {
+      const episode = handleAddEpisode(graph, {
+        source_type: "manual",
+        content: "Test content",
+        timestamp: new Date().toISOString(),
+      });
+
+      const result = await handleProject(
+        graph,
+        {
+          kind: "entity_summary",
+          anchor: "none",
+          inputs: [`episode:${episode.id}`],
+        },
+        false, // enableProjectionAuthoring = false
+      );
+
+      expect(result).toHaveProperty("error");
+      const r = result as { error: string };
+      expect(r.error).toContain("enableProjectionAuthoring");
+    });
+
+    test("creates a projection when authoring enabled", async () => {
+      const episode = handleAddEpisode(graph, {
+        source_type: "manual",
+        content: "Test content for projection",
+        timestamp: new Date().toISOString(),
+      });
+
+      const result = await handleProject(
+        graph,
+        {
+          kind: "entity_summary",
+          anchor: "none",
+          inputs: [`episode:${episode.id}`],
+        },
+        true, // enableProjectionAuthoring = true
+      );
+
+      expect(result).not.toHaveProperty("error");
+      const r = result as Exclude<typeof result, { error: string }>;
+      expect(r.projection.id).toBeTruthy();
+      expect(r.projection.kind).toBe("entity_summary");
+    });
+
+    test("returns error for invalid anchor format", async () => {
+      const episode = handleAddEpisode(graph, {
+        source_type: "manual",
+        content: "Test",
+        timestamp: new Date().toISOString(),
+      });
+
+      const result = await handleProject(
+        graph,
+        {
+          kind: "entity_summary",
+          anchor: "invalid_no_colon_and_not_none",
+          inputs: [`episode:${episode.id}`],
+        },
+        true,
+      );
+
+      expect(result).toHaveProperty("error");
+    });
+
+    test("returns error for invalid input format", async () => {
+      const result = await handleProject(
+        graph,
+        {
+          kind: "entity_summary",
+          anchor: "none",
+          inputs: ["bad_format_no_colon"],
+        },
+        true,
+      );
+
+      expect(result).toHaveProperty("error");
+    });
+
+    test("returns error for missing input", async () => {
+      const result = await handleProject(
+        graph,
+        {
+          kind: "entity_summary",
+          anchor: "none",
+          inputs: ["episode:NONEXISTENT"],
+        },
+        true,
+      );
+
+      expect(result).toHaveProperty("error");
+    });
+
+    test("parses entity:id anchor correctly", async () => {
+      const entityResult = handleAddEntity(graph, {
+        canonical_name: "TestEntity",
+        entity_type: "module",
+        episode_content: "Test module content",
+        actor: "test",
+      });
+
+      const episode = handleAddEpisode(graph, {
+        source_type: "manual",
+        content: "Some content",
+        timestamp: new Date().toISOString(),
+      });
+
+      const result = await handleProject(
+        graph,
+        {
+          kind: "entity_summary",
+          anchor: `entity:${entityResult.entity.id}`,
+          inputs: [`episode:${episode.id}`],
+        },
+        true,
+      );
+
+      expect(result).not.toHaveProperty("error");
+      const r = result as Exclude<typeof result, { error: string }>;
+      expect(r.projection.anchor_type).toBe("entity");
+      expect(r.projection.anchor_id).toBe(entityResult.entity.id);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // engram_reconcile (authoring — gated)
+  // -------------------------------------------------------------------------
+
+  describe("handleReconcile", () => {
+    test("returns error when authoring disabled", async () => {
+      const result = await handleReconcile(
+        graph,
+        { max_cost: 100 },
+        false, // enableProjectionAuthoring = false
+      );
+
+      expect(result).toHaveProperty("error");
+      const r = result as { error: string };
+      expect(r.error).toContain("enableProjectionAuthoring");
+    });
+
+    test("returns run summary with run_id when authoring enabled", async () => {
+      await seedProjection(graph);
+
+      const result = await handleReconcile(graph, { max_cost: 100 }, true);
+
+      expect(result).not.toHaveProperty("error");
+      const r = result as Exclude<typeof result, { error: string }>;
+      expect(r.run_id).toBeTruthy();
+      expect(r.status).toMatch(/^(completed|partial|failed)$/);
+      expect(typeof r.assessed).toBe("number");
+      expect(typeof r.superseded).toBe("number");
+      expect(typeof r.soft_refreshed).toBe("number");
+      expect(r.started_at).toBeTruthy();
+      expect(r.completed_at).toBeTruthy();
+    });
+
+    test("dry_run does not modify projections", async () => {
+      await seedProjection(graph);
+
+      const result = await handleReconcile(
+        graph,
+        { max_cost: 100, dry_run: true },
+        true,
+      );
+
+      expect(result).not.toHaveProperty("error");
+      const r = result as Exclude<typeof result, { error: string }>;
+      expect(r.run_id).toBeTruthy();
+    });
+
+    test("assess-only phase runs without discover", async () => {
+      await seedProjection(graph);
+
+      const result = await handleReconcile(
+        graph,
+        { max_cost: 100, phase: "assess" },
+        true,
+      );
+
+      expect(result).not.toHaveProperty("error");
+      const r = result as Exclude<typeof result, { error: string }>;
+      expect(r.run_id).toBeTruthy();
+    });
+
+    test("returns run ID in output", async () => {
+      const result = await handleReconcile(graph, { max_cost: 0 }, true);
+
+      expect(result).not.toHaveProperty("error");
+      const r = result as Exclude<typeof result, { error: string }>;
+      // run_id should be a non-empty string (ULID)
+      expect(typeof r.run_id).toBe("string");
+      expect(r.run_id.length).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // buildAllTools — authoring tool gating
+  // -------------------------------------------------------------------------
+
+  describe("buildAllTools", () => {
+    test("omits PROJECT_TOOL and RECONCILE_TOOL when enableProjectionAuthoring is false", () => {
+      const tools = buildAllTools({ enableProjectionAuthoring: false });
+      const names = tools.map((t) => t.name);
+      expect(names).not.toContain("engram_project");
+      expect(names).not.toContain("engram_reconcile");
+    });
+
+    test("omits PROJECT_TOOL and RECONCILE_TOOL when enableProjectionAuthoring is undefined", () => {
+      const tools = buildAllTools({});
+      const names = tools.map((t) => t.name);
+      expect(names).not.toContain("engram_project");
+      expect(names).not.toContain("engram_reconcile");
+    });
+
+    test("includes PROJECT_TOOL and RECONCILE_TOOL when enableProjectionAuthoring is true", () => {
+      const tools = buildAllTools({ enableProjectionAuthoring: true });
+      const names = tools.map((t) => t.name);
+      expect(names).toContain("engram_project");
+      expect(names).toContain("engram_reconcile");
+    });
+
+    test("always includes projection read tools regardless of enableProjectionAuthoring", () => {
+      const toolsOff = buildAllTools({ enableProjectionAuthoring: false });
+      const namesOff = toolsOff.map((t) => t.name);
+      expect(namesOff).toContain("engram_get_projection");
+      expect(namesOff).toContain("engram_search_projections");
+      expect(namesOff).toContain("engram_list_projections");
+
+      const toolsOn = buildAllTools({ enableProjectionAuthoring: true });
+      const namesOn = toolsOn.map((t) => t.name);
+      expect(namesOn).toContain("engram_get_projection");
+      expect(namesOn).toContain("engram_search_projections");
+      expect(namesOn).toContain("engram_list_projections");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 5 new MCP tools to `packages/engram-mcp`: 3 read tools (always enabled) and 2 authoring tools (gated by `enableProjectionAuthoring` config flag)
- Read tools surface the read-time staleness flag (`stale`, `stale_reason`) on every projection result
- Authoring tools include explicit consent language in their description and error when the flag is not set
- Full test coverage in `packages/engram-mcp/test/projections.test.ts` (26 new tests)

## Tools added

| Tool | Kind | Wraps |
|------|------|-------|
| `engram_get_projection` | read | `getProjection()` |
| `engram_search_projections` | read | `searchProjections()` |
| `engram_list_projections` | read | `listActiveProjections()` |
| `engram_project` | authoring | `project()` |
| `engram_reconcile` | authoring | `reconcile()` |

## Acceptance Criteria

- [x] 5 tools registered in `engram-mcp` server
- [x] All tools wrap the appropriate core API calls
- [x] Read tools always available; authoring tools gated by `enableProjectionAuthoring`
- [x] All tools tested in `packages/engram-mcp/test/`
- [x] Authoring tools surface clear error when no AI provider configured / flag disabled
- [x] `engram_reconcile` returns run ID in output
- [x] Staleness flag included in all projection read results

## Stack

Stacks on #88 (`feat/issue-73-reconcile-command`). This PR targets that branch as base.

Closes #75