### PR TITLE
feat(cli): add engram ingest source subcommand

### DIFF
--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -206,7 +206,6 @@ export function registerIngest(program: Command): void {
 
       const onProgress = opts.verbose
         ? (event: SourceProgressEvent) => {
-            fileIdx++;
             const label = {
               file_parsed: "parsed  ",
               file_skipped: "cached  ",
@@ -214,6 +213,7 @@ export function registerIngest(program: Command): void {
               file_scanned: null, // suppress raw scan events
             }[event.type];
             if (!label) return;
+            fileIdx++;
             const suffix = event.message ? `  ${event.message}` : "";
             log.info(`[${fileIdx}] ${label} ${event.relPath}${suffix}`);
           }

--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -4,9 +4,11 @@
  * Subcommands:
  *   - ingest git [<path>] [--since] [--branch]
  *   - ingest md <glob>
+ *   - ingest source [<path>] [--exclude] [--no-gitignore] [--dry-run] [--verbose]
  *   - ingest enrich github [--token] [--repo] [--verbose]
  */
 
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { intro, log, outro, spinner } from "@clack/prompts";
 
@@ -15,13 +17,14 @@ import { intro, log, outro, spinner } from "@clack/prompts";
 // For those commands we log a "starting" line and print results when done.
 // spinner() is only used for async operations (GitHub fetch, LLM calls).
 import type { Command } from "commander";
-import type { EngramGraph } from "engram-core";
+import type { EngramGraph, SourceProgressEvent } from "engram-core";
 import {
   closeGraph,
   GitHubAdapter,
   GitHubAuthError,
   ingestGitRepo,
   ingestMarkdown,
+  ingestSource,
   openGraph,
 } from "engram-core";
 
@@ -32,6 +35,14 @@ interface IngestGitOpts {
 }
 
 interface IngestMdOpts {
+  db: string;
+}
+
+interface IngestSourceOpts {
+  exclude?: string[];
+  gitignore: boolean;
+  dryRun?: boolean;
+  verbose?: boolean;
   db: string;
 }
 
@@ -133,6 +144,125 @@ export function registerIngest(program: Command): void {
       } catch (err) {
         log.error(
           `Markdown ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        closeGraph(graph);
+        process.exit(1);
+      }
+
+      closeGraph(graph);
+      outro("Done");
+    });
+
+  // ingest source
+  ingest
+    .command("source [sourcePath]")
+    .description("Ingest source files into the knowledge graph")
+    .option(
+      "--exclude <glob>",
+      "additional exclude glob (repeatable)",
+      (val: string, prev: string[]) => [...prev, val],
+      [] as string[],
+    )
+    .option(
+      "--no-gitignore",
+      "skip .gitignore application (denylist still applies)",
+    )
+    .option("--dry-run", "walk and report counts without writing")
+    .option("--verbose", "emit per-file progress output")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .action(async (sourcePath: string | undefined, opts: IngestSourceOpts) => {
+      intro("engram ingest source");
+
+      const dbPath = path.resolve(opts.db);
+      const resolvedSource = path.resolve(sourcePath ?? ".");
+      const startMs = Date.now();
+
+      if (opts.dryRun) {
+        log.info("Dry-run mode — no writes will be made");
+      }
+
+      try {
+        const stat = fs.statSync(resolvedSource);
+        if (!stat.isDirectory()) {
+          log.error(`Source path is not a directory: ${resolvedSource}`);
+          process.exit(1);
+        }
+      } catch {
+        log.error(`Source path does not exist: ${resolvedSource}`);
+        process.exit(1);
+      }
+
+      let graph: EngramGraph | undefined;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        log.error(
+          `Cannot open graph: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+
+      let fileIdx = 0;
+
+      const onProgress = opts.verbose
+        ? (event: SourceProgressEvent) => {
+            fileIdx++;
+            const label = {
+              file_parsed: "parsed  ",
+              file_skipped: "cached  ",
+              file_error: "error   ",
+              file_scanned: null, // suppress raw scan events
+            }[event.type];
+            if (!label) return;
+            const suffix = event.message ? `  ${event.message}` : "";
+            log.info(`[${fileIdx}] ${label} ${event.relPath}${suffix}`);
+          }
+        : undefined;
+
+      const s = opts.verbose ? undefined : spinner();
+      if (s) s.start(`Scanning ${resolvedSource}`);
+
+      try {
+        const result = await ingestSource(graph, {
+          root: resolvedSource,
+          exclude: opts.exclude?.length ? opts.exclude : undefined,
+          respectGitignore: opts.gitignore,
+          dryRun: opts.dryRun,
+          onProgress,
+        });
+
+        if (s) s.stop("Scan complete");
+
+        const elapsedSec = ((Date.now() - startMs) / 1000).toFixed(1);
+        const uncached = result.filesScanned - result.filesSkipped;
+        const summaryLines = [
+          opts.dryRun
+            ? "Source ingestion dry-run complete."
+            : "Source ingestion complete.",
+          `  Scanned:  ${result.filesScanned} files`,
+          `  Parsed:   ${result.filesParsed} files (${result.filesSkipped} unchanged, ${uncached - result.filesParsed} unsupported/errored)`,
+          `  Skipped:  ${result.filesSkipped} files`,
+          `  Archived: ${result.deletedArchived} files`,
+          `  Entities: ${result.entitiesCreated} created`,
+          `  Edges:    ${result.edgesCreated} created`,
+          `  Errors:   ${result.errors.length}`,
+          `  Elapsed:  ${elapsedSec}s`,
+        ];
+        log.success(summaryLines.join("\n"));
+
+        if (result.errors.length > 0) {
+          const errLines = result.errors
+            .slice(0, 10)
+            .map((e) => `  ${e.relPath}: ${e.message}`);
+          if (result.errors.length > 10) {
+            errLines.push(`  … and ${result.errors.length - 10} more`);
+          }
+          log.warn(`Per-file errors (not fatal):\n${errLines.join("\n")}`);
+        }
+      } catch (err) {
+        if (s) s.stop("Source ingestion failed");
+        log.error(
+          `Source ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
         );
         closeGraph(graph);
         process.exit(1);

--- a/packages/engram-cli/test/commands/cli.test.ts
+++ b/packages/engram-cli/test/commands/cli.test.ts
@@ -68,6 +68,7 @@ describe("CLI command registration", () => {
     const subNames = ingest.commands.map((c) => c.name());
     expect(subNames).toContain("git");
     expect(subNames).toContain("md");
+    expect(subNames).toContain("source");
     expect(subNames).toContain("enrich");
   });
 

--- a/packages/engram-cli/test/commands/ingest-source.test.ts
+++ b/packages/engram-cli/test/commands/ingest-source.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Integration tests for `engram ingest source` CLI subcommand.
+ *
+ * Uses commander's .parseAsync() with a patched process.exit to exercise
+ * the full action handler without exiting the test process.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { closeGraph, createGraph, openGraph } from "engram-core";
+import { registerIngest } from "../../src/commands/ingest.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-cli-source-test-"));
+  dbPath = path.join(tmpDir, "test.engram");
+  const g = await createGraph(dbPath);
+  closeGraph(g);
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function runIngestSource(
+  args: string[],
+): Promise<{ exitCode: number | undefined; output: string }> {
+  const program = new Command().exitOverride();
+  registerIngest(program);
+
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  // biome-ignore lint/suspicious/noExplicitAny: test shim
+  (process.stdout as any).write = (chunk: string | Uint8Array) => {
+    chunks.push(
+      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(),
+    );
+    return true;
+  };
+
+  let exitCode: number | undefined;
+  const origExit = process.exit;
+  // biome-ignore lint/suspicious/noExplicitAny: test needs to intercept process.exit
+  (process as any).exit = (code?: number) => {
+    exitCode = code;
+    throw new Error(`process.exit(${code})`);
+  };
+
+  try {
+    await program.parseAsync(["node", "engram", "ingest", "source", ...args]);
+  } catch {
+    // either exitOverride or our process.exit mock
+  } finally {
+    // biome-ignore lint/suspicious/noExplicitAny: restoring process.stdout.write
+    (process.stdout as any).write = origWrite;
+    // biome-ignore lint/suspicious/noExplicitAny: restoring process.exit
+    (process as any).exit = origExit;
+  }
+
+  // Strip ANSI escape codes so assertions can match plain text
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally matching ANSI escape sequences
+  const output = chunks.join("").replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "");
+  return { exitCode, output };
+}
+
+function writeFile(relPath: string, content: string) {
+  const abs = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, "utf8");
+}
+
+function activeEpisodeCount(): number {
+  const g = openGraph(dbPath);
+  const rows = g.db
+    .query<{ n: number }, []>(
+      "SELECT COUNT(*) as n FROM episodes WHERE source_type = 'source' AND status = 'active'",
+    )
+    .all();
+  closeGraph(g);
+  return rows[0]?.n ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("engram ingest source", () => {
+  test("runs against a specific subdirectory and writes episodes", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+    writeFile("src/b.ts", "export const b = 2;");
+
+    const { exitCode, output } = await runIngestSource([
+      path.join(tmpDir, "src"),
+      "--db",
+      dbPath,
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(output).toContain("Source ingestion complete");
+    expect(activeEpisodeCount()).toBe(2);
+  }, 15_000);
+
+  test("--dry-run reports but does not write", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+
+    const { exitCode, output } = await runIngestSource([
+      path.join(tmpDir, "src"),
+      "--dry-run",
+      "--db",
+      dbPath,
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(output).toContain("dry-run");
+    expect(activeEpisodeCount()).toBe(0);
+  }, 15_000);
+
+  test("--verbose emits per-file progress lines", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+
+    const { exitCode, output } = await runIngestSource([
+      path.join(tmpDir, "src"),
+      "--verbose",
+      "--db",
+      dbPath,
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    // Verbose mode should emit a parsed/cached line for the file
+    expect(output).toMatch(/parsed|cached/);
+    expect(activeEpisodeCount()).toBe(1);
+  }, 15_000);
+
+  test("--exclude filters out matching files", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+    writeFile("src/a.test.ts", "import { a } from './a.js';");
+
+    const { exitCode, output } = await runIngestSource([
+      path.join(tmpDir, "src"),
+      "--exclude",
+      "**/*.test.ts",
+      "--db",
+      dbPath,
+    ]);
+
+    expect(exitCode).toBeUndefined();
+    expect(output).toContain("Source ingestion complete");
+    // Only a.ts should be ingested
+    expect(activeEpisodeCount()).toBe(1);
+
+    const g = openGraph(dbPath);
+    const rows = g.db
+      .query<{ source_ref: string }, []>(
+        "SELECT source_ref FROM episodes WHERE source_type = 'source' AND status = 'active'",
+      )
+      .all();
+    closeGraph(g);
+    expect(rows.every((r) => !r.source_ref?.includes(".test.ts"))).toBe(true);
+  }, 15_000);
+
+  test("invalid path exits non-zero", async () => {
+    const nonExistent = path.join(tmpDir, "does-not-exist");
+
+    const { exitCode } = await runIngestSource([nonExistent, "--db", dbPath]);
+
+    expect(exitCode).toBe(1);
+  }, 15_000);
+
+  test("second run with unchanged files produces zero new episodes (idempotency)", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+
+    await runIngestSource([path.join(tmpDir, "src"), "--db", dbPath]);
+    const countAfterFirst = activeEpisodeCount();
+
+    await runIngestSource([path.join(tmpDir, "src"), "--db", dbPath]);
+    expect(activeEpisodeCount()).toBe(countAfterFirst);
+  }, 15_000);
+
+  test("summary block always shows counts", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+
+    const { output } = await runIngestSource([
+      path.join(tmpDir, "src"),
+      "--db",
+      dbPath,
+    ]);
+
+    expect(output).toContain("Scanned:");
+    expect(output).toContain("Parsed:");
+    expect(output).toContain("Entities:");
+    expect(output).toContain("Edges:");
+    expect(output).toContain("Elapsed:");
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

- Adds `engram ingest source [path]` as a new subcommand under the existing `ingest` command group
- Wires `ingestSource()` from `engram-core` with all five CLI flags
- Progress output uses `@clack/prompts` consistent with existing CLI style
- Validates source path existence before opening graph — exits non-zero for missing/non-directory paths

## Flags

| Flag | Description |
|------|-------------|
| `--exclude <glob>` | Additional exclude glob (repeatable; layers on denylist + .gitignore) |
| `--no-gitignore` | Skip .gitignore application (denylist still applies) |
| `--dry-run` | Walk and count, no writes to DB |
| `--verbose` | Per-file progress output (parsed / cached / error) |
| `--db <path>` | Path to .engram file (default: `.engram`) |

## Acceptance Criteria

- [x] `engram ingest source` runs against the current directory with defaults
- [x] `engram ingest source packages/engram-core` runs against a specific subdirectory
- [x] `--exclude "*.test.ts"` filters out test files
- [x] `--exclude` is repeatable (commander `collect` action)
- [x] `--no-gitignore` passes `respectGitignore: false` to `ingestSource`
- [x] `--dry-run` reports counts without writing (verified in test)
- [x] `--verbose` emits per-file progress with action labels
- [x] Non-verbose mode shows only the summary block
- [x] Exit code `0` on success, non-zero on hard errors (invalid path)
- [x] Individual-file parse errors do NOT produce a non-zero exit
- [x] Help text (`engram ingest source --help`) documents every flag
- [x] `bun test`, `bun run lint`, `bun run build` pass

## Test plan

- [x] 7 integration tests in `packages/engram-cli/test/commands/ingest-source.test.ts`
- [x] `cli.test.ts` updated to assert `source` is registered under `ingest`
- [x] All 810 tests pass

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)