### PR TITLE
feat(core): semantic entity embeddings — vector search over entities

### DIFF
--- a/packages/engram-core/src/ai/index.ts
+++ b/packages/engram-core/src/ai/index.ts
@@ -20,6 +20,7 @@ export type { AIConfig, AIProvider, EntityHint } from "./provider.js";
 export type { ReindexProgress } from "./utils.js";
 export {
   countEmbeddings,
+  generateEntityEmbeddings,
   generateEpisodeEmbeddings,
   reindexEmbeddings,
 } from "./utils.js";

--- a/packages/engram-core/src/ai/utils.ts
+++ b/packages/engram-core/src/ai/utils.ts
@@ -12,6 +12,12 @@ interface EpisodeContentRow {
   content: string;
 }
 
+interface EntityTextRow {
+  id: string;
+  canonical_name: string;
+  summary: string | null;
+}
+
 /**
  * Generate embeddings for a batch of episode IDs using the given provider.
  * Never throws — embedding failures are logged and skipped.
@@ -66,6 +72,68 @@ export async function generateEpisodeEmbeddings(
   }
 }
 
+/**
+ * Build the embedding text for an entity: name + optional summary.
+ */
+function entityEmbeddingText(name: string, summary: string | null): string {
+  return summary ? `${name} ${summary}` : name;
+}
+
+/**
+ * Generate embeddings for a batch of entity IDs using the given provider.
+ * Never throws — embedding failures are logged and skipped.
+ */
+export async function generateEntityEmbeddings(
+  graph: EngramGraph,
+  provider: AIProvider,
+  entityIds: string[],
+): Promise<void> {
+  if (entityIds.length === 0) return;
+
+  const rows: EntityTextRow[] = [];
+  for (const id of entityIds) {
+    const row = graph.db
+      .query<EntityTextRow, [string]>(
+        "SELECT id, canonical_name, summary FROM entities WHERE id = ? AND status = 'active'",
+      )
+      .get(id);
+    if (row) rows.push(row);
+  }
+
+  if (rows.length === 0) return;
+
+  try {
+    const texts = rows.map((r) =>
+      entityEmbeddingText(r.canonical_name, r.summary),
+    );
+    const embeddings = await provider.embed(texts);
+
+    for (let i = 0; i < rows.length; i++) {
+      const embedding = embeddings[i];
+      if (!embedding || embedding.length === 0) continue;
+
+      try {
+        storeEmbedding(
+          graph,
+          rows[i].id,
+          "entity",
+          provider.modelName(),
+          embedding,
+          texts[i].slice(0, 500),
+        );
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[engram] generateEntityEmbeddings: skip ${rows[i].id}: ${msg}`,
+        );
+      }
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[engram] generateEntityEmbeddings: provider error: ${msg}`);
+  }
+}
+
 export interface ReindexProgress {
   total: number;
   done: number;
@@ -94,15 +162,39 @@ export async function reindexEmbeddings(
     )
     .all();
 
-  const total = allEpisodes.length;
+  const allEntities = graph.db
+    .query<EntityTextRow, []>(
+      "SELECT id, canonical_name, summary FROM entities WHERE status = 'active' ORDER BY id",
+    )
+    .all();
+
+  // Interleave episodes and entities into a unified work list
+  type WorkItem =
+    | { kind: "episode"; id: string; text: string }
+    | { kind: "entity"; id: string; text: string };
+
+  const workItems: WorkItem[] = [
+    ...allEpisodes.map((r) => ({
+      kind: "episode" as const,
+      id: r.id,
+      text: r.content,
+    })),
+    ...allEntities.map((r) => ({
+      kind: "entity" as const,
+      id: r.id,
+      text: entityEmbeddingText(r.canonical_name, r.summary),
+    })),
+  ];
+
+  const total = workItems.length;
   let done = 0;
   let errors = 0;
   let newDimensions = 0;
 
   const BATCH = 50;
-  for (let offset = 0; offset < allEpisodes.length; offset += BATCH) {
-    const batch = allEpisodes.slice(offset, offset + BATCH);
-    const texts = batch.map((r) => r.content);
+  for (let offset = 0; offset < workItems.length; offset += BATCH) {
+    const batch = workItems.slice(offset, offset + BATCH);
+    const texts = batch.map((r) => r.text);
 
     try {
       const embeddings = await provider.embed(texts);
@@ -118,10 +210,10 @@ export async function reindexEmbeddings(
           storeEmbeddingRaw(
             graph,
             batch[i].id,
-            "episode",
+            batch[i].kind,
             newModel,
             embedding,
-            batch[i].content.slice(0, 500),
+            batch[i].text.slice(0, 500),
           );
           if (newDimensions === 0) newDimensions = embedding.length;
           done++;

--- a/packages/engram-core/src/ai/utils.ts
+++ b/packages/engram-core/src/ai/utils.ts
@@ -76,7 +76,8 @@ export async function generateEpisodeEmbeddings(
  * Build the embedding text for an entity: name + optional summary.
  */
 function entityEmbeddingText(name: string, summary: string | null): string {
-  return summary ? `${name} ${summary}` : name;
+  const trimmed = summary?.trim();
+  return trimmed ? `${name.trim()} ${trimmed}` : name.trim();
 }
 
 /**
@@ -90,15 +91,12 @@ export async function generateEntityEmbeddings(
 ): Promise<void> {
   if (entityIds.length === 0) return;
 
-  const rows: EntityTextRow[] = [];
-  for (const id of entityIds) {
-    const row = graph.db
-      .query<EntityTextRow, [string]>(
-        "SELECT id, canonical_name, summary FROM entities WHERE id = ? AND status = 'active'",
-      )
-      .get(id);
-    if (row) rows.push(row);
-  }
+  const placeholders = entityIds.map(() => "?").join(", ");
+  const rows = graph.db
+    .query<EntityTextRow, string[]>(
+      `SELECT id, canonical_name, summary FROM entities WHERE id IN (${placeholders}) AND status = 'active'`,
+    )
+    .all(...entityIds);
 
   if (rows.length === 0) return;
 

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -17,6 +17,7 @@ export {
   createProvider,
   GeminiGenerator,
   GeminiProvider,
+  generateEntityEmbeddings,
   generateEpisodeEmbeddings,
   NullProvider,
   OllamaProvider,

--- a/packages/engram-core/src/ingest/git.ts
+++ b/packages/engram-core/src/ingest/git.ts
@@ -267,7 +267,11 @@ function getOrCreatePerson(
   email: string,
   name: string,
   episodeId: string,
-  counts: { entitiesCreated: number; entitiesResolved: number },
+  counts: {
+    entitiesCreated: number;
+    entitiesResolved: number;
+    newEntityIds: Set<string>;
+  },
 ): string {
   // Try canonical name (email) first, then name
   const existing =
@@ -290,6 +294,7 @@ function getOrCreatePerson(
   );
 
   counts.entitiesCreated++;
+  counts.newEntityIds.add(entity.id);
   return entity.id;
 }
 
@@ -297,7 +302,11 @@ function getOrCreateModule(
   graph: EngramGraph,
   filePath: string,
   episodeId: string,
-  counts: { entitiesCreated: number; entitiesResolved: number },
+  counts: {
+    entitiesCreated: number;
+    entitiesResolved: number;
+    newEntityIds: Set<string>;
+  },
 ): string {
   const existing = resolveEntity(graph, filePath, "module");
 
@@ -316,6 +325,7 @@ function getOrCreateModule(
   );
 
   counts.entitiesCreated++;
+  counts.newEntityIds.add(entity.id);
   return entity.id;
 }
 
@@ -364,6 +374,7 @@ export async function ingestGitRepo(
     entitiesResolved: 0,
     edgesCreated: 0,
     edgesSuperseded: 0,
+    newEntityIds: new Set<string>(),
   };
 
   try {
@@ -734,14 +745,10 @@ export async function ingestGitRepo(
           ...episodeIds.values(),
         ]);
       }
-      if (counts.entitiesCreated > 0) {
-        const newEntityIds = [
-          ...new Set([
-            ...fileEntityCache.values(),
-            ...authorEntityCache.values(),
-          ]),
-        ];
-        await generateEntityEmbeddings(graph, opts.provider, newEntityIds);
+      if (counts.newEntityIds.size > 0) {
+        await generateEntityEmbeddings(graph, opts.provider, [
+          ...counts.newEntityIds,
+        ]);
       }
     }
 

--- a/packages/engram-core/src/ingest/git.ts
+++ b/packages/engram-core/src/ingest/git.ts
@@ -10,7 +10,10 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { ulid } from "ulid";
 import type { AIProvider } from "../ai/provider.js";
-import { generateEpisodeEmbeddings } from "../ai/utils.js";
+import {
+  generateEntityEmbeddings,
+  generateEpisodeEmbeddings,
+} from "../ai/utils.js";
 import type { EngramGraph } from "../format/index.js";
 import { ENGINE_VERSION } from "../format/version.js";
 import { resolveEntity } from "../graph/aliases.js";
@@ -724,11 +727,22 @@ export async function ingestGitRepo(
       edges: counts.edgesCreated,
     });
 
-    // Post-ingest: generate embeddings for new episodes (best-effort, never blocks)
-    if (opts.provider && counts.episodesCreated > 0) {
-      await generateEpisodeEmbeddings(graph, opts.provider, [
-        ...episodeIds.values(),
-      ]);
+    // Post-ingest: generate embeddings for new episodes and entities (best-effort, never blocks)
+    if (opts.provider) {
+      if (counts.episodesCreated > 0) {
+        await generateEpisodeEmbeddings(graph, opts.provider, [
+          ...episodeIds.values(),
+        ]);
+      }
+      if (counts.entitiesCreated > 0) {
+        const newEntityIds = [
+          ...new Set([
+            ...fileEntityCache.values(),
+            ...authorEntityCache.values(),
+          ]),
+        ];
+        await generateEntityEmbeddings(graph, opts.provider, newEntityIds);
+      }
     }
 
     return { ...counts, runId };

--- a/packages/engram-core/src/retrieval/search.ts
+++ b/packages/engram-core/src/retrieval/search.ts
@@ -566,13 +566,12 @@ export async function search(
     episodeRows.map((r) => r.rank),
   );
 
-  // Build vector similarity map when provider is set and produces a valid embedding.
-  // episodeVectorScores maps episode IDs to cosine similarity scores.
-  // findSimilar returns episode IDs (embeddings are generated for episodes, not entities).
-  // Entity vector scores are derived via the evidence chain:
-  //   an entity's vector score = max cosine score of any linked episode in the similarity set.
-  // The same map is used directly for edge and episode lookups (they are also keyed by episode ID).
+  // Build vector similarity maps when provider is set and produces a valid embedding.
+  // episodeVectorScores: episode_id → cosine similarity (for episodes and edges via evidence chain)
+  // entityVectorScores: entity_id → cosine similarity (direct entity embeddings, issue #113)
+  // Entity vector_score = max(direct entity score, max episode score via evidence chain).
   const episodeVectorScores = new Map<string, number>();
+  const entityVectorScores = new Map<string, number>();
   let effectiveMode = mode;
   if (opts.provider) {
     try {
@@ -589,11 +588,20 @@ export async function search(
       if (queryEmbeddings.length > 0 && queryEmbeddings[0].length > 0) {
         // Only enable hybrid mode when a real embedding was produced
         effectiveMode = "hybrid";
-        // v0.1 limitation: brute-force scan is capped at 100 embeddings.
-        // Acceptable for small graphs (<50k embeddings); revisit if performance degrades.
-        const similar = findSimilar(graph, queryEmbeddings[0], { limit: 100 });
-        for (const result of similar) {
+        // v0.1 limitation: brute-force scan is capped at 100 embeddings per type.
+        const episodeSimilar = findSimilar(graph, queryEmbeddings[0], {
+          limit: 100,
+          target_type: "episode",
+        });
+        for (const result of episodeSimilar) {
           episodeVectorScores.set(result.target_id, result.score);
+        }
+        const entitySimilar = findSimilar(graph, queryEmbeddings[0], {
+          limit: 100,
+          target_type: "entity",
+        });
+        for (const result of entitySimilar) {
+          entityVectorScores.set(result.target_id, result.score);
         }
       }
       // If embed() returned [] or [[]] (empty vector), effectiveMode stays as-is (FTS-only)
@@ -629,9 +637,9 @@ export async function search(
     const edgeCount = getEntityEdgeCount(graph, row.id);
     const graphScore = normalizeGraphScore(edgeCount);
 
-    // Compute indirect vector score via evidence chain:
-    // max cosine score of any similar episode this entity is backed by.
-    let vectorScore = 0.0;
+    // Compute entity vector score: max of direct entity embedding score and
+    // indirect score via evidence chain (episodes backing this entity).
+    let vectorScore = entityVectorScores.get(row.id) ?? 0.0;
     for (const epId of provenance) {
       const s = episodeVectorScores.get(epId) ?? 0;
       if (s > vectorScore) vectorScore = s;
@@ -682,8 +690,8 @@ export async function search(
     const traversalDiscount = t.hops === 1 ? 0.85 : 0.55;
     const proxyFtsScore = t.seedFtsScore * traversalDiscount;
 
-    // Indirect vector score via evidence chain (same logic as direct FTS entities)
-    let vectorScore = 0.0;
+    // Entity vector score: max of direct entity embedding + indirect via evidence chain
+    let vectorScore = entityVectorScores.get(t.entityId) ?? 0.0;
     for (const epId of provenance) {
       const s = episodeVectorScores.get(epId) ?? 0;
       if (s > vectorScore) vectorScore = s;

--- a/packages/engram-core/test/ai/entity-embeddings.test.ts
+++ b/packages/engram-core/test/ai/entity-embeddings.test.ts
@@ -1,0 +1,227 @@
+/**
+ * entity-embeddings.test.ts — Tests for generateEntityEmbeddings and reindexEmbeddings
+ * with entity support.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { AIProvider } from "../../src/ai/provider.js";
+import type { EngramGraph } from "../../src/index.js";
+import {
+  addEntity,
+  addEpisode,
+  closeGraph,
+  countEmbeddings,
+  createGraph,
+  findSimilar,
+  generateEntityEmbeddings,
+  reindexEmbeddings,
+} from "../../src/index.js";
+
+// Stub provider that returns a fixed embedding per text (deterministic)
+function makeStubProvider(dims = 3): AIProvider {
+  const _callCount = 0;
+  return {
+    modelName: () => "stub-model",
+    embed: async (texts: string[]) => {
+      return texts.map((_t, i) => {
+        // Embed as a unit vector pointing in a direction derived from text length + call
+        const v = new Array(dims).fill(0) as number[];
+        v[i % dims] = 1;
+        return v;
+      });
+    },
+    extract: async () => [],
+  };
+}
+
+// Minimal episode for evidence requirement
+function addTestEpisode(graph: EngramGraph) {
+  return addEpisode(graph, {
+    source_type: "manual",
+    source_ref: `test-${Date.now()}-${Math.random()}`,
+    content: "test episode",
+    timestamp: new Date().toISOString(),
+  });
+}
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+describe("generateEntityEmbeddings", () => {
+  test("stores embeddings for given entity IDs", async () => {
+    const ep = addTestEpisode(graph);
+    const entity = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    const provider = makeStubProvider(3);
+    await generateEntityEmbeddings(graph, provider, [entity.id]);
+
+    const counts = countEmbeddings(graph);
+    expect(counts.entities).toBe(1);
+    expect(counts.episodes).toBe(0);
+  });
+
+  test("uses name + summary as embedding text", async () => {
+    const ep = addTestEpisode(graph);
+    const entity = addEntity(
+      graph,
+      {
+        canonical_name: "Search Module",
+        entity_type: "module",
+        summary: "Handles full-text and vector retrieval",
+      },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    const capturedTexts: string[][] = [];
+    const provider: AIProvider = {
+      modelName: () => "stub-model",
+      embed: async (texts) => {
+        capturedTexts.push([...texts]);
+        return texts.map(() => [1, 0, 0]);
+      },
+      extract: async () => [],
+    };
+
+    await generateEntityEmbeddings(graph, provider, [entity.id]);
+
+    expect(capturedTexts.length).toBe(1);
+    expect(capturedTexts[0][0]).toBe(
+      "Search Module Handles full-text and vector retrieval",
+    );
+  });
+
+  test("uses only name when summary is null", async () => {
+    const ep = addTestEpisode(graph);
+    const entity = addEntity(
+      graph,
+      { canonical_name: "Alice", entity_type: "person" },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    const capturedTexts: string[][] = [];
+    const provider: AIProvider = {
+      modelName: () => "stub-model",
+      embed: async (texts) => {
+        capturedTexts.push([...texts]);
+        return texts.map(() => [1, 0, 0]);
+      },
+      extract: async () => [],
+    };
+
+    await generateEntityEmbeddings(graph, provider, [entity.id]);
+
+    expect(capturedTexts[0][0]).toBe("Alice");
+  });
+
+  test("skips unknown IDs silently", async () => {
+    const provider = makeStubProvider(3);
+    await expect(
+      generateEntityEmbeddings(graph, provider, ["nonexistent-id"]),
+    ).resolves.toBeUndefined();
+    expect(countEmbeddings(graph).entities).toBe(0);
+  });
+
+  test("is a no-op for empty ID list", async () => {
+    const provider = makeStubProvider(3);
+    await generateEntityEmbeddings(graph, provider, []);
+    expect(countEmbeddings(graph).entities).toBe(0);
+  });
+
+  test("does not throw when provider.embed fails", async () => {
+    const ep = addTestEpisode(graph);
+    const entity = addEntity(
+      graph,
+      { canonical_name: "Fragile", entity_type: "module" },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+
+    const provider: AIProvider = {
+      modelName: () => "stub-model",
+      embed: async () => {
+        throw new Error("provider offline");
+      },
+      extract: async () => [],
+    };
+
+    await expect(
+      generateEntityEmbeddings(graph, provider, [entity.id]),
+    ).resolves.toBeUndefined();
+    expect(countEmbeddings(graph).entities).toBe(0);
+  });
+});
+
+describe("reindexEmbeddings with entities", () => {
+  test("reindexes both episodes and entities", async () => {
+    const _ep1 = addEpisode(graph, {
+      source_type: "manual",
+      source_ref: "ep1",
+      content: "episode content",
+      timestamp: new Date().toISOString(),
+    });
+    const ep2 = addTestEpisode(graph);
+    const _entity = addEntity(
+      graph,
+      { canonical_name: "FileModule", entity_type: "module" },
+      [{ episode_id: ep2.id, extractor: "test" }],
+    );
+
+    const provider: AIProvider = {
+      modelName: () => "reindex-model",
+      embed: async (texts) => texts.map(() => [1, 0, 0]),
+      extract: async () => [],
+    };
+
+    const result = await reindexEmbeddings(graph, provider);
+
+    // Should have reindexed 2 episodes + 1 entity
+    expect(result.total).toBe(3);
+    expect(result.done).toBe(3);
+    expect(result.errors).toBe(0);
+
+    const counts = countEmbeddings(graph);
+    expect(counts.episodes).toBe(2);
+    expect(counts.entities).toBe(1);
+  });
+
+  test("entity embeddings are queryable via findSimilar after reindex", async () => {
+    const ep = addTestEpisode(graph);
+    addEntity(graph, { canonical_name: "EntityA", entity_type: "module" }, [
+      { episode_id: ep.id, extractor: "test" },
+    ]);
+    addEntity(graph, { canonical_name: "EntityB", entity_type: "module" }, [
+      { episode_id: ep.id, extractor: "test" },
+    ]);
+
+    const provider: AIProvider = {
+      modelName: () => "search-model",
+      embed: async (texts) => {
+        // EntityA → [1,0,0], EntityB → [0,1,0] (based on index in batch)
+        return texts.map((_, i) => {
+          const v = [0, 0, 0];
+          v[i % 3] = 1;
+          return v;
+        });
+      },
+      extract: async () => [],
+    };
+
+    await reindexEmbeddings(graph, provider);
+
+    const results = findSimilar(graph, [1, 0, 0], {
+      target_type: "entity",
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r) => r.target_type === "entity")).toBe(true);
+  });
+});

--- a/packages/engram-core/test/ai/entity-embeddings.test.ts
+++ b/packages/engram-core/test/ai/entity-embeddings.test.ts
@@ -19,12 +19,10 @@ import {
 
 // Stub provider that returns a fixed embedding per text (deterministic)
 function makeStubProvider(dims = 3): AIProvider {
-  const _callCount = 0;
   return {
     modelName: () => "stub-model",
     embed: async (texts: string[]) => {
       return texts.map((_t, i) => {
-        // Embed as a unit vector pointing in a direction derived from text length + call
         const v = new Array(dims).fill(0) as number[];
         v[i % dims] = 1;
         return v;


### PR DESCRIPTION
## Summary

- Adds `generateEntityEmbeddings(graph, provider, entityIds)` — embeds `name + summary` text per entity and stores in the `embeddings` table with `target_type = 'entity'`
- Updates `reindexEmbeddings()` to cover both episodes and entities in unified batches, preserving the atomic model-swap invariant
- Updates `search()` hybrid path to build a direct `entityVectorScores` map from `findSimilar(target_type='entity')`, so entities rank on their own semantic embedding rather than only via episode evidence chain
- Updates `ingestGitRepo()` to call `generateEntityEmbeddings` post-ingest for newly created file/author entities
- Exports `generateEntityEmbeddings` from the public API surface

## Acceptance Criteria

- [x] At entity ingest time: embedding of `canonical_name [+ summary]` is stored in `embeddings` table with `target_type = 'entity'`
- [x] `reindexEmbeddings` covers both episodes and entities
- [x] In hybrid search: `vector_score` for entities uses direct entity embeddings (not just episode chain)
- [x] Fall back to BM25-only (fulltext mode) when no provider/embeddings exist — unchanged behaviour
- [x] 8 tests covering text construction, error resilience, reindex counts, findSimilar queryability

## Test plan

- [x] `bun test` — 849 pass, 0 fail
- [x] `bun run build` — clean
- [x] `bunx biome check` on changed files — no errors

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)