### PR TITLE
docs: replace Money Command + Visualize with Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,30 +24,34 @@ entities, relationships, and facts that track how your understanding evolves ove
 Every claim in the graph traces back to evidence. Every fact has a validity window.
 The graph is structurally sound without AI, so when AI queries it, the answers are grounded.
 
-## The Money Command
+## Quick Start
 
 ```bash
+# Step 1 — build a knowledge graph from your git history (no API tokens needed)
+cd your-repo
 engram init --from-git .
+
+# Step 2 — query it
+engram search "who owns the auth module"
+engram search "what changed in the last 30 days"
+
+# Step 3 — visualize it (opens http://127.0.0.1:7878)
+engram visualize
+
+# Step 4 — synthesize AI documents from the graph (optional, needs ANTHROPIC_API_KEY)
+ANTHROPIC_API_KEY=<key> engram reconcile --max-cost 50000
+engram export wiki --out ./wiki
 ```
 
-One command. No API tokens. No cloud. Walks your git history and builds a knowledge graph:
+`engram init --from-git` builds the graph with no cloud and no API tokens:
 
 - **Entities**: authors, files, modules, issue references
 - **Observed edges**: git blame attribution, file change records
 - **Inferred edges**: co-change patterns, likely ownership, bus factor signals
 - **Evidence chains**: every edge traces back to specific commits
-- **Temporal validity**: all relationships carry time windows
+- **Temporal validity**: every relationship carries a validity window
 
-The resulting `.engram` file is a single SQLite database you can copy, query, and back up.
-
-## Visualize your knowledge graph
-
-```bash
-engram visualize --db repo.engram
-# Opens http://127.0.0.1:7878
-```
-
-Interactive graph: pan, zoom, time slider, decay overlay, evidence drill-down.
+The result is a single `.engram` file — a SQLite database you can copy, back up, and version alongside your repo.
 
 ## Enrichment
 


### PR DESCRIPTION
## Summary

Replaces the dated "The Money Command" and separate "Visualize your knowledge graph" sections with a single **Quick Start** that walks the full four-step workflow in one annotated code block:

1. `engram init --from-git .` — build graph from git
2. `engram search` — query it
3. `engram visualize` — see it
4. `engram reconcile` + `engram export wiki` — AI projections (optional)

The entity/edge bullet list from the old section is retained beneath the block for readers who want the structural detail.

## Test plan
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)