### PR TITLE
fix(cli): move intro before validation in embed command

### DIFF
--- a/packages/engram-cli/src/commands/embed.ts
+++ b/packages/engram-cli/src/commands/embed.ts
@@ -562,6 +562,8 @@ Examples:
   engram embed --status`,
     )
     .action(async (opts: EmbedOpts) => {
+      intro("engram embed");
+
       const modeCount = [
         opts.reindex,
         opts.fill,
@@ -589,8 +591,6 @@ Examples:
         );
         process.exit(1);
       }
-
-      intro("engram embed");
 
       const dbPath = path.resolve(opts.db);
       let graph: ReturnType<typeof openGraph>;


### PR DESCRIPTION
## Summary

- Moves `intro("engram embed")` to the top of the `.action()` handler, before any validation logic
- Fixes garbled terminal output when `--target` validation or `modeCount > 1` check fires before clack's `intro()` has been called
- Both the invalid `--target` and multiple-mode error paths now render cleanly within clack's formatting context

## Acceptance Criteria

- `engram embed --target invalid` produces a clean `log.error` message with proper clack formatting
- `engram embed --reindex --fill` (multiple modes) also produces clean output
- No visual artifacts or misaligned box-drawing characters in error output

## Test plan

- [x] All 781 existing tests pass (`bun test`)
- [x] Build succeeds (`bun run build`)
- [x] Modified file passes Biome lint (`bunx biome check packages/engram-cli/src/commands/embed.ts`)

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)