### PR TITLE
feat(cli): add -j and -v short flags to all commands

### DIFF
--- a/packages/engram-cli/src/commands/context.ts
+++ b/packages/engram-cli/src/commands/context.ts
@@ -1264,6 +1264,7 @@ interface ContextCommandOpts {
   verbose: boolean;
   maxEntities?: string;
   maxEdges?: string;
+  j?: boolean;
 }
 
 export function registerContext(program: Command): void {
@@ -1274,6 +1275,7 @@ export function registerContext(program: Command): void {
     )
     .option("--token-budget <n>", "max tokens in the assembled pack", "8000")
     .option("--format <fmt>", "output format: md or json", "md")
+    .option("-j", "shorthand for --format json")
     .option("--db <path>", "path to .engram file", ".engram")
     .option(
       "--min-confidence <n>",
@@ -1281,7 +1283,7 @@ export function registerContext(program: Command): void {
       "0.0",
     )
     .option(
-      "--verbose",
+      "-v, --verbose",
       "emit diagnostic notes (e.g. sparse-results hint) to stderr",
       false,
     )
@@ -1325,6 +1327,7 @@ See also:
   engram ingest git  Populate the knowledge graph from git history`,
     )
     .action(async (query: string, opts: ContextCommandOpts) => {
+      if (opts.j) opts.format = "json";
       const dbPath = resolveDbPath(path.resolve(opts.db));
       const tokenBudget = parseInt(opts.tokenBudget, 10);
       const minConfidence = parseFloat(opts.minConfidence);

--- a/packages/engram-cli/src/commands/decay.ts
+++ b/packages/engram-cli/src/commands/decay.ts
@@ -13,6 +13,7 @@ interface DecayOpts {
   dormantDays: string;
   format: string;
   db: string;
+  j?: boolean;
 }
 
 function renderTable(report: DecayReport): void {
@@ -52,6 +53,7 @@ export function registerDecay(program: Command): void {
     .option("--stale-days <n>", "days without evidence to mark as stale", "180")
     .option("--dormant-days <n>", "days of owner inactivity to flag", "90")
     .option("--format <fmt>", "output format: table or json", "table")
+    .option("-j", "shorthand for --format json")
     .option("--db <path>", "path to .engram file", ".engram")
     .addHelpText(
       "after",
@@ -77,6 +79,7 @@ See also:
   engram verify   check graph evidence invariants`,
     )
     .action((opts: DecayOpts) => {
+      if (opts.j) opts.format = "json";
       const dbPath = resolveDbPath(path.resolve(opts.db));
       const staleDays = parseInt(opts.staleDays, 10);
       const dormantDays = parseInt(opts.dormantDays, 10);

--- a/packages/engram-cli/src/commands/history.ts
+++ b/packages/engram-cli/src/commands/history.ts
@@ -14,6 +14,7 @@ import {
 interface HistoryOpts {
   db: string;
   format: string;
+  j?: boolean;
 }
 
 function resolveEntityByNameOrId(
@@ -31,6 +32,7 @@ export function registerHistory(program: Command): void {
     )
     .option("--db <path>", "path to .engram file", ".engram")
     .option("--format <fmt>", "output format: text or json", "text")
+    .option("-j", "shorthand for --format json")
     .addHelpText(
       "after",
       `
@@ -58,6 +60,7 @@ See also:
         entity2Arg: string | undefined,
         opts: HistoryOpts,
       ) => {
+        if (opts.j) opts.format = "json";
         if (opts.format !== "text" && opts.format !== "json") {
           console.error("Error: --format must be 'text' or 'json'");
           process.exit(1);

--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -233,7 +233,7 @@ See also:
       "skip .gitignore application (denylist still applies)",
     )
     .option("--dry-run", "walk and report counts without writing")
-    .option("--verbose", "emit per-file progress output")
+    .option("-v, --verbose", "emit per-file progress output")
     .option("--db <path>", "path to .engram file", ".engram")
     .action(async (sourcePath: string | undefined, opts: IngestSourceOpts) => {
       if (process.stdout.isTTY) intro("engram ingest source");
@@ -380,7 +380,7 @@ See also:
     )
     .option("--repo <owner/repo>", "repository in owner/repo format")
     .option(
-      "--verbose",
+      "-v, --verbose",
       "print extra details (auth mode, rate limit info)",
       false,
     )

--- a/packages/engram-cli/src/commands/ownership.ts
+++ b/packages/engram-cli/src/commands/ownership.ts
@@ -24,6 +24,7 @@ interface OwnershipOpts {
   format: string;
   minConfidence: string;
   db: string;
+  j?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,7 @@ export function registerOwnership(program: Command): void {
     .option("--limit <n>", "maximum number of entries to show", "20")
     .option("--module <path>", "scope to entities under this path prefix")
     .option("--format <fmt>", "output format: table or json", "table")
+    .option("-j", "shorthand for --format json")
     .option(
       "--min-confidence <f>",
       "minimum likely_owner_of edge confidence (0.0-1.0)",
@@ -140,6 +142,7 @@ See also:
   engram stats     quick count of graph contents`,
     )
     .action((opts: OwnershipOpts) => {
+      if (opts.j) opts.format = "json";
       const dbPath = resolveDbPath(path.resolve(opts.db));
       const limit = parseInt(opts.limit, 10);
       const minConfidence = parseFloat(opts.minConfidence);

--- a/packages/engram-cli/src/commands/search.ts
+++ b/packages/engram-cli/src/commands/search.ts
@@ -22,6 +22,7 @@ interface SearchOpts {
   validAt?: string;
   format: string;
   db: string;
+  j?: boolean;
 }
 
 export function registerSearch(program: Command): void {
@@ -31,6 +32,7 @@ export function registerSearch(program: Command): void {
     .option("--limit <n>", "maximum results to return", "20")
     .option("--valid-at <iso>", "filter edges valid at this ISO8601 timestamp")
     .option("--format <fmt>", "output format: text or json", "text")
+    .option("-j", "shorthand for --format json")
     .option("--db <path>", "path to .engram file", ".engram")
     .addHelpText(
       "after",
@@ -54,6 +56,7 @@ See also:
   engram show      display full entity details by ID`,
     )
     .action(async (query: string, opts: SearchOpts) => {
+      if (opts.j) opts.format = "json";
       const dbPath = resolveDbPath(path.resolve(opts.db));
       const limit = parseInt(opts.limit, 10);
 

--- a/packages/engram-cli/src/commands/show.ts
+++ b/packages/engram-cli/src/commands/show.ts
@@ -14,6 +14,7 @@ import {
 interface ShowOpts {
   db: string;
   format: string;
+  j?: boolean;
 }
 
 export function registerShow(program: Command): void {
@@ -22,6 +23,7 @@ export function registerShow(program: Command): void {
     .description("Show entity details, edges, and evidence")
     .option("--db <path>", "path to .engram file", ".engram")
     .option("--format <fmt>", "output format: text or json", "text")
+    .option("-j", "shorthand for --format json")
     .addHelpText(
       "after",
       `
@@ -44,6 +46,7 @@ See also:
   engram history   trace how facts about an entity changed over time`,
     )
     .action((entityArg: string, opts: ShowOpts) => {
+      if (opts.j) opts.format = "json";
       if (opts.format !== "text" && opts.format !== "json") {
         console.error("--format must be 'text' or 'json'");
         process.exit(1);

--- a/packages/engram-cli/src/commands/stats.ts
+++ b/packages/engram-cli/src/commands/stats.ts
@@ -12,6 +12,7 @@ import { closeGraph, openGraph, resolveDbPath } from "engram-core";
 interface StatsOpts {
   db: string;
   format: string;
+  j?: boolean;
 }
 
 interface CountRow {
@@ -26,6 +27,7 @@ export function registerStats(program: Command): void {
     )
     .option("--db <path>", "path to .engram file", ".engram")
     .option("--format <fmt>", "output format: text or json", "text")
+    .option("-j", "shorthand for --format json")
     .addHelpText(
       "after",
       `
@@ -45,6 +47,7 @@ See also:
   engram search    find entities by keyword`,
     )
     .action((opts: StatsOpts) => {
+      if (opts.j) opts.format = "json";
       if (opts.format !== "text" && opts.format !== "json") {
         console.error("Error: --format must be 'text' or 'json'");
         process.exit(1);


### PR DESCRIPTION
## Summary

- `-j` as shorthand for `--format json` on `search`, `show`, `history`, `stats`, `decay`, `ownership`, and `context`
- `-v` as shorthand for `--verbose` on `context`, `ingest source`, and `ingest enrich`

## Test plan

- [ ] `engram search "foo" -j` outputs JSON
- [ ] `engram show <id> -j` outputs JSON
- [ ] `engram history <id> -j` outputs JSON
- [ ] `engram stats -j` outputs JSON
- [ ] `engram decay -j` outputs JSON
- [ ] `engram ownership -j` outputs JSON
- [ ] `engram context "foo" -j` outputs JSON
- [ ] `engram ingest source -v` emits per-file progress
- [ ] `engram context "foo" -v` emits verbose diagnostics to stderr
- [ ] All tests pass, build clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)