### PR TITLE
chore(cli): help text pass — Phase 3 (maintenance + export commands)

### DIFF
--- a/packages/engram-cli/src/commands/add.ts
+++ b/packages/engram-cli/src/commands/add.ts
@@ -22,6 +22,24 @@ export function registerAdd(program: Command): void {
     .description("Add a manual note or file as evidence")
     .option("--file <path>", "read content from a file instead of the argument")
     .option("--db <path>", "path to .engram file", ".engram")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Add a short note inline
+  engram add "Decided to use ULIDs for all entity IDs"
+
+  # Add the contents of a file as an episode
+  engram add --file notes/decision.md
+
+When to use:
+  After a design decision, meeting, or observation that should be preserved
+  in the knowledge graph before it is lost to memory.
+
+See also:
+  engram ingest git   ingest git history as episodes
+  engram verify       check graph integrity after manual additions`,
+    )
     .action((content: string | undefined, opts: AddOpts) => {
       const dbPath = path.resolve(opts.db);
 

--- a/packages/engram-cli/src/commands/decay.ts
+++ b/packages/engram-cli/src/commands/decay.ts
@@ -22,6 +22,26 @@ export function registerDecay(program: Command): void {
     .option("--stale-days <n>", "days without evidence to mark as stale", "180")
     .option("--dormant-days <n>", "days of owner inactivity to flag", "90")
     .option("--db <path>", "path to .engram file", ".engram")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Show decay report with default thresholds (180-day stale, 90-day dormant)
+  engram decay
+
+  # Tighten the stale threshold to 60 days
+  engram decay --stale-days 60
+
+  # Tighten both thresholds
+  engram decay --stale-days 60 --dormant-days 30
+
+When to use:
+  Run periodically to surface knowledge that has gone stale or owners who
+  have become inactive — before their absence causes incidents.
+
+See also:
+  engram verify   check graph evidence invariants`,
+    )
     .action((opts: DecayOpts) => {
       const dbPath = path.resolve(opts.db);
       const staleDays = parseInt(opts.staleDays, 10);

--- a/packages/engram-cli/src/commands/embed.ts
+++ b/packages/engram-cli/src/commands/embed.ts
@@ -463,7 +463,9 @@ function runStatus(
 export function registerEmbed(program: Command): void {
   program
     .command("embed")
-    .description("Manage embeddings for semantic search")
+    .description(
+      "Manage embeddings for semantic search. For FTS index rebuilding, see engram rebuild-index.",
+    )
     .option("--reindex", "clear and rebuild the vector index")
     .option("--check", "validate stored model matches configured provider")
     .option(

--- a/packages/engram-cli/src/commands/export.ts
+++ b/packages/engram-cli/src/commands/export.ts
@@ -219,6 +219,26 @@ export function registerExport(program: Command): void {
     )
     .option("--format <fmt>", "output format: jsonl or md", "jsonl")
     .option("--db <path>", "path to .engram file", ".engram")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Export full graph as JSONL (default)
+  engram export
+
+  # Export as markdown summaries
+  engram export --format md
+
+  # Materialize projections to a wiki folder
+  engram export wiki --out ./wiki
+
+When to use:
+  When you need a portable snapshot of the graph for backup, diffing,
+  or loading into another tool.
+
+See also:
+  engram project    author projections on graph entities`,
+    )
     .action((opts: ExportOpts) => {
       const dbPath = path.resolve(opts.db);
 

--- a/packages/engram-cli/src/commands/maintenance.ts
+++ b/packages/engram-cli/src/commands/maintenance.ts
@@ -18,8 +18,27 @@ export function registerMaintenance(program: Command): void {
   // rebuild-index
   program
     .command("rebuild-index")
-    .description("Rebuild FTS5 indexes for entities, edges, and episodes")
+    .description(
+      "Rebuild the FTS index. To rebuild the vector index, use engram embed --reindex.",
+    )
     .option("--db <path>", "path to .engram file", ".engram")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Rebuild FTS indexes for the default database
+  engram rebuild-index
+
+  # Rebuild FTS indexes for a specific database
+  engram rebuild-index --db path/to/project.engram
+
+When to use:
+  If full-text search returns stale or missing results after a large ingestion,
+  or after a database restore.
+
+See also:
+  engram embed --reindex   rebuild the vector (semantic) index`,
+    )
     .action((opts: MaintenanceOpts) => {
       const dbPath = path.resolve(opts.db);
 

--- a/packages/engram-cli/src/commands/project.ts
+++ b/packages/engram-cli/src/commands/project.ts
@@ -221,6 +221,27 @@ export function registerProject(program: Command): void {
       "validate and print what would be authored without writing",
     )
     .option("--db <path>", "path to .engram file", ".engram")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Author an entity_summary projection anchored to an entity
+  engram project --kind entity_summary --anchor entity:01HX...
+
+  # Author with explicit input episodes
+  engram project --kind entity_summary --anchor entity:01HX... --input episode:01HY... --input episode:01HZ...
+
+  # Preview what would be authored without writing
+  engram project --kind entity_summary --anchor entity:01HX... --dry-run
+
+When to use:
+  When you want to explicitly generate or refresh a projection for a specific
+  entity rather than waiting for reconcile to discover it.
+
+See also:
+  engram reconcile   run the full projection maintenance loop
+  engram export      export projections to a wiki folder`,
+    )
     .action(async (opts: ProjectOpts) => {
       intro("engram project");
 

--- a/packages/engram-cli/src/commands/reconcile.ts
+++ b/packages/engram-cli/src/commands/reconcile.ts
@@ -64,6 +64,29 @@ export function registerReconcile(program: Command): void {
       false,
     )
     .option("--db <path>", "path to .engram file", ".engram")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Run both phases with a token budget
+  engram reconcile --max-cost 50000
+
+  # Run only the assess phase (refresh stale projections)
+  engram reconcile --phase assess --max-cost 50000
+
+  # Run only the discover phase (find uncovered substrate)
+  engram reconcile --phase discover --max-cost 50000
+
+  # Preview what would change without persisting
+  engram reconcile --dry-run
+
+When to use:
+  After ingesting new commits or enrichment data to keep projections current,
+  or on a scheduled basis to ensure the graph stays fresh.
+
+See also:
+  engram project   author a projection on a specific anchor manually`,
+    )
     .action(async (opts: ReconcileOpts) => {
       intro("engram reconcile");
 

--- a/packages/engram-cli/src/commands/verify.ts
+++ b/packages/engram-cli/src/commands/verify.ts
@@ -24,6 +24,23 @@ export function registerVerify(program: Command): void {
     .command("verify")
     .description("Validate .engram integrity (evidence invariants)")
     .option("--db <path>", "path to .engram file", ".engram")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  # Verify the default .engram file
+  engram verify
+
+  # Verify a specific database file
+  engram verify --db path/to/project.engram
+
+When to use:
+  After manual graph edits, merges, or any operation that might leave evidence
+  invariants broken. Exit code 2 means violations were found.
+
+See also:
+  engram decay   surface stale or orphaned knowledge`,
+    )
     .action((opts: VerifyOpts) => {
       const dbPath = path.resolve(opts.db);
 

--- a/packages/engram-cli/test/help-coverage.test.ts
+++ b/packages/engram-cli/test/help-coverage.test.ts
@@ -19,6 +19,41 @@ function hasExamples(help: string): boolean {
   return /#\s+\S/.test(afterExamples);
 }
 
+describe("help-coverage: Phase 3 commands have Examples blocks", () => {
+  it("engram add --help has Examples", () => {
+    expect(hasExamples(helpOutput(["add"]))).toBe(true);
+  });
+  it("engram decay --help has Examples", () => {
+    expect(hasExamples(helpOutput(["decay"]))).toBe(true);
+  });
+  it("engram embed --help has Examples", () => {
+    expect(hasExamples(helpOutput(["embed"]))).toBe(true);
+  });
+  it("engram export --help has Examples", () => {
+    expect(hasExamples(helpOutput(["export"]))).toBe(true);
+  });
+  it("engram project --help has Examples", () => {
+    expect(hasExamples(helpOutput(["project"]))).toBe(true);
+  });
+  it("engram reconcile --help has Examples", () => {
+    expect(hasExamples(helpOutput(["reconcile"]))).toBe(true);
+  });
+  it("engram verify --help has Examples", () => {
+    expect(hasExamples(helpOutput(["verify"]))).toBe(true);
+  });
+  it("engram rebuild-index --help has Examples", () => {
+    expect(hasExamples(helpOutput(["rebuild-index"]))).toBe(true);
+  });
+  it("engram embed description mentions rebuild-index", () => {
+    expect(helpOutput(["embed"])).toContain("rebuild-index");
+  });
+  it("engram rebuild-index description mentions embed --reindex", () => {
+    const out = helpOutput(["rebuild-index"]);
+    expect(out).toContain("embed");
+    expect(out).toContain("--reindex");
+  });
+});
+
 describe("help-coverage: Phase 1 commands have Examples blocks", () => {
   it("engram --help shows Typical lifecycle", () => {
     const out = helpOutput([]);


### PR DESCRIPTION
## Summary

- Adds Examples, When to use, and See also blocks to all Phase 3 maintenance/export commands
- Cross-references `engram embed` ↔ `engram rebuild-index` for vector vs FTS disambiguation
- Extends `test/help-coverage.test.ts` with Phase 3 describe block (10 new tests)
- Completes the full CLI help text sweep (Phases 1–3), 27 tests total

## Commands updated

| Command | Notes |
|---------|-------|
| `engram add` | inline note + `--file` examples |
| `engram decay` | default + `--stale-days`/`--dormant-days` |
| `engram embed` | description now references `rebuild-index`; Examples already present from #121 |
| `engram export` | JSONL, markdown, wiki subcommand |
| `engram project` | list, explicit inputs, `--dry-run` |
| `engram reconcile` | both phases, individual, `--dry-run` |
| `engram verify` | default + `--db` |
| `engram rebuild-index` | description + Examples; references `embed --reindex` |

## Acceptance Criteria

- [x] All 8 Phase 3 commands have Examples and When to use blocks
- [x] `test/help-coverage.test.ts` extended with Phase 3 block (10 tests)
- [x] `engram embed` description mentions `rebuild-index`
- [x] `engram rebuild-index` description mentions `embed --reindex`

## Test plan

- [x] `bun run build` — clean
- [x] `bun test packages/engram-cli/test/help-coverage.test.ts` — 27/27 pass (all 3 phases)
- [x] `bun test` — 833 tests pass
- [x] No untracked source files
- [x] `bunx biome check --write` — clean

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)