### PR TITLE
fix(cli): route export wiki overwrite warnings to stderr

### DIFF
--- a/packages/engram-cli/src/commands/export.ts
+++ b/packages/engram-cli/src/commands/export.ts
@@ -153,7 +153,9 @@ function registerWiki(exportCmd: Command): void {
           fs.mkdirSync(kindDir, { recursive: true });
 
           if (fs.existsSync(absPath)) {
-            console.warn(`warn: overwriting existing file ${relPath}`);
+            process.stderr.write(
+              `warn: overwriting existing file ${relPath}\n`,
+            );
           }
 
           // Write body verbatim (round-trip property)
@@ -189,7 +191,7 @@ function registerWiki(exportCmd: Command): void {
 
         const indexPath = path.join(outDir, "index.md");
         if (fs.existsSync(indexPath)) {
-          console.warn("warn: overwriting existing file index.md");
+          process.stderr.write("warn: overwriting existing file index.md\n");
         }
         fs.writeFileSync(indexPath, indexLines.join("\n"), {
           encoding: "utf8",


### PR DESCRIPTION
## Summary

- Replaces two `console.warn` calls in `export wiki` with `process.stderr.write` so overwrite warnings go to stderr instead of stdout
- Success summary (`Wrote N projection file(s)` and `Index: path`) continues to use `console.log` and goes to stdout unchanged

## Acceptance Criteria

- [x] `engram export wiki --out ./wiki 2>/dev/null` produces no overwrite warnings in stdout
- [x] Overwrite warnings appear on stderr and are visible in normal interactive use
- [x] The success summary (`Wrote N projection file(s)`) continues to go to stdout

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)