### PR TITLE
feat: add --format flag to decay command

### DIFF
--- a/packages/engram-cli/src/commands/decay.ts
+++ b/packages/engram-cli/src/commands/decay.ts
@@ -1,9 +1,3 @@
-/**
- * decay.ts — `engram decay` command.
- *
- * Runs the decay detection report and prints results.
- */
-
 import * as path from "node:path";
 import type { Command } from "commander";
 import type { DecayReport, EngramGraph } from "engram-core";
@@ -12,7 +6,38 @@ import { closeGraph, getDecayReport, openGraph } from "engram-core";
 interface DecayOpts {
   staleDays: string;
   dormantDays: string;
+  format: string;
   db: string;
+}
+
+function renderTable(report: DecayReport): void {
+  console.log(`Decay Report — ${report.generated_at}`);
+  console.log(
+    `Entities: ${report.total_entities}  Edges: ${report.total_edges}`,
+  );
+  console.log("");
+  console.log("Summary:");
+  console.log(`  stale_evidence:     ${report.summary.stale_evidence}`);
+  console.log(`  contradicted:       ${report.summary.contradicted}`);
+  console.log(`  concentrated_risk:  ${report.summary.concentrated_risk}`);
+  console.log(`  dormant_owner:      ${report.summary.dormant_owner}`);
+  console.log(`  orphaned:           ${report.summary.orphaned}`);
+
+  if (report.decay_items.length === 0) {
+    console.log("\nNo decay items found.");
+    return;
+  }
+
+  console.log(`\nDecay Items (${report.decay_items.length}):`);
+  for (const item of report.decay_items) {
+    console.log(
+      `  [${item.severity.toUpperCase()}] [${item.decay_category}] ${item.name}`,
+    );
+    console.log(`    ${item.details}`);
+    if (item.last_evidence_at) {
+      console.log(`    last evidence: ${item.last_evidence_at}`);
+    }
+  }
 }
 
 export function registerDecay(program: Command): void {
@@ -21,6 +46,7 @@ export function registerDecay(program: Command): void {
     .description("Show knowledge decay report")
     .option("--stale-days <n>", "days without evidence to mark as stale", "180")
     .option("--dormant-days <n>", "days of owner inactivity to flag", "90")
+    .option("--format <fmt>", "output format: table or json", "table")
     .option("--db <path>", "path to .engram file", ".engram")
     .addHelpText(
       "after",
@@ -35,6 +61,9 @@ Examples:
   # Tighten both thresholds
   engram decay --stale-days 60 --dormant-days 30
 
+  # JSON output for scripting
+  engram decay --format json
+
 When to use:
   Run periodically to surface knowledge that has gone stale or owners who
   have become inactive — before their absence causes incidents.
@@ -46,6 +75,7 @@ See also:
       const dbPath = path.resolve(opts.db);
       const staleDays = parseInt(opts.staleDays, 10);
       const dormantDays = parseInt(opts.dormantDays, 10);
+      const format = opts.format;
 
       if (Number.isNaN(staleDays) || staleDays < 1) {
         console.error("Error: --stale-days must be a positive integer");
@@ -53,6 +83,10 @@ See also:
       }
       if (Number.isNaN(dormantDays) || dormantDays < 1) {
         console.error("Error: --dormant-days must be a positive integer");
+        process.exit(1);
+      }
+      if (format !== "table" && format !== "json") {
+        console.error("Error: --format must be 'table' or 'json'");
         process.exit(1);
       }
 
@@ -82,32 +116,10 @@ See also:
         return;
       }
 
-      console.log(`Decay Report — ${report.generated_at}`);
-      console.log(
-        `Entities: ${report.total_entities}  Edges: ${report.total_edges}`,
-      );
-      console.log("");
-      console.log("Summary:");
-      console.log(`  stale_evidence:     ${report.summary.stale_evidence}`);
-      console.log(`  contradicted:       ${report.summary.contradicted}`);
-      console.log(`  concentrated_risk:  ${report.summary.concentrated_risk}`);
-      console.log(`  dormant_owner:      ${report.summary.dormant_owner}`);
-      console.log(`  orphaned:           ${report.summary.orphaned}`);
-
-      if (report.decay_items.length === 0) {
-        console.log("\nNo decay items found.");
-        return;
-      }
-
-      console.log(`\nDecay Items (${report.decay_items.length}):`);
-      for (const item of report.decay_items) {
-        console.log(
-          `  [${item.severity.toUpperCase()}] [${item.decay_category}] ${item.name}`,
-        );
-        console.log(`    ${item.details}`);
-        if (item.last_evidence_at) {
-          console.log(`    last evidence: ${item.last_evidence_at}`);
-        }
+      if (format === "json") {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        renderTable(report);
       }
     });
 }

--- a/packages/engram-cli/test/commands/cli.test.ts
+++ b/packages/engram-cli/test/commands/cli.test.ts
@@ -358,6 +358,104 @@ describe("engram decay", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("outputs unchanged table format with --format table", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "decay",
+          "--format",
+          "table",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const output = logs.join("\n");
+      expect(output).toContain("Decay Report");
+      expect(output).toContain("Summary");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("outputs valid JSON with --format json", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "decay",
+          "--format",
+          "json",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const parsed = JSON.parse(logs.join("\n"));
+      expect(typeof parsed.generated_at).toBe("string");
+      expect(typeof parsed.total_entities).toBe("number");
+      expect(typeof parsed.total_edges).toBe("number");
+      expect(typeof parsed.summary).toBe("object");
+      expect(Array.isArray(parsed.decay_items)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 1 on invalid --format value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const errors: string[] = [];
+      const origErr = console.error;
+      console.error = (...args: unknown[]) => errors.push(args.join(" "));
+      let exitCode: number | undefined;
+      const origExit = process.exit;
+      process.exit = (code?: number) => {
+        exitCode = code;
+        throw new Error(`process.exit(${code})`);
+      };
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "decay",
+          "--format",
+          "invalid",
+          "--db",
+          dbPath,
+        ]);
+      } catch {
+        // expected — process.exit throws
+      } finally {
+        console.error = origErr;
+        process.exit = origExit;
+      }
+      expect(exitCode).toBe(1);
+      expect(errors.join("\n")).toContain("--format must be 'table' or 'json'");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("engram error handling", () => {


### PR DESCRIPTION
## Summary

- Add `--format <table|json>` option to `engram decay` (default: `table`)
- JSON mode emits the full `DecayReport` object directly to stdout with no clack chrome
- Invalid format values exit 1 with a clear error message matching the pattern used in `ownership` and `stats`

## Acceptance Criteria

- [x] `engram decay --format json` emits the full `DecayReport` as JSON and exits 0
- [x] `engram decay --format table` (or no `--format`) produces unchanged table output
- [x] Invalid format value exits 1 with `Error: --format must be 'table' or 'json'`
- [x] No intro/outro clack output when `--format json`

## Test plan

- [ ] `bun test` — all 758 tests pass (16 CLI tests including 3 new decay format tests)
- [ ] `bun run build` — all packages build successfully
- [ ] `bunx biome check packages/engram-cli/src/commands/decay.ts packages/engram-cli/test/commands/cli.test.ts` — no lint issues

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)