### PR TITLE
fix(cli): validate --port range before starting server

### DIFF
--- a/packages/engram-cli/src/commands/visualize.ts
+++ b/packages/engram-cli/src/commands/visualize.ts
@@ -46,6 +46,10 @@ See also:
     .action((opts: VisualizeOpts) => {
       const dbPath = path.resolve(opts.db);
       const port = Number.parseInt(opts.port, 10);
+      if (Number.isNaN(port) || port < 1 || port > 65535) {
+        console.error("Error: --port must be an integer between 1 and 65535");
+        process.exit(1);
+      }
       const host = opts.host;
 
       if (!LOOPBACK_HOSTS.has(host)) {

--- a/packages/engram-cli/test/commands/visualize.test.ts
+++ b/packages/engram-cli/test/commands/visualize.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { Command } from "commander";
+import { registerVisualize } from "../../src/commands/visualize.js";
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  registerVisualize(program);
+  return program;
+}
+
+async function runVisualize(args: string[]): Promise<{
+  exitCode: number | undefined;
+  errors: string[];
+}> {
+  const program = makeProgram();
+  const errors: string[] = [];
+  const origErr = console.error;
+  console.error = (...a: unknown[]) => errors.push(a.join(" "));
+  let exitCode: number | undefined;
+  const origExit = process.exit;
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  (process as any).exit = (code?: number) => {
+    if (exitCode === undefined) exitCode = code;
+    throw new Error(`process.exit(${code})`);
+  };
+  try {
+    await program.parseAsync(["node", "engram", "visualize", ...args]);
+  } catch {
+    // expected — process.exit throws
+  } finally {
+    console.error = origErr;
+    process.exit = origExit;
+  }
+  return { exitCode, errors };
+}
+
+describe("engram visualize --port validation", () => {
+  it("exits 1 with message for non-numeric --port", async () => {
+    const { exitCode, errors } = await runVisualize(["--port", "abc"]);
+    expect(exitCode).toBe(1);
+    expect(errors.join("\n")).toContain(
+      "Error: --port must be an integer between 1 and 65535",
+    );
+  });
+
+  it("exits 1 with message for --port 0", async () => {
+    const { exitCode, errors } = await runVisualize(["--port", "0"]);
+    expect(exitCode).toBe(1);
+    expect(errors.join("\n")).toContain(
+      "Error: --port must be an integer between 1 and 65535",
+    );
+  });
+
+  it("exits 1 with message for --port 99999", async () => {
+    const { exitCode, errors } = await runVisualize(["--port", "99999"]);
+    expect(exitCode).toBe(1);
+    expect(errors.join("\n")).toContain(
+      "Error: --port must be an integer between 1 and 65535",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add explicit `Number.isNaN` and range (1–65535) check after `Number.parseInt` in the `visualize` command
- Invalid values (`abc`, `0`, `99999`) now exit 1 with `Error: --port must be an integer between 1 and 65535` instead of producing an opaque OS/network error
- Add colocated test file covering all three invalid cases

Closes #160

## Acceptance Criteria

- [x] `engram visualize --port abc` exits 1 with `Error: --port must be an integer between 1 and 65535`
- [x] `engram visualize --port 0` exits 1 with the same message
- [x] `engram visualize --port 99999` exits 1 with the same message
- [x] `engram visualize --port 8080` starts normally (validation passes through)

## Test plan

- Run `bun test packages/engram-cli/test/commands/visualize.test.ts` — 3 tests covering all invalid-port scenarios
- Full suite: `bun test` — 784 pass, 0 fail
- Build: `bun run build` — all packages build clean
- Lint: `bunx biome check` on changed files — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)