### PR TITLE
feat(cli): add --max-entities and --max-edges to context command

### DIFF
--- a/packages/engram-cli/src/commands/context.ts
+++ b/packages/engram-cli/src/commands/context.ts
@@ -1354,8 +1354,10 @@ See also:
       let maxEntities: number | undefined;
       if (opts.maxEntities !== undefined) {
         maxEntities = parseInt(opts.maxEntities, 10);
-        if (Number.isNaN(maxEntities) || maxEntities < 0) {
-          console.error("Error: --max-entities must be a non-negative integer");
+        if (Number.isNaN(maxEntities) || maxEntities < 1) {
+          console.error(
+            "Error: --max-entities must be a positive integer",
+          );
           process.exit(1);
         }
       }
@@ -1363,8 +1365,8 @@ See also:
       let maxEdges: number | undefined;
       if (opts.maxEdges !== undefined) {
         maxEdges = parseInt(opts.maxEdges, 10);
-        if (Number.isNaN(maxEdges) || maxEdges < 0) {
-          console.error("Error: --max-edges must be a non-negative integer");
+        if (Number.isNaN(maxEdges) || maxEdges < 1) {
+          console.error("Error: --max-edges must be a positive integer");
           process.exit(1);
         }
       }

--- a/packages/engram-cli/src/commands/context.ts
+++ b/packages/engram-cli/src/commands/context.ts
@@ -1355,9 +1355,7 @@ See also:
       if (opts.maxEntities !== undefined) {
         maxEntities = parseInt(opts.maxEntities, 10);
         if (Number.isNaN(maxEntities) || maxEntities < 1) {
-          console.error(
-            "Error: --max-entities must be a positive integer",
-          );
+          console.error("Error: --max-entities must be a positive integer");
           process.exit(1);
         }
       }

--- a/packages/engram-cli/src/commands/context.ts
+++ b/packages/engram-cli/src/commands/context.ts
@@ -167,6 +167,10 @@ interface ContextOpts {
   /** Minimum normalized confidence (0.0–1.0) for a discussion hit to be included. */
   minConfidence: number;
   verbose: boolean;
+  /** Hard cap on entities included, applied before the token budget loop. */
+  maxEntities?: number;
+  /** Hard cap on edges included, applied before the token budget loop. */
+  maxEdges?: number;
 }
 
 interface EnrichedEntity {
@@ -989,7 +993,12 @@ async function assembleContextPack(
       : []),
   ];
 
-  for (const row of entityRowsToProcess) {
+  const cappedEntityRows =
+    opts.maxEntities !== undefined
+      ? entityRowsToProcess.slice(0, opts.maxEntities)
+      : entityRowsToProcess;
+
+  for (const row of cappedEntityRows) {
     if (budgetExceeded()) {
       truncated++;
       continue;
@@ -1051,10 +1060,13 @@ async function assembleContextPack(
   }
 
   // Process edge results.
-  const edgeMinRank = Math.min(...edgeRows.map((r) => r.rank), 0);
+  const cappedEdgeRows =
+    opts.maxEdges !== undefined ? edgeRows.slice(0, opts.maxEdges) : edgeRows;
+
+  const edgeMinRank = Math.min(...cappedEdgeRows.map((r) => r.rank), 0);
   const edgeRankRange = Math.abs(edgeMinRank) || 1;
 
-  for (const row of edgeRows) {
+  for (const row of cappedEdgeRows) {
     if (budgetExceeded()) {
       truncated++;
       continue;
@@ -1174,11 +1186,15 @@ async function assembleContextPack(
   // search cannot derive. We add them to the edge section after FTS edges.
   const seenEdgeIds = new Set(edges.map((e) => e.result_id));
   const foundEntityIds = entities.map((e) => e.result_id);
+  const structuralLimit =
+    opts.maxEdges !== undefined
+      ? Math.max(0, opts.maxEdges - edges.length)
+      : 15;
   const structuralRows = fetchStructuralEdges(
     graph,
     foundEntityIds,
     seenEdgeIds,
-    15,
+    structuralLimit,
   );
   for (const row of structuralRows) {
     if (budgetExceeded()) {
@@ -1245,6 +1261,8 @@ interface ContextCommandOpts {
   db: string;
   minConfidence: string;
   verbose: boolean;
+  maxEntities?: string;
+  maxEdges?: string;
 }
 
 export function registerContext(program: Command): void {
@@ -1266,6 +1284,14 @@ export function registerContext(program: Command): void {
       "emit diagnostic notes (e.g. sparse-results hint) to stderr",
       false,
     )
+    .option(
+      "--max-entities <n>",
+      "hard cap on entities included regardless of token budget (default: uncapped)",
+    )
+    .option(
+      "--max-edges <n>",
+      "hard cap on edges included regardless of token budget (default: uncapped)",
+    )
     .addHelpText(
       "after",
       `
@@ -1276,6 +1302,12 @@ Examples:
   # Larger budget for complex queries
   engram context "why was X refactored" --token-budget 16000
 
+  # Limit to exactly 5 entities
+  engram context "auth middleware" --max-entities 5
+
+  # Limit both entities and edges
+  engram context "database schema" --max-entities 5 --max-edges 3
+
   # JSON output for programmatic use
   engram context "database schema" --format json
 
@@ -1283,6 +1315,9 @@ When to use:
   Call before modifying unfamiliar code, answering "why is this written
   this way?", or making multi-file changes. Output is Markdown by default
   for direct injection into CLAUDE.md or agent system prompts.
+
+  Use --max-entities / --max-edges when you need predictable output sizing
+  regardless of token budget (e.g. when injecting into a fixed-size prompt).
 
 See also:
   engram companion   Write a reusable agent prompt fragment
@@ -1316,6 +1351,24 @@ See also:
         process.exit(1);
       }
 
+      let maxEntities: number | undefined;
+      if (opts.maxEntities !== undefined) {
+        maxEntities = parseInt(opts.maxEntities, 10);
+        if (Number.isNaN(maxEntities) || maxEntities < 0) {
+          console.error("Error: --max-entities must be a non-negative integer");
+          process.exit(1);
+        }
+      }
+
+      let maxEdges: number | undefined;
+      if (opts.maxEdges !== undefined) {
+        maxEdges = parseInt(opts.maxEdges, 10);
+        if (Number.isNaN(maxEdges) || maxEdges < 0) {
+          console.error("Error: --max-edges must be a non-negative integer");
+          process.exit(1);
+        }
+      }
+
       let graph: EngramGraph | undefined;
       try {
         graph = openGraph(dbPath);
@@ -1332,6 +1385,8 @@ See also:
           format: opts.format as "md" | "json",
           minConfidence,
           verbose: opts.verbose,
+          maxEntities,
+          maxEdges,
         });
 
         if (opts.format === "json") {

--- a/packages/engram-cli/test/commands/context-max-flags.test.ts
+++ b/packages/engram-cli/test/commands/context-max-flags.test.ts
@@ -1,0 +1,219 @@
+/**
+ * context-max-flags.test.ts — Tests for --max-entities and --max-edges
+ * hard-cap flags on `engram context`.
+ *
+ * Issue #162: flags apply as secondary filters after the token budget,
+ * limiting candidate sets before the budget loop.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { addEdge, addEntity, addEpisode, createGraph } from "engram-core";
+import { registerContext } from "../../src/commands/context.js";
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  registerContext(program);
+  return program;
+}
+
+function tmpDb(): { tmpDir: string; dbPath: string } {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "engram-context-max-flags-test-"),
+  );
+  const dbPath = path.join(tmpDir, "test.engram");
+  return { tmpDir, dbPath };
+}
+
+function makePopulatedDb(dbPath: string, entityCount = 8, edgeCount = 6) {
+  const graph = createGraph(dbPath);
+  const entityIds: string[] = [];
+
+  for (let i = 0; i < entityCount; i++) {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: `auth middleware service episode ${i} token authentication`,
+      timestamp: new Date().toISOString(),
+    });
+    const entity = addEntity(
+      graph,
+      {
+        canonical_name: `AuthService${i}`,
+        entity_type: "module",
+        summary: `auth middleware module ${i}`,
+      },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+    entityIds.push(entity.id);
+  }
+
+  for (let i = 0; i < edgeCount && i + 1 < entityIds.length; i++) {
+    const ep = addEpisode(graph, {
+      source_type: "manual",
+      content: `co-change edge ${i} auth token middleware`,
+      timestamp: new Date().toISOString(),
+    });
+    addEdge(
+      graph,
+      {
+        source_id: entityIds[i],
+        target_id: entityIds[i + 1],
+        fact: `AuthService${i} co-changes with AuthService${i + 1}`,
+        edge_kind: "observed",
+        relation_type: "co_changes_with",
+      },
+      [{ episode_id: ep.id, extractor: "test" }],
+    );
+  }
+
+  graph.db.close();
+}
+
+async function runContextCapture(
+  dbPath: string,
+  extraArgs: string[] = [],
+): Promise<{ stdout: string; exitCode: number | null }> {
+  const program = makeProgram();
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...args: unknown[]) => logs.push(args.join(" "));
+  let exitCode: number | null = null;
+
+  const origExit = process.exit;
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  (process as any).exit = (code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`process.exit(${code})`);
+  };
+
+  try {
+    await program.parseAsync([
+      "node",
+      "engram",
+      "context",
+      "auth middleware",
+      "--db",
+      dbPath,
+      ...extraArgs,
+    ]);
+  } catch {
+    // expected when process.exit is called
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+    process.exit = origExit;
+  }
+
+  return { stdout: logs.join("\n"), exitCode };
+}
+
+describe("engram context --max-entities", () => {
+  it("caps entities to the specified limit", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      makePopulatedDb(dbPath, 8, 0);
+      const { stdout } = await runContextCapture(dbPath, [
+        "--max-entities",
+        "3",
+      ]);
+      const entityMatches = stdout.match(/`AuthService\d+`/g) ?? [];
+      expect(entityMatches.length).toBeLessThanOrEqual(3);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("without flag returns more entities when available", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      makePopulatedDb(dbPath, 8, 0);
+      const { stdout } = await runContextCapture(dbPath);
+      const entityMatches = stdout.match(/`AuthService\d+`/g) ?? [];
+      expect(entityMatches.length).toBeGreaterThan(3);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-integer value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { exitCode } = await runContextCapture(dbPath, [
+        "--max-entities",
+        "abc",
+      ]);
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects negative value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { exitCode } = await runContextCapture(dbPath, [
+        "--max-entities",
+        "-1",
+      ]);
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram context --max-edges", () => {
+  it("rejects non-integer value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { exitCode } = await runContextCapture(dbPath, [
+        "--max-edges",
+        "abc",
+      ]);
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects negative value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { exitCode } = await runContextCapture(dbPath, [
+        "--max-edges",
+        "-1",
+      ]);
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("engram context --max-entities and --max-edges combined", () => {
+  it("both flags can be combined", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      makePopulatedDb(dbPath, 8, 6);
+      const { stdout, exitCode } = await runContextCapture(dbPath, [
+        "--max-entities",
+        "2",
+        "--max-edges",
+        "2",
+      ]);
+      expect(exitCode).toBeNull();
+      const entityMatches = stdout.match(/`AuthService\d+`/g) ?? [];
+      expect(entityMatches.length).toBeLessThanOrEqual(2);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/engram-cli/test/commands/context-max-flags.test.ts
+++ b/packages/engram-cli/test/commands/context-max-flags.test.ts
@@ -166,6 +166,20 @@ describe("engram context --max-entities", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects zero value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { exitCode } = await runContextCapture(dbPath, [
+        "--max-entities",
+        "0",
+      ]);
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("engram context --max-edges", () => {
@@ -190,6 +204,20 @@ describe("engram context --max-edges", () => {
       const { exitCode } = await runContextCapture(dbPath, [
         "--max-edges",
         "-1",
+      ]);
+      expect(exitCode).toBe(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects zero value", async () => {
+    const { tmpDir, dbPath } = tmpDb();
+    try {
+      createGraph(dbPath).db.close();
+      const { exitCode } = await runContextCapture(dbPath, [
+        "--max-edges",
+        "0",
       ]);
       expect(exitCode).toBe(1);
     } finally {


### PR DESCRIPTION
## Summary

- Adds `--max-entities <n>` flag to cap entities included in output regardless of token budget
- Adds `--max-edges <n>` flag to cap edges (FTS + structural) included regardless of token budget
- Both flags are strictly additive — `--token-budget` remains the primary constraint; without the new flags, behavior is unchanged

## Implementation

The caps are applied as secondary filters in `assembleContextPack` before the budget loop, limiting the candidate sets:

```ts
const cappedEntityRows =
  opts.maxEntities !== undefined
    ? entityRowsToProcess.slice(0, opts.maxEntities)
    : entityRowsToProcess;
```

For edges, both the FTS edge candidates and the structural edge augmentation limit respect `--max-edges`. The structural edge fetch is capped to `max(0, maxEdges - ftsEdgesAdded)` so the combined total never exceeds the flag value.

Both flags are validated at parse time and reject non-integer or negative values with exit code 1.

## Test plan

- [ ] `engram context "query" --max-entities 5` includes at most 5 entities
- [ ] `engram context "query" --max-edges 3` includes at most 3 edges
- [ ] Both flags combined: `--max-entities 5 --max-edges 3`
- [ ] Without flags, behavior unchanged (more entities returned)
- [ ] Invalid values (non-integer, negative) exit with code 1
- [ ] `--help` documents both flags with examples
- [ ] All 794 existing tests pass

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)