### PR TITLE
fix(cli): exit 1 when ingest source --dry-run has parse errors

### DIFF
--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -284,6 +284,8 @@ See also:
       const s = opts.verbose ? undefined : spinner();
       if (s) s.start(`Scanning ${resolvedSource}`);
 
+      let dryRunHadErrors = false;
+
       try {
         const result = await ingestSource(graph, {
           root: resolvedSource,
@@ -320,6 +322,9 @@ See also:
             errLines.push(`  … and ${result.errors.length - 10} more`);
           }
           log.warn(`Per-file errors (not fatal):\n${errLines.join("\n")}`);
+          if (opts.dryRun) {
+            dryRunHadErrors = true;
+          }
         }
       } catch (err) {
         if (s) s.stop("Source ingestion failed");
@@ -332,6 +337,10 @@ See also:
 
       closeGraph(graph);
       outro("Done");
+
+      if (dryRunHadErrors) {
+        process.exit(1);
+      }
     });
 
   // ingest enrich github

--- a/packages/engram-cli/test/commands/ingest-source.test.ts
+++ b/packages/engram-cli/test/commands/ingest-source.test.ts
@@ -185,6 +185,46 @@ describe("engram ingest source", () => {
     expect(activeEpisodeCount()).toBe(countAfterFirst);
   }, 15_000);
 
+  test("--dry-run exits 1 when parse errors occur", async () => {
+    writeFile("src/bad.ts", "export function (@@@@) {}");
+
+    const { exitCode, output } = await runIngestSource([
+      path.join(tmpDir, "src"),
+      "--dry-run",
+      "--db",
+      dbPath,
+    ]);
+
+    expect(output).toContain("Errors:");
+    expect(exitCode).toBe(1);
+  }, 15_000);
+
+  test("--dry-run exits 0 on a clean run with no errors", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+
+    const { exitCode } = await runIngestSource([
+      path.join(tmpDir, "src"),
+      "--dry-run",
+      "--db",
+      dbPath,
+    ]);
+
+    expect(exitCode).toBeUndefined();
+  }, 15_000);
+
+  test("real ingest exits 0 even with per-file parse errors", async () => {
+    writeFile("src/a.ts", "export const a = 1;");
+    writeFile("src/bad.ts", "export function (@@@@) {}");
+
+    const { exitCode } = await runIngestSource([
+      path.join(tmpDir, "src"),
+      "--db",
+      dbPath,
+    ]);
+
+    expect(exitCode).toBeUndefined();
+  }, 15_000);
+
   test("summary block always shows counts", async () => {
     writeFile("src/a.ts", "export const a = 1;");
 


### PR DESCRIPTION
## Summary

- `engram ingest source --dry-run` now exits 1 when any parse errors occur, so agents can detect failures before proceeding with a real ingest
- Real ingest (without `--dry-run`) continues to exit 0 even with per-file parse errors, since partial ingestion is valid and idempotent
- Error summary is printed before the non-zero exit in both cases

## Implementation

Added a `dryRunHadErrors` flag that is set inside the try block when errors are detected during a dry run. After `closeGraph` and `outro`, `process.exit(1)` is called if the flag is set. This keeps the flag outside the try/catch scope so the `process.exit` call is not intercepted by the catch handler.

## Test plan

- [x] `--dry-run exits 1 when parse errors occur` — writes a file with `export function (@@@@) {}` (triggers `tree.rootNode.hasError`) and asserts exit code 1
- [x] `--dry-run exits 0 on a clean run with no errors` — asserts exit code undefined (no `process.exit` called)
- [x] `real ingest exits 0 even with per-file parse errors` — same malformed file, no `--dry-run`, asserts exit code undefined
- [x] All 771 existing tests pass (`bun test`)
- [x] Build passes (`bun run build`)
- [x] Changed files pass lint (`biome check`)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)