### PR TITLE
feat(cli): add --format text|json to history command

### DIFF
--- a/packages/engram-cli/src/commands/history.ts
+++ b/packages/engram-cli/src/commands/history.ts
@@ -58,7 +58,7 @@ See also:
         opts: HistoryOpts,
       ) => {
         if (opts.format !== "text" && opts.format !== "json") {
-          console.error("--format must be 'text' or 'json'");
+          console.error("Error: --format must be 'text' or 'json'");
           process.exit(1);
         }
 

--- a/packages/engram-cli/src/commands/history.ts
+++ b/packages/engram-cli/src/commands/history.ts
@@ -1,9 +1,3 @@
-/**
- * history.ts — `engram history` command.
- *
- * Shows the temporal evolution of facts for an entity or between two entities.
- */
-
 import * as path from "node:path";
 import type { Command } from "commander";
 import type { EngramGraph } from "engram-core";
@@ -18,6 +12,7 @@ import {
 
 interface HistoryOpts {
   db: string;
+  format: string;
 }
 
 function resolveEntityByNameOrId(
@@ -34,6 +29,7 @@ export function registerHistory(program: Command): void {
       "Show temporal fact evolution for an entity or between two entities",
     )
     .option("--db <path>", "path to .engram file", ".engram")
+    .option("--format <fmt>", "output format: text or json", "text")
     .addHelpText(
       "after",
       `
@@ -43,6 +39,9 @@ Examples:
 
   # Show history between two entities
   engram history <entity-id-1> <entity-id-2>
+
+  # Machine-readable JSON output
+  engram history <entity-id> --format json
 
 When to use:
   Trace how a fact about an entity changed over time — superseded edges,
@@ -58,6 +57,11 @@ See also:
         entity2Arg: string | undefined,
         opts: HistoryOpts,
       ) => {
+        if (opts.format !== "text" && opts.format !== "json") {
+          console.error("--format must be 'text' or 'json'");
+          process.exit(1);
+        }
+
         const dbPath = path.resolve(opts.db);
 
         let graph: EngramGraph | undefined;
@@ -65,7 +69,9 @@ See also:
           graph = openGraph(dbPath);
         } catch (err) {
           console.error(
-            `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+            `Error opening graph: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
           );
           process.exit(1);
         }
@@ -79,7 +85,6 @@ See also:
           }
 
           if (entity2Arg) {
-            // Show history between two entities
             const entity2 = resolveEntityByNameOrId(graph, entity2Arg);
             if (!entity2) {
               console.error(`Entity not found: ${entity2Arg}`);
@@ -88,6 +93,32 @@ See also:
             }
 
             const edges = getFactHistory(graph, entity1.id, entity2.id);
+
+            if (opts.format === "json") {
+              console.log(
+                JSON.stringify(
+                  {
+                    entity1: entity1.canonical_name,
+                    entity2: entity2.canonical_name,
+                    edges: edges.map((edge) => ({
+                      id: edge.id,
+                      fact: edge.fact,
+                      edge_kind: edge.edge_kind,
+                      relation_type: edge.relation_type,
+                      valid_from: edge.valid_from ?? null,
+                      valid_until: edge.valid_until ?? null,
+                      invalidated_at: edge.invalidated_at ?? null,
+                      superseded_by: edge.superseded_by ?? null,
+                    })),
+                  },
+                  null,
+                  2,
+                ),
+              );
+              closeGraph(graph);
+              return;
+            }
+
             console.log(
               `History: ${entity1.canonical_name} → ${entity2.canonical_name}`,
             );
@@ -106,7 +137,6 @@ See also:
               }
             }
           } else {
-            // Show all edges for entity1 with temporal info
             const outEdges = findEdges(graph, {
               source_id: entity1.id,
               include_invalidated: true,
@@ -118,6 +148,31 @@ See also:
             const allEdges = [...outEdges, ...inEdges].sort((a, b) =>
               a.created_at.localeCompare(b.created_at),
             );
+
+            if (opts.format === "json") {
+              console.log(
+                JSON.stringify(
+                  {
+                    entity1: entity1.canonical_name,
+                    entity2: null,
+                    edges: allEdges.map((edge) => ({
+                      id: edge.id,
+                      fact: edge.fact,
+                      edge_kind: edge.edge_kind,
+                      relation_type: edge.relation_type,
+                      valid_from: edge.valid_from ?? null,
+                      valid_until: edge.valid_until ?? null,
+                      invalidated_at: edge.invalidated_at ?? null,
+                      superseded_by: edge.superseded_by ?? null,
+                    })),
+                  },
+                  null,
+                  2,
+                ),
+              );
+              closeGraph(graph);
+              return;
+            }
 
             console.log(`History: ${entity1.canonical_name}`);
             console.log(`${allEdges.length} fact(s)\n`);

--- a/packages/engram-cli/test/commands/cli.test.ts
+++ b/packages/engram-cli/test/commands/cli.test.ts
@@ -812,7 +812,9 @@ describe("engram history", () => {
         process.exit = origExit;
       }
       expect(exitCode).toBe(1);
-      expect(errors.join("\n")).toContain("Error: --format must be 'text' or 'json'");
+      expect(errors.join("\n")).toContain(
+        "Error: --format must be 'text' or 'json'",
+      );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/packages/engram-cli/test/commands/cli.test.ts
+++ b/packages/engram-cli/test/commands/cli.test.ts
@@ -812,7 +812,7 @@ describe("engram history", () => {
         process.exit = origExit;
       }
       expect(exitCode).toBe(1);
-      expect(errors.join("\n")).toContain("--format must be 'text' or 'json'");
+      expect(errors.join("\n")).toContain("Error: --format must be 'text' or 'json'");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/packages/engram-cli/test/commands/cli.test.ts
+++ b/packages/engram-cli/test/commands/cli.test.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Command } from "commander";
-import { addEntity, addEpisode, createGraph } from "engram-core";
+import { addEdge, addEntity, addEpisode, createGraph } from "engram-core";
 import { registerAdd } from "../../src/commands/add.js";
 import { registerDecay } from "../../src/commands/decay.js";
 import { registerExport } from "../../src/commands/export.js";
@@ -636,6 +636,183 @@ describe("engram show", () => {
       const output = logs.join("\n");
       expect(output).toContain("TestModule");
       expect(output).toContain(entity.id);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram history", () => {
+  function makeDbWithEdge(dbPath: string) {
+    const graph = createGraph(dbPath);
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: "history test episode",
+      timestamp: new Date().toISOString(),
+    });
+    const ev = [{ episode_id: ep.id, extractor: "test", confidence: 1 }];
+    const e1 = addEntity(
+      graph,
+      { canonical_name: "Alpha", entity_type: "module" },
+      ev,
+    );
+    const e2 = addEntity(
+      graph,
+      { canonical_name: "Beta", entity_type: "module" },
+      ev,
+    );
+    addEdge(
+      graph,
+      {
+        source_id: e1.id,
+        target_id: e2.id,
+        relation_type: "depends_on",
+        edge_kind: "observed",
+        fact: "Alpha depends on Beta",
+      },
+      ev,
+    );
+    graph.db.close();
+    return { e1, e2 };
+  }
+
+  it("default text output is unchanged", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      const { e1 } = makeDbWithEdge(dbPath);
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "history",
+          e1.id,
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const output = logs.join("\n");
+      expect(output).toContain("History:");
+      expect(output).toContain("Alpha");
+      expect(output).toContain("fact(s)");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--format json emits full temporal fields for single entity", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      const { e1 } = makeDbWithEdge(dbPath);
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "history",
+          e1.id,
+          "--format",
+          "json",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const parsed = JSON.parse(logs.join("\n"));
+      expect(parsed.entity1).toBe("Alpha");
+      expect(parsed.entity2).toBeNull();
+      expect(Array.isArray(parsed.edges)).toBe(true);
+      expect(parsed.edges.length).toBeGreaterThanOrEqual(1);
+      const edge = parsed.edges[0];
+      expect(typeof edge.id).toBe("string");
+      expect(typeof edge.fact).toBe("string");
+      expect(typeof edge.edge_kind).toBe("string");
+      expect(typeof edge.relation_type).toBe("string");
+      expect("valid_from" in edge).toBe(true);
+      expect("valid_until" in edge).toBe(true);
+      expect("invalidated_at" in edge).toBe(true);
+      expect("superseded_by" in edge).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--format json emits pairwise edge history", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      const { e1, e2 } = makeDbWithEdge(dbPath);
+      const program = makeProgram();
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (...args: unknown[]) => logs.push(args.join(" "));
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "history",
+          e1.id,
+          e2.id,
+          "--format",
+          "json",
+          "--db",
+          dbPath,
+        ]);
+      } finally {
+        console.log = origLog;
+      }
+      const parsed = JSON.parse(logs.join("\n"));
+      expect(parsed.entity1).toBe("Alpha");
+      expect(parsed.entity2).toBe("Beta");
+      expect(Array.isArray(parsed.edges)).toBe(true);
+      expect(parsed.edges.length).toBeGreaterThanOrEqual(1);
+      expect(parsed.edges[0].fact).toContain("Alpha");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 1 on invalid --format value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const program = makeProgram();
+      const errors: string[] = [];
+      const origErr = console.error;
+      console.error = (...args: unknown[]) => errors.push(args.join(" "));
+      let exitCode: number | undefined;
+      const origExit = process.exit;
+      process.exit = (code?: number) => {
+        exitCode = code;
+        throw new Error(`process.exit(${code})`);
+      };
+      try {
+        await program.parseAsync([
+          "node",
+          "engram",
+          "history",
+          "anything",
+          "--format",
+          "xml",
+          "--db",
+          dbPath,
+        ]);
+      } catch {
+        // expected — process.exit throws
+      } finally {
+        console.error = origErr;
+        process.exit = origExit;
+      }
+      expect(exitCode).toBe(1);
+      expect(errors.join("\n")).toContain("--format must be 'text' or 'json'");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Adds `--format <text|json>` option to `engram history` (default: `text`)
- JSON output emits all temporal edge fields: `id`, `fact`, `edge_kind`, `relation_type`, `valid_from`, `valid_until`, `invalidated_at`, `superseded_by`
- No clack chrome when `--format json`
- Invalid format values exit 1 with `--format must be 'text' or 'json'`

Closes #148

## Acceptance Criteria

- [x] `engram history <entity> --format json` emits all edges with full temporal fields
- [x] `engram history <entity1> <entity2> --format json` emits pairwise edge history
- [x] Default text output is unchanged
- [x] Invalid format exits 1 with a clear error

## Test plan

- [ ] `bun test packages/engram-cli/test/commands/cli.test.ts` — all 25 tests pass (4 new history tests added)
- [ ] `bun run build` — clean build
- [ ] `bunx biome check` on changed files — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)