### PR TITLE
feat(cli): add color to terminal output for readability

### DIFF
--- a/packages/engram-cli/package.json
+++ b/packages/engram-cli/package.json
@@ -11,9 +11,10 @@
     "test": "bun test"
   },
   "dependencies": {
-    "engram-core": "workspace:*",
+    "@clack/prompts": "^0.9.0",
     "@engram/engram-web": "workspace:*",
     "commander": "^13.0.0",
-    "@clack/prompts": "^0.9.0"
+    "engram-core": "workspace:*",
+    "picocolors": "^1.1.1"
   }
 }

--- a/packages/engram-cli/src/colors.ts
+++ b/packages/engram-cli/src/colors.ts
@@ -1,0 +1,13 @@
+import pc from "picocolors";
+
+// Respect NO_COLOR env var and non-TTY output (pipes, CI)
+const enabled = process.stdout.isTTY && !process.env.NO_COLOR;
+
+export const c = {
+  bold: (s: string) => (enabled ? pc.bold(s) : s),
+  dim: (s: string) => (enabled ? pc.dim(s) : s),
+  red: (s: string) => (enabled ? pc.red(s) : s),
+  yellow: (s: string) => (enabled ? pc.yellow(s) : s),
+  green: (s: string) => (enabled ? pc.green(s) : s),
+  cyan: (s: string) => (enabled ? pc.cyan(s) : s),
+};

--- a/packages/engram-cli/src/colors.ts
+++ b/packages/engram-cli/src/colors.ts
@@ -1,13 +1,18 @@
 import pc from "picocolors";
 
-// Respect NO_COLOR env var and non-TTY output (pipes, CI)
-const enabled = process.stdout.isTTY && !process.env.NO_COLOR;
+// Respect NO_COLOR env var (spec: any value, including empty string, disables color)
+// and non-TTY output (pipes, CI). Use separate flags for stdout vs stderr so that
+// piping stdout does not strip color from stderr error messages and vice versa.
+const noColor = process.env.NO_COLOR !== undefined;
+const stdoutColor = !noColor && !!process.stdout.isTTY;
+const stderrColor = !noColor && !!process.stderr.isTTY;
 
 export const c = {
-  bold: (s: string) => (enabled ? pc.bold(s) : s),
-  dim: (s: string) => (enabled ? pc.dim(s) : s),
-  red: (s: string) => (enabled ? pc.red(s) : s),
-  yellow: (s: string) => (enabled ? pc.yellow(s) : s),
-  green: (s: string) => (enabled ? pc.green(s) : s),
-  cyan: (s: string) => (enabled ? pc.cyan(s) : s),
+  bold: (s: string) => (stdoutColor ? pc.bold(s) : s),
+  dim: (s: string) => (stdoutColor ? pc.dim(s) : s),
+  // red is used on stderr (console.error) — gate on stderrColor
+  red: (s: string) => (stderrColor ? pc.red(s) : s),
+  yellow: (s: string) => (stdoutColor ? pc.yellow(s) : s),
+  green: (s: string) => (stdoutColor ? pc.green(s) : s),
+  cyan: (s: string) => (stdoutColor ? pc.cyan(s) : s),
 };

--- a/packages/engram-cli/src/commands/decay.ts
+++ b/packages/engram-cli/src/commands/decay.ts
@@ -7,6 +7,7 @@ import {
   openGraph,
   resolveDbPath,
 } from "engram-core";
+import { c } from "../colors.js";
 
 interface DecayOpts {
   staleDays: string;
@@ -16,18 +17,24 @@ interface DecayOpts {
   j?: boolean;
 }
 
+function colorCount(n: number): string {
+  return n > 0 ? c.yellow(n.toString()) : c.dim("0");
+}
+
 function renderTable(report: DecayReport): void {
-  console.log(`Decay Report — ${report.generated_at}`);
+  console.log(
+    `${c.bold("Decay Report")}${c.dim(` — ${report.generated_at}`)}`,
+  );
   console.log(
     `Entities: ${report.total_entities}  Edges: ${report.total_edges}`,
   );
   console.log("");
   console.log("Summary:");
-  console.log(`  stale_evidence:     ${report.summary.stale_evidence}`);
-  console.log(`  contradicted:       ${report.summary.contradicted}`);
-  console.log(`  concentrated_risk:  ${report.summary.concentrated_risk}`);
-  console.log(`  dormant_owner:      ${report.summary.dormant_owner}`);
-  console.log(`  orphaned:           ${report.summary.orphaned}`);
+  console.log(`  stale_evidence:     ${colorCount(report.summary.stale_evidence)}`);
+  console.log(`  contradicted:       ${colorCount(report.summary.contradicted)}`);
+  console.log(`  concentrated_risk:  ${colorCount(report.summary.concentrated_risk)}`);
+  console.log(`  dormant_owner:      ${colorCount(report.summary.dormant_owner)}`);
+  console.log(`  orphaned:           ${colorCount(report.summary.orphaned)}`);
 
   if (report.decay_items.length === 0) {
     console.log("\nNo decay items found.");
@@ -86,15 +93,15 @@ See also:
       const format = opts.format;
 
       if (Number.isNaN(staleDays) || staleDays < 1) {
-        console.error("Error: --stale-days must be a positive integer");
+        console.error(`${c.red("Error:")} --stale-days must be a positive integer`);
         process.exit(1);
       }
       if (Number.isNaN(dormantDays) || dormantDays < 1) {
-        console.error("Error: --dormant-days must be a positive integer");
+        console.error(`${c.red("Error:")} --dormant-days must be a positive integer`);
         process.exit(1);
       }
       if (format !== "table" && format !== "json") {
-        console.error("Error: --format must be 'table' or 'json'");
+        console.error(`${c.red("Error:")} --format must be 'table' or 'json'`);
         process.exit(1);
       }
 
@@ -103,7 +110,7 @@ See also:
         graph = openGraph(dbPath);
       } catch (err) {
         console.error(
-          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} opening graph: ${err instanceof Error ? err.message : String(err)}`,
         );
         process.exit(1);
       }
@@ -117,7 +124,7 @@ See also:
         closeGraph(graph);
       } catch (err) {
         console.error(
-          `Decay report failed: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} decay report failed: ${err instanceof Error ? err.message : String(err)}`,
         );
         closeGraph(graph);
         process.exit(1);

--- a/packages/engram-cli/src/commands/decay.ts
+++ b/packages/engram-cli/src/commands/decay.ts
@@ -22,18 +22,24 @@ function colorCount(n: number): string {
 }
 
 function renderTable(report: DecayReport): void {
-  console.log(
-    `${c.bold("Decay Report")}${c.dim(` — ${report.generated_at}`)}`,
-  );
+  console.log(`${c.bold("Decay Report")}${c.dim(` — ${report.generated_at}`)}`);
   console.log(
     `Entities: ${report.total_entities}  Edges: ${report.total_edges}`,
   );
   console.log("");
   console.log("Summary:");
-  console.log(`  stale_evidence:     ${colorCount(report.summary.stale_evidence)}`);
-  console.log(`  contradicted:       ${colorCount(report.summary.contradicted)}`);
-  console.log(`  concentrated_risk:  ${colorCount(report.summary.concentrated_risk)}`);
-  console.log(`  dormant_owner:      ${colorCount(report.summary.dormant_owner)}`);
+  console.log(
+    `  stale_evidence:     ${colorCount(report.summary.stale_evidence)}`,
+  );
+  console.log(
+    `  contradicted:       ${colorCount(report.summary.contradicted)}`,
+  );
+  console.log(
+    `  concentrated_risk:  ${colorCount(report.summary.concentrated_risk)}`,
+  );
+  console.log(
+    `  dormant_owner:      ${colorCount(report.summary.dormant_owner)}`,
+  );
   console.log(`  orphaned:           ${colorCount(report.summary.orphaned)}`);
 
   if (report.decay_items.length === 0) {
@@ -93,11 +99,15 @@ See also:
       const format = opts.format;
 
       if (Number.isNaN(staleDays) || staleDays < 1) {
-        console.error(`${c.red("Error:")} --stale-days must be a positive integer`);
+        console.error(
+          `${c.red("Error:")} --stale-days must be a positive integer`,
+        );
         process.exit(1);
       }
       if (Number.isNaN(dormantDays) || dormantDays < 1) {
-        console.error(`${c.red("Error:")} --dormant-days must be a positive integer`);
+        console.error(
+          `${c.red("Error:")} --dormant-days must be a positive integer`,
+        );
         process.exit(1);
       }
       if (format !== "table" && format !== "json") {

--- a/packages/engram-cli/src/commands/doctor.ts
+++ b/packages/engram-cli/src/commands/doctor.ts
@@ -26,6 +26,7 @@ import * as nodePath from "node:path";
 import { confirm, log } from "@clack/prompts";
 import type { Command } from "commander";
 import { resolveDbPath } from "engram-core";
+import { c } from "../colors.js";
 import type { CheckResult, CheckStatus } from "./doctor-checks.js";
 import {
   checkEmbeddingIndex,
@@ -64,11 +65,11 @@ interface DoctorOpts {
 function statusIcon(status: CheckStatus): string {
   switch (status) {
     case "pass":
-      return "✓";
+      return c.green("✓");
     case "fail":
-      return "✗";
+      return c.red("✗");
     case "warn":
-      return "⚠";
+      return c.yellow("⚠");
     case "skip":
       return "-";
   }
@@ -91,13 +92,13 @@ function renderHuman(report: DoctorReport): void {
   const hasIssues = failed.length > 0 || warned.length > 0;
 
   if (hasIssues) {
-    console.log("\nIssues found:");
+    console.log(`\n${c.red("Issues found:")}`);
     for (const check of [...failed, ...warned]) {
       if (check.fix) {
-        console.log(`  ${check.name}  ${check.message}`);
+        console.log(`  ${c.bold(check.name)}  ${check.message}`);
         console.log(`    fix: ${check.fix}`);
       } else {
-        console.log(`  ${check.name}  ${check.message}`);
+        console.log(`  ${c.bold(check.name)}  ${check.message}`);
       }
     }
   }
@@ -105,8 +106,12 @@ function renderHuman(report: DoctorReport): void {
   if (report.fixes_applied.length > 0) {
     console.log("\nFixes applied:");
     for (const f of report.fixes_applied) {
-      console.log(`  ✓  ${f}`);
+      console.log(`  ${c.green("✓")}  ${f}`);
     }
+  }
+
+  if (failed.length === 0 && warned.length === 0) {
+    console.log(`\n${c.green("All checks passed.")}`);
   }
 
   if (failed.length > 0) {

--- a/packages/engram-cli/src/commands/history.ts
+++ b/packages/engram-cli/src/commands/history.ts
@@ -130,7 +130,6 @@ See also:
             console.log(`${edges.length} fact(s)\n`);
 
             for (const edge of edges) {
-              const status = edge.invalidated_at ? "superseded" : "active";
               const from = edge.valid_from ?? "unknown";
               const until = edge.valid_until ?? "present";
               const statusLabel = edge.invalidated_at

--- a/packages/engram-cli/src/commands/history.ts
+++ b/packages/engram-cli/src/commands/history.ts
@@ -92,7 +92,9 @@ See also:
           if (entity2Arg) {
             const entity2 = resolveEntityByNameOrId(graph, entity2Arg);
             if (!entity2) {
-              console.error(`${c.red("Error:")} entity not found: ${entity2Arg}`);
+              console.error(
+                `${c.red("Error:")} entity not found: ${entity2Arg}`,
+              );
               closeGraph(graph);
               process.exit(1);
             }

--- a/packages/engram-cli/src/commands/history.ts
+++ b/packages/engram-cli/src/commands/history.ts
@@ -10,6 +10,7 @@ import {
   resolveDbPath,
   resolveEntity,
 } from "engram-core";
+import { c } from "../colors.js";
 
 interface HistoryOpts {
   db: string;
@@ -62,7 +63,7 @@ See also:
       ) => {
         if (opts.j) opts.format = "json";
         if (opts.format !== "text" && opts.format !== "json") {
-          console.error("Error: --format must be 'text' or 'json'");
+          console.error(`${c.red("Error:")} --format must be 'text' or 'json'`);
           process.exit(1);
         }
 
@@ -73,7 +74,7 @@ See also:
           graph = openGraph(dbPath);
         } catch (err) {
           console.error(
-            `Error opening graph: ${
+            `${c.red("Error:")} opening graph: ${
               err instanceof Error ? err.message : String(err)
             }`,
           );
@@ -83,7 +84,7 @@ See also:
         try {
           const entity1 = resolveEntityByNameOrId(graph, entity1Arg);
           if (!entity1) {
-            console.error(`Entity not found: ${entity1Arg}`);
+            console.error(`${c.red("Error:")} entity not found: ${entity1Arg}`);
             closeGraph(graph);
             process.exit(1);
           }
@@ -91,7 +92,7 @@ See also:
           if (entity2Arg) {
             const entity2 = resolveEntityByNameOrId(graph, entity2Arg);
             if (!entity2) {
-              console.error(`Entity not found: ${entity2Arg}`);
+              console.error(`${c.red("Error:")} entity not found: ${entity2Arg}`);
               closeGraph(graph);
               process.exit(1);
             }
@@ -132,7 +133,10 @@ See also:
               const status = edge.invalidated_at ? "superseded" : "active";
               const from = edge.valid_from ?? "unknown";
               const until = edge.valid_until ?? "present";
-              console.log(`[${status}] ${edge.fact}`);
+              const statusLabel = edge.invalidated_at
+                ? c.dim("[superseded]")
+                : c.green("[active]");
+              console.log(`${statusLabel} ${c.bold(edge.fact)}`);
               console.log(`  kind:  ${edge.edge_kind}`);
               console.log(`  valid: ${from} — ${until}`);
               console.log(`  id:    ${edge.id}`);
@@ -182,10 +186,12 @@ See also:
             console.log(`${allEdges.length} fact(s)\n`);
 
             for (const edge of allEdges) {
-              const status = edge.invalidated_at ? "superseded" : "active";
               const from = edge.valid_from ?? "unknown";
               const until = edge.valid_until ?? "present";
-              console.log(`[${status}] ${edge.fact}`);
+              const statusLabel = edge.invalidated_at
+                ? c.dim("[superseded]")
+                : c.green("[active]");
+              console.log(`${statusLabel} ${c.bold(edge.fact)}`);
               console.log(
                 `  kind:  ${edge.edge_kind}  relation: ${edge.relation_type}`,
               );
@@ -194,7 +200,7 @@ See also:
           }
         } catch (err) {
           console.error(
-            `Error: ${err instanceof Error ? err.message : String(err)}`,
+            `${c.red("Error:")} ${err instanceof Error ? err.message : String(err)}`,
           );
           closeGraph(graph);
           process.exit(1);

--- a/packages/engram-cli/src/commands/ownership.ts
+++ b/packages/engram-cli/src/commands/ownership.ts
@@ -17,6 +17,7 @@ import {
   openGraph,
   resolveDbPath,
 } from "engram-core";
+import { c } from "../colors.js";
 
 interface OwnershipOpts {
   limit: string;
@@ -50,7 +51,7 @@ function renderTable(report: OwnershipReport): void {
   };
 
   if (byLevel.critical.length > 0) {
-    console.log(`CRITICAL (${byLevel.critical.length})`);
+    console.log(`${c.red(c.bold("CRITICAL"))} (${byLevel.critical.length})`);
     for (const entry of byLevel.critical) {
       renderEntry(entry);
     }
@@ -58,7 +59,7 @@ function renderTable(report: OwnershipReport): void {
   }
 
   if (byLevel.elevated.length > 0) {
-    console.log(`ELEVATED (${byLevel.elevated.length})`);
+    console.log(`${c.yellow(c.bold("ELEVATED"))} (${byLevel.elevated.length})`);
     for (const entry of byLevel.elevated) {
       renderEntry(entry);
     }
@@ -66,7 +67,7 @@ function renderTable(report: OwnershipReport): void {
   }
 
   if (byLevel.stable.length > 0) {
-    console.log(`STABLE (${byLevel.stable.length})`);
+    console.log(`${c.green("STABLE")} (${byLevel.stable.length})`);
     for (const entry of byLevel.stable) {
       renderEntry(entry);
     }
@@ -149,7 +150,7 @@ See also:
       const format = opts.format;
 
       if (Number.isNaN(limit) || limit < 1) {
-        console.error("Error: --limit must be a positive integer");
+        console.error(`${c.red("Error:")} --limit must be a positive integer`);
         process.exit(1);
       }
 
@@ -159,13 +160,13 @@ See also:
         minConfidence > 1
       ) {
         console.error(
-          "Error: --min-confidence must be a number between 0 and 1",
+          `${c.red("Error:")} --min-confidence must be a number between 0 and 1`,
         );
         process.exit(1);
       }
 
       if (format !== "table" && format !== "json") {
-        console.error("Error: --format must be 'table' or 'json'");
+        console.error(`${c.red("Error:")} --format must be 'table' or 'json'`);
         process.exit(1);
       }
 
@@ -174,7 +175,7 @@ See also:
         graph = openGraph(dbPath);
       } catch (err) {
         console.error(
-          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} opening graph: ${err instanceof Error ? err.message : String(err)}`,
         );
         process.exit(1);
       }
@@ -189,7 +190,7 @@ See also:
         closeGraph(graph);
       } catch (err) {
         console.error(
-          `Ownership report failed: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} ownership report failed: ${err instanceof Error ? err.message : String(err)}`,
         );
         closeGraph(graph);
         process.exit(1);

--- a/packages/engram-cli/src/commands/search.ts
+++ b/packages/engram-cli/src/commands/search.ts
@@ -16,6 +16,7 @@ import {
   resolveDbPath,
   search,
 } from "engram-core";
+import { c } from "../colors.js";
 
 interface SearchOpts {
   limit: string;
@@ -61,12 +62,12 @@ See also:
       const limit = parseInt(opts.limit, 10);
 
       if (Number.isNaN(limit) || limit < 1) {
-        console.error("Error: --limit must be a positive integer");
+        console.error(`${c.red("Error:")} --limit must be a positive integer`);
         process.exit(1);
       }
 
       if (opts.format !== "text" && opts.format !== "json") {
-        console.error("Error: --format must be 'text' or 'json'");
+        console.error(`${c.red("Error:")} --format must be 'text' or 'json'`);
         process.exit(1);
       }
 
@@ -75,7 +76,7 @@ See also:
         graph = openGraph(dbPath);
       } catch (err) {
         console.error(
-          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} opening graph: ${err instanceof Error ? err.message : String(err)}`,
         );
         process.exit(1);
       }
@@ -108,7 +109,7 @@ See also:
           );
         } else {
           console.error(
-            `Search failed: ${err instanceof Error ? err.message : String(err)}`,
+            `${c.red("Error:")} search failed: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
         closeGraph(graph);
@@ -122,15 +123,17 @@ See also:
       }
 
       if (results.length === 0) {
-        console.log("No results found.");
+        console.log(c.dim("No results found."));
         return;
       }
 
       for (const r of results) {
         const score = r.score.toFixed(3);
         const kind = r.edge_kind ? ` [${r.edge_kind}]` : "";
-        console.log(`[${r.type}${kind}] (${score}) ${r.content}`);
-        console.log(`  id: ${r.id}`);
+        console.log(
+          `${c.cyan(`[${r.type}${kind}]`)} ${c.dim(`(${score})`)} ${r.content}`,
+        );
+        console.log(`${c.dim("  id: ")}${r.id}`);
         if (r.provenance.length > 0) {
           console.log(`  evidence: ${r.provenance.length} episode(s)`);
         }

--- a/packages/engram-cli/src/commands/show.ts
+++ b/packages/engram-cli/src/commands/show.ts
@@ -10,6 +10,7 @@ import {
   resolveDbPath,
   resolveEntity,
 } from "engram-core";
+import { c } from "../colors.js";
 
 interface ShowOpts {
   db: string;
@@ -48,7 +49,7 @@ See also:
     .action((entityArg: string, opts: ShowOpts) => {
       if (opts.j) opts.format = "json";
       if (opts.format !== "text" && opts.format !== "json") {
-        console.error("--format must be 'text' or 'json'");
+        console.error(`${c.red("Error:")} --format must be 'text' or 'json'`);
         process.exit(1);
       }
 
@@ -59,7 +60,7 @@ See also:
         graph = openGraph(dbPath);
       } catch (err) {
         console.error(
-          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} opening graph: ${err instanceof Error ? err.message : String(err)}`,
         );
         process.exit(1);
       }
@@ -71,7 +72,7 @@ See also:
         }
 
         if (!entity) {
-          console.error(`Entity not found: ${entityArg}`);
+          console.error(`${c.red("Error:")} entity not found: ${entityArg}`);
           closeGraph(graph);
           process.exit(1);
         }
@@ -111,10 +112,14 @@ See also:
           return;
         }
 
-        console.log(`${entity.canonical_name}`);
-        console.log(`  id:     ${entity.id}`);
-        console.log(`  type:   ${entity.entity_type}`);
-        console.log(`  status: ${entity.status}`);
+        console.log(c.bold(entity.canonical_name));
+        console.log(`${c.dim("  id:     ")}${entity.id}`);
+        console.log(`${c.dim("  type:   ")}${entity.entity_type}`);
+        const statusValue =
+          entity.status === "active"
+            ? c.green(entity.status)
+            : c.dim(entity.status);
+        console.log(`${c.dim("  status: ")}${statusValue}`);
         if (entity.summary) {
           console.log(`  summary: ${entity.summary}`);
         }
@@ -146,7 +151,7 @@ See also:
         }
       } catch (err) {
         console.error(
-          `Error: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} ${err instanceof Error ? err.message : String(err)}`,
         );
         closeGraph(graph);
         process.exit(1);

--- a/packages/engram-cli/src/commands/verify.ts
+++ b/packages/engram-cli/src/commands/verify.ts
@@ -9,6 +9,7 @@ import * as path from "node:path";
 import type { Command } from "commander";
 import type { EngramGraph } from "engram-core";
 import { closeGraph, openGraph, resolveDbPath } from "engram-core";
+import { c } from "../colors.js";
 
 interface VerifyOpts {
   db: string;
@@ -49,7 +50,7 @@ See also:
         graph = openGraph(dbPath);
       } catch (err) {
         console.error(
-          `Error opening graph: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} opening graph: ${err instanceof Error ? err.message : String(err)}`,
         );
         process.exit(1);
       }
@@ -128,7 +129,7 @@ See also:
         }
       } catch (err) {
         console.error(
-          `Verify failed: ${err instanceof Error ? err.message : String(err)}`,
+          `${c.red("Error:")} verify failed: ${err instanceof Error ? err.message : String(err)}`,
         );
         closeGraph(graph);
         process.exit(1);
@@ -137,13 +138,13 @@ See also:
       closeGraph(graph);
 
       if (violations.length === 0) {
-        console.log("Graph integrity OK — no violations found.");
+        console.log(c.green("Graph integrity OK — no violations found."));
         return;
       }
 
-      console.error(`Found ${violations.length} integrity violation(s):`);
+      console.error(c.red(`Found ${violations.length} integrity violation(s):`));
       for (const v of violations) {
-        console.error(`  - ${v}`);
+        console.error(c.red(`  - ${v}`));
       }
       process.exit(2);
     });

--- a/packages/engram-cli/src/commands/verify.ts
+++ b/packages/engram-cli/src/commands/verify.ts
@@ -142,7 +142,9 @@ See also:
         return;
       }
 
-      console.error(c.red(`Found ${violations.length} integrity violation(s):`));
+      console.error(
+        c.red(`Found ${violations.length} integrity violation(s):`),
+      );
       for (const v of violations) {
         console.error(c.red(`  - ${v}`));
       }


### PR DESCRIPTION
## Summary

- Adds `picocolors` (zero-dep, TTY-aware) for color output
- New `src/colors.ts` helper respects `NO_COLOR` env var and non-TTY (pipes, CI)
- Color applied where it adds meaning, not decoration:
  - **doctor**: ✓ green / ✗ red / ⚠ yellow; "Issues found:" red; "All checks passed." green; check names bold
  - **verify**: OK green, violations red
  - **ownership**: CRITICAL red+bold, ELEVATED yellow+bold, STABLE green
  - **history**: active green, superseded dim; edge fact bold
  - **show**: entity name bold, active status green, inactive/redacted dim; field labels dim
  - **search**: type labels cyan, scores dim; "No results found." dim; id label dim
  - **decay**: header bold/dim; non-zero summary counts yellow, zero counts dim
  - **all commands**: `console.error` prefixes use `c.red("Error:")` instead of hardcoded "Error:"
- JSON output paths unaffected — color never emitted in `--format json` mode

## Test plan

- [ ] Run `engram doctor` against a healthy `.engram` dir — ✓ icons green, "All checks passed." green
- [ ] Run `engram doctor` with a warn — ⚠ yellow, "Issues found:" red, check name bold
- [ ] Run `engram verify` on a clean graph — output is green
- [ ] Run `engram search "foo"` in a TTY — type label cyan, score dim
- [ ] Run `engram search "foo" | cat` — no ANSI escape codes in piped output
- [ ] Run `NO_COLOR=1 engram doctor` — no color codes emitted
- [ ] Run `engram decay` — non-zero summary counts yellow, zero counts dim

🤖 Generated with [Claude Code](https://claude.com/claude-code)