### PR TITLE
feat(ingest): sweep phase archives episodes for deleted source files

### DIFF
--- a/packages/engram-core/src/ingest/source/index.ts
+++ b/packages/engram-core/src/ingest/source/index.ts
@@ -544,8 +544,8 @@ export async function ingestSource(
     for (const ep of sweepCandidates) {
       if (!ep.source_ref) continue;
       const atIdx = ep.source_ref.lastIndexOf("@");
-      const epRelPath =
-        atIdx >= 0 ? ep.source_ref.slice(0, atIdx) : ep.source_ref;
+      if (atIdx < 0) continue; // malformed source_ref — skip rather than over-archive
+      const epRelPath = ep.source_ref.slice(0, atIdx);
       if (!visitedRelPaths.has(epRelPath)) {
         graph.db
           .prepare(`UPDATE episodes SET status = 'archived' WHERE id = ?`)
@@ -567,8 +567,8 @@ export async function ingestSource(
     for (const ep of sweepCandidates) {
       if (!ep.source_ref) continue;
       const atIdx = ep.source_ref.lastIndexOf("@");
-      const epRelPath =
-        atIdx >= 0 ? ep.source_ref.slice(0, atIdx) : ep.source_ref;
+      if (atIdx < 0) continue; // malformed source_ref — skip rather than over-archive
+      const epRelPath = ep.source_ref.slice(0, atIdx);
       if (!visitedRelPaths.has(epRelPath)) {
         result.deletedArchived++;
       }

--- a/packages/engram-core/src/ingest/source/index.ts
+++ b/packages/engram-core/src/ingest/source/index.ts
@@ -48,7 +48,7 @@ export interface SourceIngestResult {
   episodesCreated: number;
   entitiesCreated: number;
   edgesCreated: number;
-  /** Always 0 in this chunk — sweep lands in a later issue. */
+  /** Number of episodes archived because their file was no longer found under the walk root. */
   deletedArchived: number;
   errors: Array<{ relPath: string; message: string }>;
 }
@@ -192,6 +192,10 @@ export async function ingestSource(
     errors: [],
   };
 
+  const absRoot = path.resolve(root);
+  // Track every relPath visited in this walk so the sweep pass can identify deletions.
+  const visitedRelPaths = new Set<string>();
+
   const parser = await SourceParser.create();
 
   // Per-file data for post-processing passes.
@@ -227,6 +231,7 @@ export async function ingestSource(
           .get(SOURCE_TYPE, sourceRef);
         if (existing) {
           result.filesSkipped++;
+          visitedRelPaths.add(relPath);
           // Still record the file entity id so the import resolution pass can use it.
           const fe = findEntities(graph, { canonical_name: relPath });
           if (fe.length > 0) fileEntityIds.set(relPath, fe[0].id);
@@ -293,6 +298,7 @@ export async function ingestSource(
           source_ref: sourceRef,
           content: body,
           timestamp: now,
+          metadata: { walk_root: absRoot },
         });
         episodeId = episode.id;
         result.episodesCreated++;
@@ -349,6 +355,7 @@ export async function ingestSource(
       }
 
       // Populate tracking maps for post-processing passes (both modes).
+      visitedRelPaths.add(relPath);
       fileEntityIds.set(relPath, fileEntityId);
       fileData.set(relPath, {
         episodeId,
@@ -513,6 +520,57 @@ export async function ingestSource(
           ev,
         );
         if (created) result.edgesCreated++;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // SWEEP PASS — archive episodes for files no longer present under walk root.
+  // Queries only episodes whose metadata.walk_root matches this run's absRoot
+  // so that partial-ingest runs from different roots don't archive each other.
+  // Runs in both normal and dryRun mode (counts deletedArchived either way).
+  // ---------------------------------------------------------------------------
+
+  if (!dryRun) {
+    const sweepCandidates = graph.db
+      .query<{ id: string; source_ref: string }, [string]>(
+        `SELECT id, source_ref FROM episodes
+         WHERE source_type = 'source'
+           AND status = 'active'
+           AND json_extract(metadata, '$.walk_root') = ?`,
+      )
+      .all(absRoot);
+
+    for (const ep of sweepCandidates) {
+      if (!ep.source_ref) continue;
+      const atIdx = ep.source_ref.lastIndexOf("@");
+      const epRelPath =
+        atIdx >= 0 ? ep.source_ref.slice(0, atIdx) : ep.source_ref;
+      if (!visitedRelPaths.has(epRelPath)) {
+        graph.db
+          .prepare(`UPDATE episodes SET status = 'archived' WHERE id = ?`)
+          .run(ep.id);
+        result.deletedArchived++;
+      }
+    }
+  } else {
+    // dryRun: count what would be archived without writing
+    const sweepCandidates = graph.db
+      .query<{ source_ref: string }, [string]>(
+        `SELECT source_ref FROM episodes
+         WHERE source_type = 'source'
+           AND status = 'active'
+           AND json_extract(metadata, '$.walk_root') = ?`,
+      )
+      .all(absRoot);
+
+    for (const ep of sweepCandidates) {
+      if (!ep.source_ref) continue;
+      const atIdx = ep.source_ref.lastIndexOf("@");
+      const epRelPath =
+        atIdx >= 0 ? ep.source_ref.slice(0, atIdx) : ep.source_ref;
+      if (!visitedRelPaths.has(epRelPath)) {
+        result.deletedArchived++;
       }
     }
   }

--- a/packages/engram-core/test/ingest/source/sweep.test.ts
+++ b/packages/engram-core/test/ingest/source/sweep.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Integration tests for the sweep phase of ingestSource() — issue #101.
+ *
+ * Verifies that episodes for files deleted from the walk root are archived,
+ * that scope enforcement prevents cross-root archiving, and that re-adding
+ * a deleted file creates a fresh episode while the archived one stays put.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { EngramGraph } from "../../../src/format/index.js";
+import {
+  closeGraph,
+  createGraph,
+  verifyGraph,
+} from "../../../src/format/index.js";
+import { ingestSource } from "../../../src/ingest/source/index.js";
+
+// ---------------------------------------------------------------------------
+// Test lifecycle — uses a mutable temp fixture (not the shared source-sample)
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let graphPath: string;
+let graph: EngramGraph;
+let fixtureDir: string;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-sweep-test-"));
+  graphPath = path.join(tmpDir, "test.engram");
+  graph = await createGraph(graphPath);
+  // Create a mutable fixture directory inside tmpDir
+  fixtureDir = path.join(tmpDir, "src");
+  fs.mkdirSync(fixtureDir, { recursive: true });
+});
+
+afterEach(async () => {
+  closeGraph(graph);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeFile(relPath: string, content: string) {
+  const abs = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, "utf8");
+}
+
+function deleteFile(relPath: string) {
+  fs.rmSync(path.join(tmpDir, relPath), { force: true });
+}
+
+function activeEpisodes(graph: EngramGraph) {
+  return graph.db
+    .query<{ id: string; source_ref: string }, []>(
+      `SELECT id, source_ref FROM episodes WHERE source_type = 'source' AND status = 'active'`,
+    )
+    .all();
+}
+
+function archivedEpisodes(graph: EngramGraph) {
+  return graph.db
+    .query<{ id: string; source_ref: string }, []>(
+      `SELECT id, source_ref FROM episodes WHERE source_type = 'source' AND status = 'archived'`,
+    )
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Sweep tests
+// ---------------------------------------------------------------------------
+
+describe("sweep phase — deleted file archiving", () => {
+  test("removing a file from the fixture archives its episode on re-ingest", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+    writeFile("src/b.ts", "export const b = 2;");
+
+    // First ingest — both files get active episodes
+    await ingestSource(graph, { root: tmpDir });
+    expect(activeEpisodes(graph).length).toBe(2);
+    expect(archivedEpisodes(graph).length).toBe(0);
+
+    // Delete one file
+    deleteFile("src/b.ts");
+
+    // Re-ingest — a.ts is fast-pathed (unchanged), b.ts gets archived
+    const result = await ingestSource(graph, { root: tmpDir });
+    expect(result.deletedArchived).toBe(1);
+
+    const active = activeEpisodes(graph);
+    const archived = archivedEpisodes(graph);
+    expect(active.length).toBe(1);
+    expect(active[0].source_ref).toMatch(/^src\/a\.ts@/);
+    expect(archived.length).toBe(1);
+    expect(archived[0].source_ref).toMatch(/^src\/b\.ts@/);
+  }, 15_000);
+
+  test("deletedArchived count matches number of deleted files", async () => {
+    writeFile("src/x.ts", "export const x = 1;");
+    writeFile("src/y.ts", "export const y = 2;");
+    writeFile("src/z.ts", "export const z = 3;");
+
+    await ingestSource(graph, { root: tmpDir });
+
+    deleteFile("src/x.ts");
+    deleteFile("src/y.ts");
+
+    const result = await ingestSource(graph, { root: tmpDir });
+    expect(result.deletedArchived).toBe(2);
+    expect(archivedEpisodes(graph).length).toBe(2);
+    expect(activeEpisodes(graph).length).toBe(1);
+  }, 15_000);
+
+  test("scope enforcement: episodes from a different walk_root are not archived", async () => {
+    // Two separate roots — each has one file
+    const rootA = path.join(tmpDir, "rootA");
+    const rootB = path.join(tmpDir, "rootB");
+    fs.mkdirSync(rootA);
+    fs.mkdirSync(rootB);
+    fs.writeFileSync(path.join(rootA, "a.ts"), "export const a = 1;");
+    fs.writeFileSync(path.join(rootB, "b.ts"), "export const b = 2;");
+
+    // Ingest both roots independently
+    await ingestSource(graph, { root: rootA });
+    await ingestSource(graph, { root: rootB });
+    expect(activeEpisodes(graph).length).toBe(2);
+
+    // Re-ingest rootA only — rootB's episode must NOT be archived
+    const result = await ingestSource(graph, { root: rootA });
+    expect(result.deletedArchived).toBe(0);
+    expect(archivedEpisodes(graph).length).toBe(0);
+    expect(activeEpisodes(graph).length).toBe(2);
+  }, 15_000);
+
+  test("re-adding a deleted file creates a new episode; archived episode stays archived", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+
+    await ingestSource(graph, { root: tmpDir });
+    const firstEps = activeEpisodes(graph);
+    expect(firstEps.length).toBe(1);
+    const firstEpId = firstEps[0].id;
+
+    // Delete then re-ingest to archive
+    deleteFile("src/a.ts");
+    await ingestSource(graph, { root: tmpDir });
+    expect(archivedEpisodes(graph).length).toBe(1);
+    expect(archivedEpisodes(graph)[0].id).toBe(firstEpId);
+
+    // Re-add the file with different content
+    writeFile("src/a.ts", "export const a = 42; // changed");
+    const result = await ingestSource(graph, { root: tmpDir });
+
+    // A brand-new active episode; the archived one is unchanged
+    expect(result.episodesCreated).toBe(1);
+    const active = activeEpisodes(graph);
+    expect(active.length).toBe(1);
+    expect(active[0].id).not.toBe(firstEpId);
+    expect(archivedEpisodes(graph).length).toBe(1);
+    expect(archivedEpisodes(graph)[0].id).toBe(firstEpId);
+  }, 15_000);
+
+  test("verifyGraph passes after sweep", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+    writeFile("src/b.ts", "export const b = 2;");
+
+    await ingestSource(graph, { root: tmpDir });
+
+    deleteFile("src/b.ts");
+    await ingestSource(graph, { root: tmpDir });
+
+    const { valid, violations } = verifyGraph(graph);
+    expect(valid).toBe(true);
+    expect(violations).toEqual([]);
+  }, 15_000);
+
+  test("dryRun reports deletedArchived count without writing", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+    writeFile("src/b.ts", "export const b = 2;");
+
+    await ingestSource(graph, { root: tmpDir });
+    deleteFile("src/b.ts");
+
+    const result = await ingestSource(graph, { root: tmpDir, dryRun: true });
+    expect(result.deletedArchived).toBe(1);
+
+    // No actual archiving should have occurred
+    expect(archivedEpisodes(graph).length).toBe(0);
+    expect(activeEpisodes(graph).length).toBe(2);
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

- Extends `ingestSource()` with a sweep pass that runs after walk + import resolution
- Archives (sets `status='archived'`) episodes for files no longer present under the walk root
- Uses `walk_root` episode metadata for scope enforcement: only episodes from the same absolute root are candidates, so partial-ingest runs from different roots never interfere
- `deletedArchived` field on `SourceIngestResult` is now populated
- `dryRun` mode counts what would be archived without writing

## Acceptance Criteria

- [x] Removing a file from the fixture and re-running archives its episode (`status='archived'`)
- [x] Episodes from a different `walk_root` are not touched (scope enforcement)
- [x] Re-adding a deleted file creates a new active episode; archived episode stays archived
- [x] `deletedArchived` count is accurate
- [x] `dryRun: true` reports `deletedArchived` without modifying DB
- [x] `verifyGraph()` passes after sweep

## Test plan

- [x] 6 new integration tests in `packages/engram-core/test/ingest/source/sweep.test.ts`
- [x] All 546 existing tests continue to pass
- [x] Build passes, lint clean

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)