### PR TITLE
fix(cli): gate sparse-results note on --verbose or stderr TTY

### DIFF
--- a/packages/engram-cli/src/commands/context.ts
+++ b/packages/engram-cli/src/commands/context.ts
@@ -166,6 +166,7 @@ interface ContextOpts {
   format: "md" | "json";
   /** Minimum normalized confidence (0.0–1.0) for a discussion hit to be included. */
   minConfidence: number;
+  verbose: boolean;
 }
 
 interface EnrichedEntity {
@@ -1210,10 +1211,15 @@ async function assembleContextPack(
   // Fix 3: Suggest enrichment when the pack is sparse and no discussions found.
   // A pack with fewer than 3 entities and no confident discussion hits is likely
   // the result of an under-populated knowledge base (no markdown or source ingestion).
-  if (entities.length < 3 && discussions.length === 0) {
+  // Gate on --verbose or TTY so CI pipelines are not spammed on every query.
+  if (
+    entities.length < 3 &&
+    discussions.length === 0 &&
+    (opts.verbose || process.stderr.isTTY)
+  ) {
     process.stderr.write(
-      "Note: fewer than 3 entities found. Run 'engram ingest md <docs-dir>' or\n" +
-        "'engram ingest source' to enrich the knowledge base.\n",
+      "Note: fewer than 3 entities found. Run 'engram ingest md <docs-dir>'" +
+        " or\n'engram ingest source' to enrich the knowledge base.\n",
     );
   }
 
@@ -1238,6 +1244,7 @@ interface ContextCommandOpts {
   format: string;
   db: string;
   minConfidence: string;
+  verbose: boolean;
 }
 
 export function registerContext(program: Command): void {
@@ -1253,6 +1260,11 @@ export function registerContext(program: Command): void {
       "--min-confidence <n>",
       "minimum confidence (0.0–1.0) for a discussion hit to be included; prefer silence to noise",
       "0.0",
+    )
+    .option(
+      "--verbose",
+      "emit diagnostic notes (e.g. sparse-results hint) to stderr",
+      false,
     )
     .addHelpText(
       "after",
@@ -1319,6 +1331,7 @@ See also:
           tokenBudget,
           format: opts.format as "md" | "json",
           minConfidence,
+          verbose: opts.verbose,
         });
 
         if (opts.format === "json") {

--- a/packages/engram-cli/test/commands/context-sparse.test.ts
+++ b/packages/engram-cli/test/commands/context-sparse.test.ts
@@ -1,0 +1,125 @@
+/**
+ * context-sparse.test.ts — Tests that the sparse-results diagnostic note on
+ * stderr is gated on --verbose or process.stderr.isTTY.
+ *
+ * Issue #155: the note was unconditionally written, causing noise in CI.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { createGraph } from "engram-core";
+import { registerContext } from "../../src/commands/context.js";
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  registerContext(program);
+  return program;
+}
+
+function tmpDb(): { tmpDir: string; dbPath: string } {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "engram-context-sparse-test-"),
+  );
+  const dbPath = path.join(tmpDir, "test.engram");
+  return { tmpDir, dbPath };
+}
+
+async function runContext(
+  dbPath: string,
+  extraArgs: string[] = [],
+  stderrIsTTY = false,
+): Promise<{ stderrWrites: string[] }> {
+  const program = makeProgram();
+  const stderrWrites: string[] = [];
+
+  const origWrite = process.stderr.write.bind(process.stderr);
+  const origIsTTY = process.stderr.isTTY;
+
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  (process.stderr as any).isTTY = stderrIsTTY;
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  (process.stderr as any).write = (chunk: string | Uint8Array) => {
+    stderrWrites.push(typeof chunk === "string" ? chunk : chunk.toString());
+    return true;
+  };
+
+  const origExit = process.exit;
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  (process as any).exit = (code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  };
+
+  try {
+    await program.parseAsync([
+      "node",
+      "engram",
+      "context",
+      "test query",
+      "--db",
+      dbPath,
+      ...extraArgs,
+    ]);
+  } catch {
+    // expected — process.exit throws or commander exits
+  } finally {
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    (process.stderr as any).write = origWrite;
+    // biome-ignore lint/suspicious/noExplicitAny: test mock
+    (process.stderr as any).isTTY = origIsTTY;
+    process.exit = origExit;
+  }
+  return { stderrWrites };
+}
+
+describe("engram context — sparse-results note gating", () => {
+  it("suppresses note when stderr is non-TTY and --verbose not set", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { stderrWrites } = await runContext(
+        dbPath,
+        [],
+        false, // non-TTY
+      );
+      const combined = stderrWrites.join("");
+      expect(combined).not.toContain("fewer than 3 entities");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits note when --verbose is set and db is sparse", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { stderrWrites } = await runContext(
+        dbPath,
+        ["--verbose"],
+        false, // non-TTY — note should still appear due to --verbose
+      );
+      const combined = stderrWrites.join("");
+      expect(combined).toContain("fewer than 3 entities");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits note when stderr is TTY even without --verbose", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { stderrWrites } = await runContext(
+        dbPath,
+        [],
+        true, // TTY — note should appear
+      );
+      const combined = stderrWrites.join("");
+      expect(combined).toContain("fewer than 3 entities");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Gates the diagnostic note ("fewer than 3 entities found...") behind `opts.verbose || process.stderr.isTTY` so CI pipelines with redirected stderr no longer see constant noise
- Adds `--verbose` flag to `engram context` (false by default)
- Adds three targeted tests covering all three acceptance criteria from the issue

## Acceptance Criteria

- [x] `engram context "query" 2>/dev/null` produces no stderr output for sparse results (non-TTY + no --verbose)
- [x] `engram context "query" --verbose` shows the sparse-results note on stderr
- [x] In interactive use (stderr is TTY), the note still appears without `--verbose`

## Test plan

- [ ] Run `bun test packages/engram-cli/test/commands/context-sparse.test.ts` — all 3 tests pass
- [ ] Run `bun test` — all 779 tests pass
- [ ] Run `bun run build` — clean build

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)