### PR TITLE
fix(cli): validate --max-cost before opening graph

### DIFF
--- a/packages/engram-cli/test/commands/reconcile.test.ts
+++ b/packages/engram-cli/test/commands/reconcile.test.ts
@@ -184,6 +184,17 @@ describe("reconcile usage errors", () => {
     expect(output).toContain("--max-cost");
   });
 
+  it("exits 2 for missing --max-cost before graph I/O (non-existent db)", async () => {
+    closeGraph(graph);
+    const { exitCode, output } = await runCommand([
+      "reconcile",
+      "--db",
+      "/tmp/does-not-exist-ever.engram",
+    ]);
+    expect(exitCode).toBe(2);
+    expect(output).toContain("--max-cost");
+  });
+
   it("exits with code 2 for invalid --phase value", async () => {
     closeGraph(graph);
     const { exitCode, output } = await runCommand([


### PR DESCRIPTION
## Summary

- Confirms `--max-cost` validation (exit 2) fires before any graph I/O
- Adds an explicit regression test using a non-existent db path: if `openGraph` ran first the error message would reference the missing file rather than `--max-cost`
- All 768 existing tests continue to pass; new test count is 20 in the reconcile suite

## Implementation notes

The ordering of pre-condition validation (phase → scope → max-cost → parse values → openGraph) was already correct in the current code. This PR makes the invariant machine-verifiable by adding a test that would fail if the validation were ever moved after `openGraph`.

## Test plan
- [x] `bun test packages/engram-cli/test/commands/reconcile.test.ts` — 20 pass
- [x] `bun test` — 768 pass
- [x] `bun run build` — clean
- [x] `bunx biome check packages/engram-cli/test/commands/reconcile.test.ts` — no issues

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)