### PR TITLE
fix(cli): status exits 0 for databases initialized with --embedding-model none

### DIFF
--- a/packages/engram-cli/src/commands/status.ts
+++ b/packages/engram-cli/src/commands/status.ts
@@ -7,7 +7,7 @@
  * Exit codes:
  *   0 — all OK
  *   1 — DB cannot be opened
- *   2 — embedding model not recorded
+ *   2 — embedding model not recorded (absent from metadata; "none" is valid)
  *   3 — embedding provider reachability failed
  *   4 — generation provider reachability failed (only if configured)
  */
@@ -482,18 +482,27 @@ function printHuman(status: StatusOutput, noVerify: boolean): void {
 
   // Embedding
   console.log("Embedding");
-  const modelStr = embedding.model
-    ? `${embedding.model}${embedding.dimensions ? ` (${embedding.dimensions} dims)` : ""}`
-    : "(not recorded)";
+  let modelStr: string;
+  if (embedding.model === "none") {
+    modelStr = "BM25 only (no vector search)";
+  } else if (embedding.model) {
+    modelStr = `${embedding.model}${embedding.dimensions ? ` (${embedding.dimensions} dims)` : ""}`;
+  } else {
+    modelStr = "(not recorded)";
+  }
   console.log(`  Model:           ${modelStr}`);
 
   let providerLine: string;
   if (embedding.provider === "ollama") {
     providerLine = `ollama @ ${embedding.providerEndpoint}${reachIcon(embedding.reachability)}`;
   } else if (embedding.provider === "none") {
-    providerLine = embedding.model
-      ? "none (set ENGRAM_AI_PROVIDER or the matching API key)"
-      : "none (set ENGRAM_AI_PROVIDER)";
+    if (embedding.model === "none") {
+      providerLine = "none (BM25-only mode)";
+    } else if (embedding.model) {
+      providerLine = "none (set ENGRAM_AI_PROVIDER or the matching API key)";
+    } else {
+      providerLine = "none (set ENGRAM_AI_PROVIDER)";
+    }
   } else {
     providerLine = `${embedding.provider}${reachIcon(embedding.reachability)}`;
   }
@@ -706,7 +715,7 @@ See also:
         // Determine exit code
         let exitCode = 0;
 
-        if (!embeddingSection.model) {
+        if (embeddingSection.model === null) {
           exitCode = 2;
         } else if (
           embeddingSection.reachability &&

--- a/packages/engram-cli/test/commands/status.test.ts
+++ b/packages/engram-cli/test/commands/status.test.ts
@@ -1,0 +1,141 @@
+/**
+ * status.test.ts — Tests for `engram status` command.
+ *
+ * Focuses on exit code and output correctness for BM25-only databases
+ * (initialized with --embedding-model none).
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { createGraph, openGraph } from "engram-core";
+import { registerStatus } from "../../src/commands/status.js";
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  registerStatus(program);
+  return program;
+}
+
+function tmpDb(): { tmpDir: string; dbPath: string } {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-status-test-"));
+  const dbPath = path.join(tmpDir, "test.engram");
+  return { tmpDir, dbPath };
+}
+
+function setMeta(dbPath: string, key: string, value: string): void {
+  const graph = openGraph(dbPath);
+  graph.db
+    .prepare(
+      "INSERT INTO metadata (key, value) VALUES (?, ?)" +
+        " ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .run(key, value);
+  graph.db.close();
+}
+
+async function runStatus(
+  dbPath: string,
+  extraArgs: string[] = [],
+): Promise<{ exitCode: number | undefined; logs: string[]; errors: string[] }> {
+  const program = makeProgram();
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+  console.error = (...args: unknown[]) => errors.push(args.join(" "));
+  let exitCode: number | undefined;
+  const origExit = process.exit;
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  (process as any).exit = (code?: number) => {
+    if (exitCode === undefined) exitCode = code;
+    throw new Error(`process.exit(${code})`);
+  };
+  try {
+    await program.parseAsync([
+      "node",
+      "engram",
+      "status",
+      "--db",
+      dbPath,
+      "--no-verify",
+      ...extraArgs,
+    ]);
+  } catch {
+    // expected — process.exit throws
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+    process.exit = origExit;
+  }
+  return { exitCode, logs, errors };
+}
+
+describe("engram status — BM25-only database (embedding-model none)", () => {
+  it("exits 0 when embedding_model is 'none'", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      setMeta(dbPath, "embedding_model", "none");
+      const { exitCode } = await runStatus(dbPath);
+      expect(exitCode).toBe(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 0 in quiet mode for BM25-only database", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      setMeta(dbPath, "embedding_model", "none");
+      const { exitCode, logs } = await runStatus(dbPath, ["--quiet"]);
+      expect(exitCode).toBe(0);
+      expect(logs.join("\n")).toBe("");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("shows 'BM25 only' in human output when model is 'none'", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      setMeta(dbPath, "embedding_model", "none");
+      const { logs } = await runStatus(dbPath);
+      const output = logs.join("\n");
+      expect(output).toContain("BM25 only");
+      expect(output).not.toContain("(not recorded)");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("includes model: 'none' (not null) in JSON output", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      setMeta(dbPath, "embedding_model", "none");
+      const { logs } = await runStatus(dbPath, ["--json"]);
+      const json = JSON.parse(logs.join("\n"));
+      expect(json.embedding.model).toBe("none");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 2 for a database with genuinely missing embedding model", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      // No embedding_model metadata set at all
+      const { exitCode } = await runStatus(dbPath);
+      expect(exitCode).toBe(2);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Changes the exit code 2 trigger from `!embeddingSection.model` to `embeddingSection.model === null`, so the string `"none"` (intentional BM25-only mode) is treated as a valid configured state
- Updates `printHuman` to display `"BM25 only (no vector search)"` instead of the raw `"none"` string when the embedding model is `"none"`
- Updates the provider line to show `"none (BM25-only mode)"` instead of the confusing "set ENGRAM_AI_PROVIDER" hint for BM25-only databases
- Adds `test/commands/status.test.ts` with 5 tests covering: exit 0 for `model=none`, quiet-mode exit 0, human output "BM25 only" label, JSON `model: "none"` (not null), and exit 2 for genuinely missing model

## Test plan

- [x] `engram init --yes --embedding-model none && engram status` exits 0
- [x] `engram status --quiet` exits 0 for BM25-only database with no other issues
- [x] `engram status --json` includes `"model": "none"` (not null) for BM25-only databases
- [x] `engram status` human output shows "BM25 only" label rather than "(not recorded)"
- [x] Databases with genuinely missing embedding model (null) still exit 2
- [x] All 776 tests pass, build succeeds, Biome clean on changed files

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)