### PR TITLE
feat(cli): add --format <text|json> to show command

### DIFF
--- a/packages/engram-cli/src/commands/show.ts
+++ b/packages/engram-cli/src/commands/show.ts
@@ -1,9 +1,3 @@
-/**
- * show.ts — `engram show` command.
- *
- * Displays entity details with edges grouped by relation_type and evidence count.
- */
-
 import * as path from "node:path";
 import type { Command } from "commander";
 import type { EngramGraph } from "engram-core";
@@ -18,6 +12,7 @@ import {
 
 interface ShowOpts {
   db: string;
+  format: string;
 }
 
 export function registerShow(program: Command): void {
@@ -25,6 +20,7 @@ export function registerShow(program: Command): void {
     .command("show <entity>")
     .description("Show entity details, edges, and evidence")
     .option("--db <path>", "path to .engram file", ".engram")
+    .option("--format <fmt>", "output format: text or json", "text")
     .addHelpText(
       "after",
       `
@@ -35,6 +31,9 @@ Examples:
   # Show by canonical name or alias
   engram show "auth middleware"
 
+  # Machine-readable JSON output
+  engram show <entity-id> --format json
+
 When to use:
   Use when you already have an entity ID from search results or want to
   inspect a specific entity's edges and evidence chain.
@@ -44,6 +43,11 @@ See also:
   engram history   trace how facts about an entity changed over time`,
     )
     .action((entityArg: string, opts: ShowOpts) => {
+      if (opts.format !== "text" && opts.format !== "json") {
+        console.error("--format must be 'text' or 'json'");
+        process.exit(1);
+      }
+
       const dbPath = path.resolve(opts.db);
 
       let graph: EngramGraph | undefined;
@@ -57,7 +61,6 @@ See also:
       }
 
       try {
-        // Try by ID first, then by name/alias
         let entity = getEntity(graph, entityArg);
         if (!entity) {
           entity = resolveEntity(graph, entityArg);
@@ -69,6 +72,41 @@ See also:
           process.exit(1);
         }
 
+        const evidence = getEvidenceForEntity(graph, entity.id);
+
+        const outEdges = findEdges(graph, { source_id: entity.id });
+        const inEdges = findEdges(graph, { target_id: entity.id });
+
+        const edgeMap = new Map<string, (typeof outEdges)[0]>();
+        for (const edge of [...outEdges, ...inEdges]) {
+          if (!edgeMap.has(edge.id)) edgeMap.set(edge.id, edge);
+        }
+        const allEdges = Array.from(edgeMap.values());
+
+        if (opts.format === "json") {
+          const output = {
+            entity: {
+              id: entity.id,
+              canonical_name: entity.canonical_name,
+              entity_type: entity.entity_type,
+              status: entity.status,
+              summary: entity.summary ?? null,
+              created_at: entity.created_at,
+            },
+            edges: allEdges.map((edge) => ({
+              fact: edge.fact,
+              edge_kind: edge.edge_kind,
+              relation_type: edge.relation_type,
+              direction: edge.source_id === entity?.id ? "out" : "in",
+              invalidated_at: edge.invalidated_at ?? null,
+            })),
+            evidenceCount: evidence.length,
+          };
+          console.log(JSON.stringify(output, null, 2));
+          closeGraph(graph);
+          return;
+        }
+
         console.log(`${entity.canonical_name}`);
         console.log(`  id:     ${entity.id}`);
         console.log(`  type:   ${entity.entity_type}`);
@@ -77,24 +115,9 @@ See also:
           console.log(`  summary: ${entity.summary}`);
         }
         console.log(`  created: ${entity.created_at}`);
-
-        const evidence = getEvidenceForEntity(graph, entity.id);
         console.log(`  evidence: ${evidence.length} episode(s)`);
 
-        // Edges — source
-        const outEdges = findEdges(graph, { source_id: entity.id });
-        // Edges — target
-        const inEdges = findEdges(graph, { target_id: entity.id });
-
-        // Dedup edges by ID (outEdges and inEdges may overlap)
-        const edgeMap = new Map<string, (typeof outEdges)[0]>();
-        for (const edge of [...outEdges, ...inEdges]) {
-          if (!edgeMap.has(edge.id)) edgeMap.set(edge.id, edge);
-        }
-        const allEdges = Array.from(edgeMap.values());
-
         if (allEdges.length > 0) {
-          // Group by relation_type
           const grouped = new Map<string, typeof allEdges>();
           for (const edge of allEdges) {
             const group = grouped.get(edge.relation_type) ?? [];

--- a/packages/engram-cli/test/commands/cli.test.ts
+++ b/packages/engram-cli/test/commands/cli.test.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Command } from "commander";
-import { addEpisode, createGraph } from "engram-core";
+import { addEntity, addEpisode, createGraph } from "engram-core";
 import { registerAdd } from "../../src/commands/add.js";
 import { registerDecay } from "../../src/commands/decay.js";
 import { registerExport } from "../../src/commands/export.js";
@@ -452,6 +452,190 @@ describe("engram decay", () => {
       }
       expect(exitCode).toBe(1);
       expect(errors.join("\n")).toContain("--format must be 'table' or 'json'");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram show", () => {
+  function makeEntityInDb(dbPath: string) {
+    const graph = createGraph(dbPath);
+    const episode = addEpisode(graph, {
+      source_type: "manual",
+      content: "test episode for show",
+      timestamp: new Date().toISOString(),
+    });
+    const entity = addEntity(
+      graph,
+      {
+        canonical_name: "TestModule",
+        entity_type: "module",
+        summary: "a test module",
+      },
+      [{ episode_id: episode.id, extractor: "test" }],
+    );
+    graph.db.close();
+    return entity;
+  }
+
+  it("default text output shows entity fields", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      const entity = makeEntityInDb(dbPath);
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "show",
+          entity.id,
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const output = logs.join("\n");
+      expect(output).toContain("TestModule");
+      expect(output).toContain(entity.id);
+      expect(output).toContain("module");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--format json emits valid JSON with entity, edges, evidenceCount", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      const entity = makeEntityInDb(dbPath);
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "show",
+          entity.id,
+          "--format",
+          "json",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const parsed = JSON.parse(logs.join("\n"));
+      expect(parsed.entity.id).toBe(entity.id);
+      expect(parsed.entity.canonical_name).toBe("TestModule");
+      expect(parsed.entity.entity_type).toBe("module");
+      expect(parsed.entity.status).toBeDefined();
+      expect(parsed.entity.created_at).toBeDefined();
+      expect(Array.isArray(parsed.edges)).toBe(true);
+      expect(typeof parsed.evidenceCount).toBe("number");
+      expect(parsed.evidenceCount).toBeGreaterThanOrEqual(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--format json resolves by canonical name", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      const entity = makeEntityInDb(dbPath);
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "show",
+          "TestModule",
+          "--format",
+          "json",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const parsed = JSON.parse(logs.join("\n"));
+      expect(parsed.entity.id).toBe(entity.id);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 1 on invalid --format value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const errors: string[] = [];
+      const origErr = console.error;
+      console.error = (...args: unknown[]) => errors.push(args.join(" "));
+      let exitCode: number | undefined;
+      const origExit = process.exit;
+      process.exit = (code?: number) => {
+        exitCode = code;
+        throw new Error(`process.exit(${code})`);
+      };
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "show",
+          "anything",
+          "--format",
+          "xml",
+          "--db",
+          dbPath,
+        ]);
+      } catch {
+        // expected — process.exit throws
+      } finally {
+        console.error = origErr;
+        process.exit = origExit;
+      }
+      expect(exitCode).toBe(1);
+      expect(errors.join("\n")).toContain("--format must be 'text' or 'json'");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--format text is unchanged (same as default)", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      const entity = makeEntityInDb(dbPath);
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "show",
+          entity.id,
+          "--format",
+          "text",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const output = logs.join("\n");
+      expect(output).toContain("TestModule");
+      expect(output).toContain(entity.id);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Adds `--format <text|json>` option to `engram show` (default: `text`)
- When `--format json`, emits a machine-readable JSON object: `{ entity, edges[], evidenceCount }` — no clack chrome
- Each edge in the array includes `fact`, `edge_kind`, `relation_type`, `direction` (`"out"` | `"in"`), and `invalidated_at`
- Invalid format value exits 1 with `--format must be 'text' or 'json'`
- Default text output is unchanged

## Acceptance Criteria

- [x] `engram show <id> --format json` emits valid JSON with entity, edges array, evidenceCount
- [x] `engram show <name> --format json` resolves by name/alias before emitting
- [x] Default text output is unchanged
- [x] Invalid format exits 1 with a clear error
- [x] No intro/outro clack output when `--format json`

## Test plan

- [x] `engram show` default text output shows entity fields
- [x] `--format json` emits valid JSON with correct shape
- [x] `--format json` resolves by canonical name/alias
- [x] `--format text` explicitly produces same text output as default
- [x] Invalid `--format xml` exits 1 with clear error message
- [x] All 763 existing tests pass

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)