### PR TITLE
fix(cli): align reconcile summary label column

### DIFF
--- a/packages/engram-cli/src/commands/reconcile.ts
+++ b/packages/engram-cli/src/commands/reconcile.ts
@@ -239,20 +239,20 @@ See also:
       ).toFixed(1);
 
       const summaryLines = [
-        `Status:   ${result.status}${opts.dryRun ? " (dry-run)" : ""}`,
-        `Elapsed:  ${elapsed}s`,
+        `Status:       ${result.status}${opts.dryRun ? " (dry-run)" : ""}`,
+        `Elapsed:      ${elapsed}s`,
       ];
       if (phases.includes("assess")) {
         summaryLines.push(
-          `Assessed: ${result.assessed}`,
-          `Refreshed:   ${result.soft_refreshed}`,
-          `Superseded:  ${result.superseded}`,
+          `Assessed:     ${result.assessed}`,
+          `Refreshed:    ${result.soft_refreshed}`,
+          `Superseded:   ${result.superseded}`,
         );
       }
       if (phases.includes("discover")) {
-        summaryLines.push(`Discovered:  ${result.discovered}`);
+        summaryLines.push(`Discovered:   ${result.discovered}`);
       }
-      summaryLines.push(`Run ID:   ${result.run_id}`);
+      summaryLines.push(`Run ID:       ${result.run_id}`);
       log.info(summaryLines.join("\n"));
 
       if (result.status === "partial") {


### PR DESCRIPTION
## Summary

- Aligns all labels in the `engram reconcile` post-run summary to a consistent 13-char column width
- Fixes `Refreshed:`, `Superseded:`, and `Discovered:` which had inconsistent trailing spaces compared to `Status:`, `Elapsed:`, `Assessed:`, and `Run ID:`
- Applies to `--phase assess`, `--phase discover`, and `--phase both` outputs

## Acceptance Criteria

- [x] All summary labels align to the same column in `engram reconcile` output
- [x] Both `--phase assess` and `--phase discover` outputs are aligned
- [x] Combined `--phase both` output is aligned

## Test plan

- [x] All 781 existing tests pass
- [x] Build succeeds across all packages
- [x] Changed file passes Biome lint

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)