### PR TITLE
fix(cli): show character constraint in --kind help text

### DIFF
--- a/packages/engram-cli/src/commands/project.ts
+++ b/packages/engram-cli/src/commands/project.ts
@@ -202,7 +202,10 @@ export function registerProject(program: Command): void {
   program
     .command("project")
     .description("Author a projection on an anchor with explicit inputs")
-    .requiredOption("--kind <kind>", "projection kind (e.g. entity_summary)")
+    .requiredOption(
+      "--kind <kind>",
+      "projection kind — lowercase letters, digits, underscores only (e.g. entity_summary)",
+    )
     .requiredOption(
       "--anchor <type:id>",
       'anchor for the projection (e.g. "entity:01HX..." or "none")',


### PR DESCRIPTION
## Summary

- Updates `--kind` flag description to include the regex constraint (`/^[a-z][a-z0-9_]*$/`) so users and agents reading `--help` see the valid character set upfront
- Runtime validation error message is unchanged

## Acceptance Criteria

- [x] `engram project --help` shows the character constraint in the `--kind` flag description
- [x] Runtime validation error message is unchanged (still fires on invalid input)

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)