### PR TITLE
fix(cli): default embed to --status when no mode flag given

### DIFF
--- a/packages/engram-cli/src/commands/embed.ts
+++ b/packages/engram-cli/src/commands/embed.ts
@@ -506,7 +506,7 @@ export function registerEmbed(program: Command): void {
   program
     .command("embed")
     .description(
-      "Manage embeddings for semantic search. For FTS index rebuilding, see engram rebuild-index.",
+      "Manage embeddings for semantic search. With no flags, shows coverage status. For FTS index rebuilding, see engram rebuild-index.",
     )
     .option("--reindex", "clear and rebuild the vector index")
     .option(
@@ -570,11 +570,7 @@ Examples:
         opts.status,
       ].filter(Boolean).length;
       if (modeCount === 0) {
-        log.error(
-          "Specify a mode: --reindex, --check, --enable, or --status\n" +
-            "Run  engram embed --help  for usage.",
-        );
-        process.exit(1);
+        opts.status = true;
       }
       if (modeCount > 1) {
         log.error(


### PR DESCRIPTION
## Summary

- `engram embed` with no flags now shows coverage status (same output as `engram embed --status`) instead of printing an error and exiting
- Updated command description to say "With no flags, shows coverage status"
- Mutually-exclusive mode enforcement is unchanged (multiple flags still error)

## Acceptance Criteria

- [x] `engram embed` with no flags shows coverage status (same output as `engram embed --status`)
- [x] `engram embed --help` documents that no-flags shows status (updated `.description()`)
- [x] Explicit `--reindex`, `--fill`, `--check`, `--enable`, `--status` all behave unchanged
- [x] Mutually-exclusive mode enforcement still works when multiple flags are given

## Test plan

- [ ] Run `engram embed` against a real `.engram` file — confirm status output
- [ ] Run `engram embed --status` — confirm identical output
- [ ] Run `engram embed --reindex --status` — confirm mutual-exclusion error still fires
- [ ] Run `bun test` — all 767 tests pass
- [ ] Run `bun run build` — clean build

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)