### PR TITLE
feat(cli): emit structured ingestion summary in init --yes

### DIFF
--- a/packages/engram-cli/src/commands/init.ts
+++ b/packages/engram-cli/src/commands/init.ts
@@ -89,7 +89,7 @@ function buildProvider(
 async function runMarkdownIngest(
   graph: ReturnType<typeof createGraph>,
   mdPath: string,
-): Promise<void> {
+): Promise<{ episodesCreated: number; episodesSkipped: number } | null> {
   const s = spinner();
   s.start(`Ingesting markdown: ${mdPath}`);
   try {
@@ -97,17 +97,27 @@ async function runMarkdownIngest(
     s.stop(
       `Markdown ingestion complete — ${result.episodesCreated} episodes created, ${result.episodesSkipped} skipped`,
     );
+    return {
+      episodesCreated: result.episodesCreated,
+      episodesSkipped: result.episodesSkipped,
+    };
   } catch (err) {
     s.stop(
       `Markdown ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+    return null;
   }
 }
 
 async function runSourceIngest(
   graph: ReturnType<typeof createGraph>,
   root: string,
-): Promise<void> {
+): Promise<{
+  filesParsed: number;
+  filesSkipped: number;
+  entitiesCreated: number;
+  edgesCreated: number;
+} | null> {
   const s = spinner();
   s.start("Ingesting source code…");
   try {
@@ -115,22 +125,29 @@ async function runSourceIngest(
     s.stop(
       [
         "Source ingestion complete",
-        `  Files: ${result.parsed} parsed, ${result.skipped} skipped`,
+        `  Files: ${result.filesParsed} parsed, ${result.filesSkipped} skipped`,
         `  Entities: ${result.entitiesCreated} created`,
         `  Edges:    ${result.edgesCreated} created`,
       ].join("\n"),
     );
+    return {
+      filesParsed: result.filesParsed,
+      filesSkipped: result.filesSkipped,
+      entitiesCreated: result.entitiesCreated,
+      edgesCreated: result.edgesCreated,
+    };
   } catch (err) {
     s.stop(
       `Source ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+    return null;
   }
 }
 
 async function runEmbed(
   graph: ReturnType<typeof createGraph>,
   provider: AIProvider,
-): Promise<void> {
+): Promise<{ done: number; errors: number; elapsedS: string } | null> {
   const startMs = Date.now();
   const s = spinner();
   s.start("Generating embeddings…");
@@ -149,11 +166,13 @@ async function runEmbed(
         `${result.errors} items failed — run  engram embed --reindex  to retry.`,
       );
     }
+    return { done: result.done, errors: result.errors, elapsedS: elapsed };
   } catch (err) {
     s.stop(
       `Embedding failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     log.warn("Run  engram embed --reindex  to retry.");
+    return null;
   }
 }
 
@@ -415,6 +434,26 @@ async function runNonInteractive(opts: InitOpts): Promise<void> {
     setEmbeddingModel(graph, embeddingModel, dims);
   }
 
+  type GitSummary = {
+    episodesCreated: number;
+    episodesSkipped: number;
+    entitiesCreated: number;
+    edgesCreated: number;
+  };
+  type MdSummary = { episodesCreated: number; episodesSkipped: number };
+  type SourceSummary = {
+    filesParsed: number;
+    filesSkipped: number;
+    entitiesCreated: number;
+    edgesCreated: number;
+  };
+  type EmbedSummary = { done: number; errors: number; elapsedS: string };
+
+  let gitSummary: GitSummary | null = null;
+  let mdSummary: MdSummary | null = null;
+  let sourceSummary: SourceSummary | null = null;
+  let embedSummary: EmbedSummary | null = null;
+
   if (opts.fromGit) {
     const repoPath = path.resolve(opts.fromGit);
     log.info(`Ingesting git repository at ${repoPath}…`);
@@ -428,6 +467,12 @@ async function runNonInteractive(opts: InitOpts): Promise<void> {
           `  Edges:    ${result.edgesCreated} created`,
         ].join("\n"),
       );
+      gitSummary = {
+        episodesCreated: result.episodesCreated,
+        episodesSkipped: result.episodesSkipped,
+        entitiesCreated: result.entitiesCreated,
+        edgesCreated: result.edgesCreated,
+      };
     } catch (err) {
       log.error(
         `Git ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -438,11 +483,11 @@ async function runNonInteractive(opts: InitOpts): Promise<void> {
   }
 
   if (opts.ingestMd) {
-    await runMarkdownIngest(graph, opts.ingestMd);
+    mdSummary = await runMarkdownIngest(graph, opts.ingestMd);
   }
 
   if (opts.ingestSource) {
-    await runSourceIngest(graph, path.resolve("."));
+    sourceSummary = await runSourceIngest(graph, path.resolve("."));
   }
 
   if (opts.embed) {
@@ -455,11 +500,52 @@ async function runNonInteractive(opts: InitOpts): Promise<void> {
           "Set GEMINI_API_KEY, OPENAI_API_KEY, or ensure Ollama is running.",
       );
     } else {
-      await runEmbed(graph, provider);
+      embedSummary = await runEmbed(graph, provider);
     }
   }
 
-  log.success(`Created ${dbPath}`);
+  const summaryLines: string[] = [`✓ Created ${dbPath}`, ""];
+  if (gitSummary) {
+    summaryLines.push(
+      `  Git ingestion:    ${gitSummary.episodesCreated} episodes, ` +
+        `${gitSummary.entitiesCreated} entities, ${gitSummary.edgesCreated} edges` +
+        (gitSummary.episodesSkipped > 0
+          ? ` (${gitSummary.episodesSkipped} skipped)`
+          : ""),
+    );
+  }
+  if (mdSummary) {
+    summaryLines.push(
+      `  Markdown:         ${mdSummary.episodesCreated} episodes created` +
+        (mdSummary.episodesSkipped > 0
+          ? `, ${mdSummary.episodesSkipped} skipped`
+          : ""),
+    );
+  }
+  if (sourceSummary) {
+    summaryLines.push(
+      `  Source ingestion: ${sourceSummary.entitiesCreated} entities, ` +
+        `${sourceSummary.edgesCreated} edges (${sourceSummary.filesParsed} files parsed)`,
+    );
+  }
+  if (embedSummary) {
+    summaryLines.push(
+      `  Embeddings:       ${embedSummary.done} items indexed in ${embedSummary.elapsedS}s`,
+    );
+  }
+
+  const hasStats =
+    gitSummary !== null ||
+    mdSummary !== null ||
+    sourceSummary !== null ||
+    embedSummary !== null;
+  if (hasStats) summaryLines.push("");
+
+  summaryLines.push("Next steps:");
+  summaryLines.push(`  engram context "your query" --db ${dbPath}`);
+  summaryLines.push("  engram companion >> CLAUDE.md");
+
+  log.success(summaryLines.join("\n"));
   closeGraph(graph);
 }
 

--- a/packages/engram-cli/test/commands/init-yes-summary.test.ts
+++ b/packages/engram-cli/test/commands/init-yes-summary.test.ts
@@ -1,0 +1,146 @@
+/**
+ * init-yes-summary.test.ts — Tests for structured summary emitted by
+ * `engram init --yes` in non-interactive mode.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { registerInit } from "../../src/commands/init.js";
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  registerInit(program);
+  return program;
+}
+
+function tmpDir(): { dir: string; dbPath: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-init-summary-"));
+  const dbPath = path.join(dir, "test.engram");
+  return { dir, dbPath };
+}
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (
+    chunk: string | Uint8Array,
+    ...rest: unknown[]
+  ): boolean => {
+    chunks.push(
+      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
+    );
+    return orig(
+      chunk,
+      ...(rest as Parameters<typeof process.stdout.write>).slice(1),
+    );
+  };
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = orig;
+  }
+  return chunks.join("");
+}
+
+describe("engram init --yes summary", () => {
+  let dir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    ({ dir, dbPath } = tmpDir());
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("no ingestion flags: shows Created and Next steps, no stat lines", async () => {
+    const out = await captureStdout(async () => {
+      await makeProgram().parseAsync([
+        "node",
+        "engram",
+        "init",
+        "--yes",
+        "--embedding-model",
+        "none",
+        "--db",
+        dbPath,
+      ]);
+    });
+
+    expect(out).toContain("Created");
+    expect(out).toContain(dbPath);
+    expect(out).toContain("Next steps:");
+    expect(out).toContain("engram context");
+    expect(out).toContain("engram companion");
+
+    expect(out).not.toContain("Git ingestion:");
+    expect(out).not.toContain("Markdown:");
+    expect(out).not.toContain("Source ingestion:");
+    expect(out).not.toContain("Embeddings:");
+  });
+
+  it("--from-git: shows git ingestion stats in summary", {
+    timeout: 30000,
+  }, async () => {
+    const repoPath = path.resolve(__dirname, "../../../..");
+
+    const out = await captureStdout(async () => {
+      await makeProgram().parseAsync([
+        "node",
+        "engram",
+        "init",
+        "--yes",
+        "--embedding-model",
+        "none",
+        "--from-git",
+        repoPath,
+        "--db",
+        dbPath,
+      ]);
+    });
+
+    expect(out).toContain("Created");
+    expect(out).toContain("Git ingestion:");
+    expect(out).toContain("episodes");
+    expect(out).toContain("entities");
+    expect(out).toContain("edges");
+    expect(out).toContain("Next steps:");
+
+    expect(out).not.toContain("Markdown:");
+    expect(out).not.toContain("Source ingestion:");
+    expect(out).not.toContain("Embeddings:");
+  });
+
+  it("--from-git --ingest-source: shows both git and source stats", {
+    timeout: 120000,
+  }, async () => {
+    const repoPath = path.resolve(__dirname, "../../../..");
+
+    const out = await captureStdout(async () => {
+      await makeProgram().parseAsync([
+        "node",
+        "engram",
+        "init",
+        "--yes",
+        "--embedding-model",
+        "none",
+        "--from-git",
+        repoPath,
+        "--ingest-source",
+        "--db",
+        dbPath,
+      ]);
+    });
+
+    expect(out).toContain("Git ingestion:");
+    expect(out).toContain("Source ingestion:");
+    expect(out).toContain("files parsed");
+    expect(out).toContain("Next steps:");
+
+    expect(out).not.toContain("Embeddings:");
+  });
+});


### PR DESCRIPTION
## Summary

- Collects return values from each ingestion step in `runNonInteractive` and emits a formatted multi-line summary at the end
- Only shows sections for steps that were actually run (git, markdown, source, embeddings)
- Also fixes `runSourceIngest` to use correct field names (`filesParsed`/`filesSkipped`) from `SourceIngestResult` — the old code referenced `result.parsed`/`result.skipped` which don't exist on that type
- Adds 3 integration tests covering the no-ingestion, git-only, and git+source cases

## Acceptance Criteria

- [x] `engram init --yes --from-git .` shows git ingestion stats
- [x] `engram init --yes --from-git . --ingest-source --embed` shows stats for all three steps
- [x] `engram init --yes` (no ingestion flags) shows only the "Created" line and next steps
- [x] Stats match the actual results returned by each ingest function

## Test plan

- [x] `bun test` — 787 pass, 0 fail
- [x] `bun run build` — all packages built cleanly
- [x] `bunx biome check` — no lint errors on changed files

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)