### PR TITLE
feat(ingest): cross-source reference edge resolver

### DIFF
--- a/docs/internal/specs/cross-source-references.md
+++ b/docs/internal/specs/cross-source-references.md
@@ -1,0 +1,211 @@
+# Cross-Source Reference Edge Resolution
+
+**Status**: Implemented (v0.1)
+**Location**: `packages/engram-core/src/ingest/cross-ref/`
+
+---
+
+## Overview
+
+Cross-source reference resolution scans episode content for textual references to other
+source objects (commits, PRs, issues, Jira tickets, etc.) and emits `references` edges
+in the knowledge graph. This connects knowledge silos that would otherwise remain
+isolated (e.g., a commit message that cites a GitHub PR, or an issue body that cites a
+commit SHA).
+
+---
+
+## Pattern Registry Shape
+
+Each entry in the pattern registry is a `ReferencePattern`:
+
+```typescript
+interface ReferencePattern {
+  sourceType: string;        // Target episodes.source_type
+  pattern: RegExp;           // Regex, capture group 1 = identifier
+  normalizeRef: (match: string) => string;  // Normalise captured group
+  confidence: number;        // Edge confidence, 0..1
+  _lookupOverride?: (graph: EngramGraph, normalizedRef: string) => { id: string } | null;
+}
+```
+
+Built-in patterns are in `BUILT_IN_PATTERNS` (ordered most-specific first):
+
+| Pattern | source_type | Confidence |
+|---------|-------------|------------|
+| Full GitHub PR URL | `github_pr` | 0.95 |
+| Full GitHub Issue URL | `github_issue` | 0.95 |
+| Full Gerrit CL URL | `gerrit_change` | 0.95 |
+| Full Google Doc URL | `google_doc` | 0.95 |
+| Full Linear Issue URL | `linear_issue` | 0.95 |
+| Full Jira Issue URL | `jira_issue` | 0.95 |
+| `b/NNNNNN` (Buganizer) | `buganizer_issue` | 0.90 |
+| `go/cl/NNN` (Gerrit shorthand) | `gerrit_change` | 0.90 |
+| Full 40-char commit SHA | `git_commit` | 0.90 |
+| Short SHA (7–11 chars) | `git_commit` | 0.75 |
+| `#N` (repo-scoped issue/PR) | `github_issue` | 0.85 |
+
+---
+
+## Resolution Algorithm
+
+```
+for each episodeId in episodeIds:
+  1. Load episode content. Skip if status = 'redacted'.
+  2. Find the primary entity for this episode (highest-confidence entity_evidence link).
+  3. For each pattern in the registry:
+     a. Reset pattern.lastIndex (global flag safety).
+     b. Exec pattern against episode.content.
+     c. For each match:
+        - Normalize captured group → normalizedRef
+        - Deduplicate: skip if (sourceType, normalizedRef) already seen in this episode
+        - Lookup target entity:
+            - If _lookupOverride: call it with (graph, normalizedRef)
+            - Else: findTargetEntityBySourceRef(graph, sourceType, normalizedRef)
+            - If not found: also try with fullMatch (for URL patterns)
+        - If target not found: record in unresolved_refs; continue
+        - Self-reference guard: skip if sourceEntity.id == targetEntity.id
+        - emitReferenceEdge(source, target, episode, confidence, fact, timestamp)
+  4. Call drainUnresolvedForEpisode to resolve any pending refs that match this episode's source_ref.
+```
+
+The lookup chain:
+
+```
+episode.source_ref == normalizedRef  →  find via entity_evidence JOIN episodes
+  └─ fallback: episode.source_ref == fullMatch (capture may be partial)
+```
+
+---
+
+## Ambiguity Handling
+
+When the same normalized ref could match multiple target entities (e.g., a short SHA
+that matches two commit entities), the current implementation resolves to the **first
+match** via `LIMIT 1` SQL queries. This is intentional conservatism for v0.1.
+
+Future work: when multiple entities match a single ref, emit N edges each at
+`confidence * 0.6` to signal reduced certainty. This is tracked in the backlog.
+
+---
+
+## Self-Reference Guard
+
+Before emitting an edge, the resolver checks:
+
+```
+if sourceEntity && targetEntity.id === sourceEntity.id: skip
+```
+
+This prevents a commit from referencing itself when its own SHA appears in its content
+(e.g., `commit abcdef1234...` in the git log header).
+
+---
+
+## Deduplication Semantics
+
+**Within a single episode**: the `seenRefs` set (keyed by `sourceType:normalizedRef`)
+prevents the same reference from being processed twice even if it appears multiple times
+in the episode content.
+
+**Across episodes (same source/target pair)**: `emitReferenceEdge` checks for an
+existing active edge with the same `(source_id, target_id, relation_type, edge_kind)`.
+If found, it adds an `edge_evidence` link (`INSERT OR IGNORE`) rather than creating a
+duplicate edge. This means the same logical reference can accumulate multiple evidence
+links from different episodes.
+
+---
+
+## Plugin Contribution Format
+
+Plugins can contribute additional patterns via `PluginReferencePattern` (manifest-safe;
+no closures):
+
+```typescript
+interface PluginReferencePattern {
+  source_type: string;          // Target source_type
+  pattern: string;              // Regex source (no delimiters)
+  flags?: string;               // Regex flags (default: "g")
+  normalize_template: string;   // "$1" is replaced by capture group 1
+  confidence: number;           // 0..1
+}
+```
+
+Compile with:
+
+```typescript
+const myPattern = compilePluginPattern(manifest, BUILT_IN_PATTERNS);
+resolveReferences(graph, episodeIds, [...BUILT_IN_PATTERNS, myPattern]);
+```
+
+`compilePluginPattern` throws `Error` if the `(source_type, pattern.source)` pair
+collides with any existing registry entry. This prevents duplicate resolution paths.
+
+Plugin patterns **cannot** use `_lookupOverride` (closures are not serializable in
+manifest form). They use the default `findTargetEntityBySourceRef` lookup.
+
+---
+
+## `unresolved_refs` Lifecycle
+
+When a reference target is not yet in the graph at scan time, the ref is recorded in
+`unresolved_refs`:
+
+```sql
+CREATE TABLE unresolved_refs (
+  id                 TEXT PRIMARY KEY,
+  source_episode_id  TEXT NOT NULL REFERENCES episodes(id),
+  target_source_type TEXT NOT NULL,
+  target_ref         TEXT NOT NULL,
+  detected_at        TEXT NOT NULL,
+  resolved_at        TEXT        -- NULL until resolved
+);
+```
+
+**Drain on arrival**: when a new episode is ingested, `drainUnresolvedForEpisode` runs
+immediately to check if any pending refs match the new episode's `(source_type,
+source_ref)`. If so, the edge is emitted and `resolved_at` is set.
+
+**Batch drain**: `drainUnresolved(graph)` performs a two-phase scan:
+1. Attempt to resolve all `resolved_at IS NULL` rows.
+2. Full re-scan of all active episodes (catches patterns that were added after initial
+   ingest).
+
+Returns `{ edgesCreated, unresolved }` — `unresolved` is the count of rows still
+unresolved after the run. These represent dangling references to content not yet
+ingested.
+
+---
+
+## CLI: `engram reconcile --cross-refs`
+
+```sh
+engram reconcile --cross-refs [--db <path>]
+```
+
+Runs `drainUnresolved()` over the entire graph. Use this after ingesting a new data
+source to wire up references that were previously unresolvable.
+
+Output:
+```
+Edges created: 42
+Still unresolved: 7
+```
+
+This flag bypasses the normal assess/discover reconciliation phases.
+
+---
+
+## Edge Contract
+
+All emitted edges satisfy the engram evidence invariant:
+
+- `relation_type`: `"references"` (from `RELATION_TYPES.REFERENCES`)
+- `edge_kind`: `"observed"`
+- Evidence: at least one `edge_evidence` link pointing to the source episode
+- `extractor`: `"cross-ref-resolver"`
+
+The `fact` field describes the relationship:
+```
+Episode <id> (<source_type>) references <target_source_type> <normalizedRef>
+```

--- a/packages/engram-cli/src/commands/reconcile.ts
+++ b/packages/engram-cli/src/commands/reconcile.ts
@@ -17,6 +17,7 @@ import type { EngramGraph } from "engram-core";
 import {
   closeGraph,
   createGenerator,
+  drainUnresolved,
   openGraph,
   reconcile,
   resolveDbPath,
@@ -31,6 +32,7 @@ interface ReconcileOpts {
   maxDeltaItems?: string;
   dryRun: boolean;
   resetCursor: boolean;
+  crossRefs: boolean;
   db: string;
 }
 
@@ -67,6 +69,11 @@ export function registerReconcile(program: Command): void {
     .option(
       "--reset-cursor",
       "clear reconciliation history so the next run re-processes all substrate data",
+      false,
+    )
+    .option(
+      "--cross-refs",
+      "re-run cross-source reference resolution over all episodes",
       false,
     )
     .option("--db <path>", "path to .engram file", ".engram")
@@ -117,6 +124,30 @@ See also:
         log.info(
           `Cursor reset — deleted ${deleted} reconciliation run(s). Re-run without --reset-cursor to discover from scratch.`,
         );
+        outro("Done");
+        process.exit(0);
+      }
+
+      // ── Cross-refs resolution ────────────────────────────────────────────────
+      if (opts.crossRefs) {
+        const dbPath = resolveDbPath(path.resolve(opts.db));
+        let graph: EngramGraph | undefined;
+        try {
+          graph = openGraph(dbPath);
+        } catch (err) {
+          log.error(
+            `Cannot open graph: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          process.exit(1);
+        }
+        const s = spinner();
+        s.start("Resolving cross-source references");
+        const result = drainUnresolved(graph);
+        s.stop("Done");
+        log.info(
+          `Edges created: ${result.edgesCreated}\nStill unresolved: ${result.unresolved}`,
+        );
+        closeGraph(graph);
         outro("Done");
         process.exit(0);
       }

--- a/packages/engram-core/src/format/graph.ts
+++ b/packages/engram-core/src/format/graph.ts
@@ -12,7 +12,7 @@ import { Database } from "bun:sqlite";
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import { ulid } from "ulid";
-import { SCHEMA_DDL } from "./schema.js";
+import { ADDITIVE_DDL, SCHEMA_DDL } from "./schema.js";
 import {
   ENGINE_VERSION,
   FORMAT_VERSION,
@@ -202,6 +202,12 @@ export function openGraph(path: string): EngramGraph {
     throw new EngramFormatError(
       `openGraph: missing 'owner_id' in metadata — not a valid .engram file: ${path}`,
     );
+  }
+
+  // Apply additive DDL (idempotent IF NOT EXISTS) so existing databases gain
+  // new optional tables (e.g. unresolved_refs) without a schema version bump.
+  for (const ddl of ADDITIVE_DDL) {
+    db.exec(ddl);
   }
 
   return {

--- a/packages/engram-core/src/format/index.ts
+++ b/packages/engram-core/src/format/index.ts
@@ -11,6 +11,6 @@ export {
   resolveDbPath,
 } from "./graph.js";
 export { migrate_0_1_0_to_0_2_0 } from "./migrations.js";
-export { SCHEMA_DDL } from "./schema.js";
+export { ADDITIVE_DDL, SCHEMA_DDL } from "./schema.js";
 export type { VerifyResult, Violation, ViolationSeverity } from "./verify.js";
 export { verifyGraph } from "./verify.js";

--- a/packages/engram-core/src/format/schema.ts
+++ b/packages/engram-core/src/format/schema.ts
@@ -298,6 +298,33 @@ CREATE TRIGGER projections_au AFTER UPDATE ON projections BEGIN
 END;
 `;
 
+// ─── Additive DDL ────────────────────────────────────────────────────────────
+// These use IF NOT EXISTS so they are safe to run against both new and existing
+// databases. Applied by both createGraph (via SCHEMA_DDL) and openGraph.
+
+export const CREATE_UNRESOLVED_REFS = `
+CREATE TABLE IF NOT EXISTS unresolved_refs (
+  id                 TEXT PRIMARY KEY,
+  source_episode_id  TEXT NOT NULL REFERENCES episodes(id),
+  target_source_type TEXT NOT NULL,
+  target_ref         TEXT NOT NULL,
+  detected_at        TEXT NOT NULL,
+  resolved_at        TEXT
+);
+`;
+
+export const CREATE_UNRESOLVED_REFS_INDEX = `
+CREATE INDEX IF NOT EXISTS idx_unresolved_refs_target
+  ON unresolved_refs(target_source_type, target_ref)
+  WHERE resolved_at IS NULL;
+`;
+
+/** DDL that is safe to apply on every open (idempotent IF NOT EXISTS). */
+export const ADDITIVE_DDL: string[] = [
+  CREATE_UNRESOLVED_REFS,
+  CREATE_UNRESOLVED_REFS_INDEX,
+];
+
 /**
  * All DDL statements in the order they must be applied.
  * Tables with foreign key dependencies come after their referenced tables.
@@ -329,4 +356,6 @@ export const SCHEMA_DDL: string[] = [
   CREATE_RECONCILIATION_RUNS,
   CREATE_PROJECTIONS_FTS,
   CREATE_PROJECTIONS_FTS_TRIGGERS,
+  // Additive (IF NOT EXISTS — safe to re-run)
+  ...ADDITIVE_DDL,
 ];

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -144,6 +144,17 @@ export type {
 export { EnrichmentAdapterError } from "./ingest/adapter.js";
 export { GerritAdapter } from "./ingest/adapters/gerrit.js";
 export { GitHubAdapter, GitHubAuthError } from "./ingest/adapters/github.js";
+export type {
+  PluginReferencePattern,
+  ReferencePattern,
+  ResolveResult,
+} from "./ingest/cross-ref/index.js";
+export {
+  BUILT_IN_PATTERNS,
+  compilePluginPattern,
+  drainUnresolved,
+  resolveReferences,
+} from "./ingest/cross-ref/index.js";
 export type { GitIngestOpts, IngestResult } from "./ingest/git.js";
 export { ingestGitRepo } from "./ingest/git.js";
 export type { MarkdownIngestOpts } from "./ingest/markdown.js";
@@ -190,3 +201,5 @@ export {
   getSnapshot,
   supersedeEdge,
 } from "./temporal/index.js";
+export type { RelationType } from "./vocab/relation-types.js";
+export { RELATION_TYPES } from "./vocab/relation-types.js";

--- a/packages/engram-core/src/ingest/adapters/github.ts
+++ b/packages/engram-core/src/ingest/adapters/github.ts
@@ -418,6 +418,18 @@ function ingestIssue(
     episodeIds: string[];
   },
 ): void {
+  // Pre-check for existing episode (idempotent dedup — mirrors ingestPR)
+  const existingEpisode = graph.db
+    .query<{ id: string }, [string, string]>(
+      "SELECT id FROM episodes WHERE source_type = ? AND source_ref = ?",
+    )
+    .get("github_issue", issue.html_url);
+
+  if (existingEpisode) {
+    counts.episodesSkipped++;
+    return;
+  }
+
   const content = [
     `Issue #${issue.number}: ${issue.title}`,
     `URL: ${issue.html_url}`,

--- a/packages/engram-core/src/ingest/adapters/github.ts
+++ b/packages/engram-core/src/ingest/adapters/github.ts
@@ -16,6 +16,7 @@ import { addEntity, type EvidenceInput } from "../../graph/entities.js";
 import { addEpisode } from "../../graph/episodes.js";
 import type { EnrichmentAdapter, EnrichOpts } from "../adapter.js";
 import { EnrichmentAdapterError } from "../adapter.js";
+import { BUILT_IN_PATTERNS, resolveReferences } from "../cross-ref/index.js";
 import type { IngestResult } from "../git.js";
 
 // ---------------------------------------------------------------------------
@@ -307,6 +308,7 @@ function ingestPR(
     entitiesResolved: number;
     edgesCreated: number;
     edgesSuperseded: number;
+    episodeIds: string[];
   },
 ): void {
   const content = [
@@ -351,6 +353,7 @@ function ingestPR(
   counts.episodesCreated++;
 
   const episodeId = episode.id;
+  counts.episodeIds.push(episodeId);
   const evidence: EvidenceInput[] = [
     { episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 },
   ];
@@ -402,10 +405,6 @@ function ingestPR(
 // Issue ingestion
 // ---------------------------------------------------------------------------
 
-// Match #123 PR/issue references and short 7-40 char hex SHAs
-const SHA_RE = /\b([0-9a-f]{7,40})\b/gi;
-const PR_REF_RE = /#(\d+)/g;
-
 function ingestIssue(
   graph: EngramGraph,
   issue: GitHubIssue,
@@ -416,6 +415,7 @@ function ingestIssue(
     entitiesResolved: number;
     edgesCreated: number;
     edgesSuperseded: number;
+    episodeIds: string[];
   },
 ): void {
   const content = [
@@ -448,6 +448,7 @@ function ingestIssue(
   counts.episodesCreated++;
 
   const episodeId = episode.id;
+  counts.episodeIds.push(episodeId);
   const evidence: EvidenceInput[] = [
     { episode_id: episodeId, extractor: EXTRACTOR, confidence: 1.0 },
   ];
@@ -467,96 +468,6 @@ function ingestIssue(
     counts.entitiesCreated++;
   } else {
     counts.entitiesResolved++;
-  }
-
-  const body = issue.body ?? "";
-
-  // Create references edges for mentioned commit SHAs
-  const shaMatches = [...body.matchAll(SHA_RE)];
-  for (const match of shaMatches) {
-    const sha = match[1];
-    if (!sha) continue;
-
-    const mentioned = graph.db
-      .query<{ id: string }, [string, string]>(
-        "SELECT id FROM entities WHERE canonical_name = ? AND entity_type = ? LIMIT 1",
-      )
-      .get(sha, "commit");
-
-    if (!mentioned) continue;
-
-    // Self-reference guard
-    if (mentioned.id === issueEntity.id) continue;
-
-    const existing = graph.db
-      .query<{ id: string }, [string, string, string, string]>(
-        `SELECT id FROM edges
-         WHERE source_id = ? AND target_id = ? AND relation_type = ?
-           AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
-      )
-      .get(issueEntity.id, mentioned.id, "references", "observed");
-
-    if (!existing) {
-      addEdge(
-        graph,
-        {
-          source_id: issueEntity.id,
-          target_id: mentioned.id,
-          relation_type: "references",
-          edge_kind: "observed",
-          fact: `Issue #${issue.number} references commit ${sha}`,
-          valid_from: issue.created_at,
-          confidence: 0.9,
-        },
-        evidence,
-      );
-      counts.edgesCreated++;
-    }
-  }
-
-  // Create references edges for mentioned #N (PR/issue refs)
-  const prMatches = [...body.matchAll(PR_REF_RE)];
-  for (const match of prMatches) {
-    const refNum = match[1];
-    if (!refNum) continue;
-
-    // Look for an entity whose canonical_name ends with /pull/<N> or /issues/<N>
-    const mentioned = graph.db
-      .query<{ id: string }, [string, string]>(
-        `SELECT id FROM entities WHERE (canonical_name LIKE ? OR canonical_name LIKE ?)
-         AND entity_type IN ('issue', 'pull_request') LIMIT 1`,
-      )
-      .get(`%/pull/${refNum}`, `%/issues/${refNum}`);
-
-    if (!mentioned) continue;
-
-    // Self-reference guard
-    if (mentioned.id === issueEntity.id) continue;
-
-    const existing = graph.db
-      .query<{ id: string }, [string, string, string, string]>(
-        `SELECT id FROM edges
-         WHERE source_id = ? AND target_id = ? AND relation_type = ?
-           AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
-      )
-      .get(issueEntity.id, mentioned.id, "references", "observed");
-
-    if (!existing) {
-      addEdge(
-        graph,
-        {
-          source_id: issueEntity.id,
-          target_id: mentioned.id,
-          relation_type: "references",
-          edge_kind: "observed",
-          fact: `Issue #${issue.number} references #${refNum}`,
-          valid_from: issue.created_at,
-          confidence: 0.9,
-        },
-        evidence,
-      );
-      counts.edgesCreated++;
-    }
   }
 }
 
@@ -602,6 +513,7 @@ export class GitHubAdapter implements EnrichmentAdapter {
       entitiesResolved: 0,
       edgesCreated: 0,
       edgesSuperseded: 0,
+      episodeIds: [] as string[],
     };
 
     try {
@@ -661,6 +573,8 @@ export class GitHubAdapter implements EnrichmentAdapter {
         entities: counts.entitiesCreated,
         edges: counts.edgesCreated,
       });
+
+      resolveReferences(graph, counts.episodeIds, BUILT_IN_PATTERNS);
 
       return { ...counts, runId };
     } catch (err: unknown) {

--- a/packages/engram-core/src/ingest/cross-ref/index.ts
+++ b/packages/engram-core/src/ingest/cross-ref/index.ts
@@ -1,0 +1,5 @@
+export type { PluginReferencePattern, ReferencePattern } from "./patterns.js";
+export { BUILT_IN_PATTERNS, compilePluginPattern } from "./patterns.js";
+export type { ResolveResult } from "./resolver.js";
+export { drainUnresolved, resolveReferences } from "./resolver.js";
+export { ensureUnresolvedRefsTable } from "./schema.js";

--- a/packages/engram-core/src/ingest/cross-ref/patterns.ts
+++ b/packages/engram-core/src/ingest/cross-ref/patterns.ts
@@ -56,7 +56,7 @@ export function compilePluginPattern(
     sourceType: manifest.source_type,
     pattern: compiled,
     normalizeRef: (match: string) =>
-      manifest.normalize_template.replace("$1", match),
+      manifest.normalize_template.replaceAll("$1", match),
     confidence: manifest.confidence,
   };
 }

--- a/packages/engram-core/src/ingest/cross-ref/patterns.ts
+++ b/packages/engram-core/src/ingest/cross-ref/patterns.ts
@@ -1,0 +1,156 @@
+/**
+ * patterns.ts — Reference pattern registry for cross-source edge resolution.
+ */
+
+import type { EngramGraph } from "../../format/index.js";
+
+export interface ReferencePattern {
+  /** episodes.source_type of the target */
+  sourceType: string;
+  /** Regex with capture group 1 = the identifier */
+  pattern: RegExp;
+  /** Map the match to a searchable ref value */
+  normalizeRef: (match: string) => string;
+  /** Confidence on the emitted edge, 0..1 */
+  confidence: number;
+  /**
+   * Built-in override for non-standard entity lookup.
+   * Not available to plugins (plugins use default source_type+source_ref lookup).
+   */
+  _lookupOverride?: (
+    graph: EngramGraph,
+    normalizedRef: string,
+  ) => { id: string } | null;
+}
+
+/** Manifest-safe plugin pattern (no closures) */
+export interface PluginReferencePattern {
+  source_type: string;
+  pattern: string;
+  flags?: string;
+  normalize_template: string;
+  confidence: number;
+}
+
+/**
+ * Compile a plugin manifest pattern into a ReferencePattern.
+ * Throws if source_type or pattern.source collides with an existing registry entry.
+ */
+export function compilePluginPattern(
+  manifest: PluginReferencePattern,
+  existing: ReferencePattern[],
+): ReferencePattern {
+  const compiled = new RegExp(manifest.pattern, manifest.flags ?? "g");
+  const collision = existing.find(
+    (p) =>
+      p.sourceType === manifest.source_type &&
+      p.pattern.source === compiled.source,
+  );
+  if (collision) {
+    throw new Error(
+      `Plugin pattern collision on (source_type="${manifest.source_type}", pattern="${manifest.pattern}"): ` +
+        `a built-in pattern already declares this combination`,
+    );
+  }
+  return {
+    sourceType: manifest.source_type,
+    pattern: compiled,
+    normalizeRef: (match: string) =>
+      manifest.normalize_template.replace("$1", match),
+    confidence: manifest.confidence,
+  };
+}
+
+/** Built-in reference patterns (ordered from most- to least-specific) */
+export const BUILT_IN_PATTERNS: ReferencePattern[] = [
+  // ── Full GitHub PR URL ────────────────────────────────────────────────────
+  {
+    sourceType: "github_pr",
+    pattern: /https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)/gi,
+    normalizeRef: (match) => match,
+    confidence: 0.95,
+  },
+  // ── Full GitHub Issue URL ─────────────────────────────────────────────────
+  {
+    sourceType: "github_issue",
+    pattern: /https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/(\d+)/gi,
+    normalizeRef: (match) => match,
+    confidence: 0.95,
+  },
+  // ── Full Gerrit CL URL ────────────────────────────────────────────────────
+  {
+    sourceType: "gerrit_change",
+    pattern: /https?:\/\/[^/\s]*googlesource\.com\/c\/[^/\s]+\/\+\/(\d+)/gi,
+    normalizeRef: (match) => match,
+    confidence: 0.95,
+  },
+  // ── Full Google Doc URL ───────────────────────────────────────────────────
+  {
+    sourceType: "google_doc",
+    pattern: /https?:\/\/docs\.google\.com\/document\/d\/([A-Za-z0-9_-]+)/gi,
+    normalizeRef: (match) => match,
+    confidence: 0.95,
+  },
+  // ── Full Linear Issue URL ─────────────────────────────────────────────────
+  {
+    sourceType: "linear_issue",
+    pattern: /https?:\/\/linear\.app\/[^/\s]+\/issue\/([A-Z]+-\d+)/gi,
+    normalizeRef: (match) => match,
+    confidence: 0.95,
+  },
+  // ── Full Jira Issue URL ───────────────────────────────────────────────────
+  {
+    sourceType: "jira_issue",
+    pattern:
+      /https?:\/\/[^/\s]+\.atlassian\.net\/browse\/([A-Z][A-Z0-9]+-\d+)/gi,
+    normalizeRef: (match) => match,
+    confidence: 0.95,
+  },
+  // ── b/NNNN (Buganizer shorthand) ──────────────────────────────────────────
+  {
+    sourceType: "buganizer_issue",
+    pattern: /\bb\/(\d{6,})\b/g,
+    normalizeRef: (match) => `b/${match}`,
+    confidence: 0.9,
+  },
+  // ── go/cl/NNNN (Gerrit shorthand) ─────────────────────────────────────────
+  {
+    sourceType: "gerrit_change",
+    pattern: /\bgo\/cl\/(\d+)\b/g,
+    normalizeRef: (match) => `go/cl/${match}`,
+    confidence: 0.9,
+  },
+  // ── Full 40-char SHA ─────────────────────────────────────────────────────
+  {
+    sourceType: "git_commit",
+    pattern: /\b([0-9a-f]{40})\b/gi,
+    normalizeRef: (match) => match.toLowerCase(),
+    confidence: 0.9,
+  },
+  // ── Short SHA (7–11 chars) ────────────────────────────────────────────────
+  {
+    sourceType: "git_commit",
+    pattern: /\b([0-9a-f]{7,11})\b/gi,
+    normalizeRef: (match) => match.toLowerCase(),
+    confidence: 0.75,
+  },
+  // ── Repo-scoped #N reference (GitHub issue or PR) ─────────────────────────
+  {
+    sourceType: "github_issue",
+    pattern: /#(\d+)\b/g,
+    normalizeRef: (match) => `#${match}`,
+    confidence: 0.85,
+    _lookupOverride(graph, normalizedRef) {
+      const num = normalizedRef.slice(1);
+      const row = graph.db
+        .query<{ id: string }, [string, string]>(
+          `SELECT e.id FROM entities e
+           WHERE (e.canonical_name LIKE ? OR e.canonical_name LIKE ?)
+             AND e.entity_type IN ('issue', 'pull_request')
+           LIMIT 1`,
+        )
+        .get(`%/issues/${num}`, `%/pull/${num}`);
+      return row ?? null;
+    },
+  },
+];

--- a/packages/engram-core/src/ingest/cross-ref/resolver.ts
+++ b/packages/engram-core/src/ingest/cross-ref/resolver.ts
@@ -241,13 +241,17 @@ export function resolveReferences(
           continue;
         }
 
+        // Skip if we have no source entity — emitting a self-loop (source === target)
+        // is worse than dropping the edge.
+        if (!sourceEntity) continue;
+
         // Self-reference guard
-        if (sourceEntity && targetEntity.id === sourceEntity.id) continue;
+        if (targetEntity.id === sourceEntity.id) continue;
 
         const fact = `Episode ${episodeId} (${episode.source_type}) references ${pat.sourceType} ${normalizedRef}`;
         const created = emitReferenceEdge(
           graph,
-          sourceEntity?.id ?? targetEntity.id, // fall back to target if no source entity
+          sourceEntity.id,
           targetEntity.id,
           episodeId,
           pat.confidence,

--- a/packages/engram-core/src/ingest/cross-ref/resolver.ts
+++ b/packages/engram-core/src/ingest/cross-ref/resolver.ts
@@ -1,0 +1,416 @@
+/**
+ * resolver.ts — Cross-source reference edge resolution.
+ */
+
+import { ulid } from "ulid";
+import type { EngramGraph } from "../../format/index.js";
+import { addEdge } from "../../graph/edges.js";
+import { RELATION_TYPES } from "../../vocab/relation-types.js";
+import { BUILT_IN_PATTERNS, type ReferencePattern } from "./patterns.js";
+import { ensureUnresolvedRefsTable } from "./schema.js";
+
+export interface ResolveResult {
+  edgesCreated: number;
+  unresolved: number;
+}
+
+/**
+ * Find the primary entity for an episode (highest-confidence evidence link).
+ * Returns null if no entity evidence exists.
+ */
+function getPrimaryEntity(
+  graph: EngramGraph,
+  episodeId: string,
+): { id: string } | null {
+  const row = graph.db
+    .query<{ entity_id: string }, [string]>(
+      `SELECT entity_id FROM entity_evidence
+       WHERE episode_id = ?
+       ORDER BY confidence DESC
+       LIMIT 1`,
+    )
+    .get(episodeId);
+  return row ? { id: row.entity_id } : null;
+}
+
+/**
+ * Find the entity representing a given (source_type, source_ref) target.
+ * Looks up through the episode → entity_evidence chain.
+ * Skips episodes with status 'redacted'.
+ */
+function findTargetEntityBySourceRef(
+  graph: EngramGraph,
+  sourceType: string,
+  sourceRef: string,
+): { id: string } | null {
+  const row = graph.db
+    .query<{ entity_id: string }, [string, string]>(
+      `SELECT ee.entity_id
+       FROM entity_evidence ee
+       JOIN episodes ep ON ee.episode_id = ep.id
+       WHERE ep.source_type = ? AND ep.source_ref = ? AND ep.status != 'redacted'
+       LIMIT 1`,
+    )
+    .get(sourceType, sourceRef);
+  return row ? { id: row.entity_id } : null;
+}
+
+/**
+ * Emit or update a 'references' edge between two entities.
+ * Dedup: if an active edge already exists, add evidence link; otherwise create.
+ */
+function emitReferenceEdge(
+  graph: EngramGraph,
+  sourceEntityId: string,
+  targetEntityId: string,
+  episodeId: string,
+  confidence: number,
+  fact: string,
+  validFrom?: string,
+): boolean {
+  const existing = graph.db
+    .query<{ id: string }, [string, string, string, string]>(
+      `SELECT id FROM edges
+       WHERE source_id = ? AND target_id = ? AND relation_type = ?
+         AND edge_kind = ? AND invalidated_at IS NULL LIMIT 1`,
+    )
+    .get(sourceEntityId, targetEntityId, RELATION_TYPES.REFERENCES, "observed");
+
+  if (existing) {
+    // Add evidence link to existing edge (INSERT OR IGNORE to handle PK collision)
+    const now = new Date().toISOString();
+    graph.db
+      .prepare(
+        `INSERT OR IGNORE INTO edge_evidence (edge_id, episode_id, extractor, confidence, created_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run(existing.id, episodeId, "cross-ref-resolver", confidence, now);
+    return false; // edge already existed
+  }
+
+  addEdge(
+    graph,
+    {
+      source_id: sourceEntityId,
+      target_id: targetEntityId,
+      relation_type: RELATION_TYPES.REFERENCES,
+      edge_kind: "observed",
+      fact,
+      confidence,
+      valid_from: validFrom,
+    },
+    [{ episode_id: episodeId, extractor: "cross-ref-resolver", confidence }],
+  );
+  return true;
+}
+
+/**
+ * Record a reference that couldn't be resolved yet.
+ * Dedup: if an unresolved row already exists for this (episode, type, ref), skip.
+ */
+function recordUnresolved(
+  graph: EngramGraph,
+  sourceEpisodeId: string,
+  targetSourceType: string,
+  targetRef: string,
+): void {
+  const exists = graph.db
+    .query<{ id: string }, [string, string, string]>(
+      `SELECT id FROM unresolved_refs
+       WHERE source_episode_id = ? AND target_source_type = ? AND target_ref = ?
+         AND resolved_at IS NULL LIMIT 1`,
+    )
+    .get(sourceEpisodeId, targetSourceType, targetRef);
+
+  if (exists) return;
+
+  graph.db
+    .prepare(
+      `INSERT INTO unresolved_refs (id, source_episode_id, target_source_type, target_ref, detected_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    )
+    .run(
+      ulid(),
+      sourceEpisodeId,
+      targetSourceType,
+      targetRef,
+      new Date().toISOString(),
+    );
+}
+
+/**
+ * Scan episodes for cross-source references and emit edges.
+ *
+ * For each episode, scans content against all patterns. Emits a 'references'
+ * edge (edge_kind: 'observed') for each resolved match. Unresolved matches
+ * land in `unresolved_refs` for later resolution via `drainUnresolved`.
+ */
+export function resolveReferences(
+  graph: EngramGraph,
+  episodeIds: string[],
+  patterns: ReferencePattern[] = BUILT_IN_PATTERNS,
+): ResolveResult {
+  ensureUnresolvedRefsTable(graph);
+
+  let edgesCreated = 0;
+  let unresolved = 0;
+
+  for (const episodeId of episodeIds) {
+    const episode = graph.db
+      .query<
+        {
+          id: string;
+          content: string;
+          source_type: string;
+          source_ref: string | null;
+          timestamp: string;
+          status: string;
+        },
+        [string]
+      >(
+        "SELECT id, content, source_type, source_ref, timestamp, status FROM episodes WHERE id = ?",
+      )
+      .get(episodeId);
+
+    if (!episode || episode.status === "redacted") continue;
+
+    const sourceEntity = getPrimaryEntity(graph, episodeId);
+
+    // Deduplicate matches within this episode: (sourceType, normalizedRef) → seen
+    const seenRefs = new Set<string>();
+
+    for (const pat of patterns) {
+      // Reset lastIndex for stateful regexes (global flag)
+      pat.pattern.lastIndex = 0;
+
+      const allMatches: RegExpExecArray[] = [];
+      {
+        let m = pat.pattern.exec(episode.content);
+        while (m !== null) {
+          allMatches.push(m);
+          m = pat.pattern.exec(episode.content);
+        }
+      }
+
+      for (const match of allMatches) {
+        const captured = match[1];
+        if (!captured) continue;
+
+        const normalizedRef = pat.normalizeRef(captured);
+        const dedupeKey = `${pat.sourceType}:${normalizedRef}`;
+
+        if (seenRefs.has(dedupeKey)) continue;
+        seenRefs.add(dedupeKey);
+
+        // Find target entity
+        let targetEntity: { id: string } | null = null;
+
+        if (pat._lookupOverride) {
+          targetEntity = pat._lookupOverride(graph, normalizedRef);
+        } else {
+          targetEntity = findTargetEntityBySourceRef(
+            graph,
+            pat.sourceType,
+            normalizedRef,
+          );
+        }
+
+        if (!targetEntity) {
+          // Also try with the full match (for URL patterns where capture group = path segment)
+          if (!pat._lookupOverride) {
+            const fullMatch = match[0];
+            if (fullMatch !== normalizedRef) {
+              targetEntity = findTargetEntityBySourceRef(
+                graph,
+                pat.sourceType,
+                fullMatch,
+              );
+            }
+          }
+        }
+
+        if (!targetEntity) {
+          // Record using the full match when available (matches episode source_ref for drain)
+          const fullMatch = match[0];
+          const unresolvedRef =
+            !pat._lookupOverride && fullMatch !== normalizedRef
+              ? fullMatch
+              : normalizedRef;
+          recordUnresolved(graph, episodeId, pat.sourceType, unresolvedRef);
+          unresolved++;
+          continue;
+        }
+
+        // Self-reference guard
+        if (sourceEntity && targetEntity.id === sourceEntity.id) continue;
+
+        const fact = `Episode ${episodeId} (${episode.source_type}) references ${pat.sourceType} ${normalizedRef}`;
+        const created = emitReferenceEdge(
+          graph,
+          sourceEntity?.id ?? targetEntity.id, // fall back to target if no source entity
+          targetEntity.id,
+          episodeId,
+          pat.confidence,
+          fact,
+          episode.timestamp,
+        );
+        if (created) edgesCreated++;
+      }
+
+      // Reset lastIndex after use
+      pat.pattern.lastIndex = 0;
+    }
+
+    // Check if any existing unresolved_refs can be resolved by this new episode
+    drainUnresolvedForEpisode(graph, episode, patterns);
+  }
+
+  return { edgesCreated, unresolved };
+}
+
+/**
+ * Drain unresolved_refs entries that match the given episode's (source_type, source_ref).
+ * Called when a new episode lands that may satisfy pending references.
+ */
+function drainUnresolvedForEpisode(
+  graph: EngramGraph,
+  episode: {
+    id: string;
+    source_type: string;
+    source_ref: string | null;
+    timestamp: string;
+  },
+  _patterns: ReferencePattern[],
+): void {
+  if (!episode.source_ref) return;
+
+  const pending = graph.db
+    .query<
+      { id: string; source_episode_id: string; target_ref: string },
+      [string, string]
+    >(
+      `SELECT id, source_episode_id, target_ref FROM unresolved_refs
+       WHERE target_source_type = ? AND target_ref = ? AND resolved_at IS NULL`,
+    )
+    .all(episode.source_type, episode.source_ref);
+
+  if (pending.length === 0) return;
+
+  const targetEntity = findTargetEntityBySourceRef(
+    graph,
+    episode.source_type,
+    episode.source_ref,
+  );
+  if (!targetEntity) return;
+
+  const now = new Date().toISOString();
+
+  for (const row of pending) {
+    const sourceEntity = getPrimaryEntity(graph, row.source_episode_id);
+    if (!sourceEntity) continue;
+    if (sourceEntity.id === targetEntity.id) continue;
+
+    const fact = `Resolved reference: episode ${row.source_episode_id} references ${episode.source_type} ${row.target_ref}`;
+    emitReferenceEdge(
+      graph,
+      sourceEntity.id,
+      targetEntity.id,
+      row.source_episode_id,
+      0.9,
+      fact,
+      episode.timestamp,
+    );
+
+    graph.db
+      .prepare(`UPDATE unresolved_refs SET resolved_at = ? WHERE id = ?`)
+      .run(now, row.id);
+  }
+}
+
+/**
+ * Re-scan all episodes for unresolved references and attempt resolution.
+ * Used by `engram reconcile --cross-refs`.
+ *
+ * Returns count of edges created and remaining unresolved rows.
+ */
+export function drainUnresolved(
+  graph: EngramGraph,
+  patterns: ReferencePattern[] = BUILT_IN_PATTERNS,
+): ResolveResult {
+  ensureUnresolvedRefsTable(graph);
+
+  // Phase 1: try to resolve existing unresolved_refs rows
+  const pending = graph.db
+    .query<
+      {
+        id: string;
+        source_episode_id: string;
+        target_source_type: string;
+        target_ref: string;
+      },
+      []
+    >(
+      `SELECT id, source_episode_id, target_source_type, target_ref
+       FROM unresolved_refs WHERE resolved_at IS NULL`,
+    )
+    .all();
+
+  let edgesCreated = 0;
+  const now = new Date().toISOString();
+
+  for (const row of pending) {
+    // Find target entity using default lookup
+    const targetEntity = findTargetEntityBySourceRef(
+      graph,
+      row.target_source_type,
+      row.target_ref,
+    );
+    if (!targetEntity) continue;
+
+    const sourceEntity = getPrimaryEntity(graph, row.source_episode_id);
+    if (!sourceEntity) continue;
+    if (sourceEntity.id === targetEntity.id) continue;
+
+    const sourceEpisode = graph.db
+      .query<{ timestamp: string; source_type: string }, [string]>(
+        "SELECT timestamp, source_type FROM episodes WHERE id = ?",
+      )
+      .get(row.source_episode_id);
+
+    const fact = `Resolved reference: episode ${row.source_episode_id} references ${row.target_source_type} ${row.target_ref}`;
+    const created = emitReferenceEdge(
+      graph,
+      sourceEntity.id,
+      targetEntity.id,
+      row.source_episode_id,
+      0.9,
+      fact,
+      sourceEpisode?.timestamp,
+    );
+    if (created) edgesCreated++;
+
+    graph.db
+      .prepare(`UPDATE unresolved_refs SET resolved_at = ? WHERE id = ?`)
+      .run(now, row.id);
+  }
+
+  // Phase 2: full re-scan of all active episodes
+  const allEpisodes = graph.db
+    .query<{ id: string }, []>(
+      "SELECT id FROM episodes WHERE status != 'redacted' ORDER BY timestamp ASC",
+    )
+    .all();
+
+  const allEpisodeIds = allEpisodes.map((e) => e.id);
+  const scanResult = resolveReferences(graph, allEpisodeIds, patterns);
+  edgesCreated += scanResult.edgesCreated;
+
+  const remainingUnresolved =
+    graph.db
+      .query<{ count: number }, []>(
+        "SELECT COUNT(*) as count FROM unresolved_refs WHERE resolved_at IS NULL",
+      )
+      .get()?.count ?? 0;
+
+  return { edgesCreated, unresolved: remainingUnresolved };
+}

--- a/packages/engram-core/src/ingest/cross-ref/schema.ts
+++ b/packages/engram-core/src/ingest/cross-ref/schema.ts
@@ -1,0 +1,29 @@
+/**
+ * schema.ts — DDL for the unresolved_refs table.
+ * Uses CREATE TABLE IF NOT EXISTS for idempotent setup on open.
+ */
+
+import type { EngramGraph } from "../../format/index.js";
+
+export const CREATE_UNRESOLVED_REFS = `
+CREATE TABLE IF NOT EXISTS unresolved_refs (
+  id                 TEXT PRIMARY KEY,
+  source_episode_id  TEXT NOT NULL REFERENCES episodes(id),
+  target_source_type TEXT NOT NULL,
+  target_ref         TEXT NOT NULL,
+  detected_at        TEXT NOT NULL,
+  resolved_at        TEXT
+);
+`;
+
+export const CREATE_UNRESOLVED_REFS_INDEX = `
+CREATE INDEX IF NOT EXISTS idx_unresolved_refs_target
+  ON unresolved_refs(target_source_type, target_ref)
+  WHERE resolved_at IS NULL;
+`;
+
+/** Idempotent: create unresolved_refs table if it does not exist. */
+export function ensureUnresolvedRefsTable(graph: EngramGraph): void {
+  graph.db.exec(CREATE_UNRESOLVED_REFS);
+  graph.db.exec(CREATE_UNRESOLVED_REFS_INDEX);
+}

--- a/packages/engram-core/src/ingest/cross-ref/schema.ts
+++ b/packages/engram-core/src/ingest/cross-ref/schema.ts
@@ -6,11 +6,11 @@
  * The table is created by openGraph automatically on every open via ADDITIVE_DDL.
  */
 
+import type { EngramGraph } from "../../format/index.js";
 import {
   CREATE_UNRESOLVED_REFS,
   CREATE_UNRESOLVED_REFS_INDEX,
 } from "../../format/schema.js";
-import type { EngramGraph } from "../../format/index.js";
 
 export { CREATE_UNRESOLVED_REFS, CREATE_UNRESOLVED_REFS_INDEX };
 

--- a/packages/engram-core/src/ingest/cross-ref/schema.ts
+++ b/packages/engram-core/src/ingest/cross-ref/schema.ts
@@ -1,26 +1,18 @@
 /**
- * schema.ts — DDL for the unresolved_refs table.
- * Uses CREATE TABLE IF NOT EXISTS for idempotent setup on open.
+ * schema.ts — Re-exports the unresolved_refs DDL constants and exposes an
+ * idempotent setup helper for contexts that don't go through openGraph (tests,
+ * migration scripts, etc.).
+ *
+ * The table is created by openGraph automatically on every open via ADDITIVE_DDL.
  */
 
+import {
+  CREATE_UNRESOLVED_REFS,
+  CREATE_UNRESOLVED_REFS_INDEX,
+} from "../../format/schema.js";
 import type { EngramGraph } from "../../format/index.js";
 
-export const CREATE_UNRESOLVED_REFS = `
-CREATE TABLE IF NOT EXISTS unresolved_refs (
-  id                 TEXT PRIMARY KEY,
-  source_episode_id  TEXT NOT NULL REFERENCES episodes(id),
-  target_source_type TEXT NOT NULL,
-  target_ref         TEXT NOT NULL,
-  detected_at        TEXT NOT NULL,
-  resolved_at        TEXT
-);
-`;
-
-export const CREATE_UNRESOLVED_REFS_INDEX = `
-CREATE INDEX IF NOT EXISTS idx_unresolved_refs_target
-  ON unresolved_refs(target_source_type, target_ref)
-  WHERE resolved_at IS NULL;
-`;
+export { CREATE_UNRESOLVED_REFS, CREATE_UNRESOLVED_REFS_INDEX };
 
 /** Idempotent: create unresolved_refs table if it does not exist. */
 export function ensureUnresolvedRefsTable(graph: EngramGraph): void {

--- a/packages/engram-core/src/ingest/git.ts
+++ b/packages/engram-core/src/ingest/git.ts
@@ -21,6 +21,7 @@ import { addEdge } from "../graph/edges.js";
 import { addEntity, type EvidenceInput } from "../graph/entities.js";
 import { addEpisode } from "../graph/episodes.js";
 import { supersedeEdge } from "../temporal/supersession.js";
+import { BUILT_IN_PATTERNS, resolveReferences } from "./cross-ref/index.js";
 import { parseGitLog, recencyWeight } from "./git-parse.js";
 
 // ---------------------------------------------------------------------------
@@ -737,6 +738,8 @@ export async function ingestGitRepo(
       entities: counts.entitiesCreated,
       edges: counts.edgesCreated,
     });
+
+    resolveReferences(graph, [...episodeIds.values()], BUILT_IN_PATTERNS);
 
     // Post-ingest: generate embeddings for new episodes and entities (best-effort, never blocks)
     if (opts.provider) {

--- a/packages/engram-core/src/vocab/relation-types.ts
+++ b/packages/engram-core/src/vocab/relation-types.ts
@@ -1,0 +1,9 @@
+export const RELATION_TYPES = {
+  LIKELY_OWNER_OF: "likely_owner_of",
+  CO_CHANGES_WITH: "co_changes_with",
+  REVIEWED_BY: "reviewed_by",
+  AUTHORED_BY: "authored_by",
+  REFERENCES: "references",
+} as const;
+
+export type RelationType = (typeof RELATION_TYPES)[keyof typeof RELATION_TYPES];

--- a/packages/engram-core/test/cross-ref/resolver.test.ts
+++ b/packages/engram-core/test/cross-ref/resolver.test.ts
@@ -283,72 +283,36 @@ describe("SHA confidence levels", () => {
 
   test("short 7-11 char SHA produces confidence 0.75", () => {
     const shortSha = "abcdef1";
-    const fullSha = "abcdef1234567890abcdef1234567890abcdef99";
-    const targetEp = makeEpisode("git_commit", fullSha, `commit ${fullSha}`);
-    const _targetEntity = makeEntity(fullSha, "commit", targetEp.id);
 
-    // Only use short-SHA pattern (filter to it)
-    const shortShaPatternFound = BUILT_IN_PATTERNS.find(
+    // Only use the short-SHA pattern to test it specifically
+    const shortShaPattern = BUILT_IN_PATTERNS.find(
       (p) => p.sourceType === "git_commit" && p.confidence === 0.75,
-    );
-    if (!shortShaPatternFound) {
-      throw new Error("short SHA pattern not found in BUILT_IN_PATTERNS");
-    }
-    const shortShaPattern: ReferencePattern = shortShaPatternFound;
+    ) as ReferencePattern;
+    expect(shortShaPattern).toBeDefined();
 
-    // Create episode whose content has the short sha
+    // Target episode uses the short SHA as its source_ref so the resolver finds it
+    const targetEp = makeEpisode("git_commit", shortSha, `commit ${shortSha}`);
+    makeEntity(`commit-short-${shortSha}`, "commit", targetEp.id);
+
     const sourceEp = makeEpisode(
-      "git_commit",
-      "2222222222222222222222222222222222222222",
-      `See abcdef1 for the fix`,
-    );
-    const sourceEntity = makeEntity(
-      "2222222222222222222222222222222222222222",
-      "commit",
-      sourceEp.id,
-    );
-
-    // Run only the short-SHA pattern (so we test that pattern specifically)
-    resolveReferences(graph, [sourceEp.id], [shortShaPattern]);
-
-    const _edges = findEdges(graph, {
-      source_id: sourceEntity.id,
-      relation_type: "references",
-    });
-    // Short SHA won't match because source_ref is full SHA - need the source_ref to be the short sha
-    // The lookup uses source_ref == normalized match, so let's use a different approach:
-    // create an episode with source_ref = shortSha
-    const targetEp2 = makeEpisode("git_commit", shortSha, `commit ${shortSha}`);
-    const _targetEntity2 = makeEntity(
-      `commit-short-${shortSha}`,
-      "commit",
-      targetEp2.id,
-    );
-
-    // Re-run with entity that has source_ref = shortSha
-    const sourceEp2 = makeEpisode(
       "git_commit",
       "3333333333333333333333333333333333333333",
       `See ${shortSha} for the fix`,
     );
-    const sourceEntity2 = makeEntity(
+    const sourceEntity = makeEntity(
       "3333333333333333333333333333333333333333",
       "commit",
-      sourceEp2.id,
+      sourceEp.id,
     );
 
-    const _result2 = resolveReferences(
-      graph,
-      [sourceEp2.id],
-      [shortShaPattern],
-    );
+    resolveReferences(graph, [sourceEp.id], [shortShaPattern]);
 
-    const edges2 = findEdges(graph, {
-      source_id: sourceEntity2.id,
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
       relation_type: "references",
     });
-    expect(edges2.length).toBeGreaterThan(0);
-    expect(edges2[0].confidence).toBe(0.75);
+    expect(edges.length).toBeGreaterThan(0);
+    expect(edges[0].confidence).toBe(0.75);
   });
 });
 

--- a/packages/engram-core/test/cross-ref/resolver.test.ts
+++ b/packages/engram-core/test/cross-ref/resolver.test.ts
@@ -1,0 +1,798 @@
+/**
+ * resolver.test.ts — Tests for cross-source reference edge resolution.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EngramGraph } from "../../src/index.js";
+import {
+  addEntity,
+  addEpisode,
+  closeGraph,
+  createGraph,
+  findEdges,
+} from "../../src/index.js";
+import type { ReferencePattern } from "../../src/ingest/cross-ref/index.js";
+import {
+  BUILT_IN_PATTERNS,
+  compilePluginPattern,
+  drainUnresolved,
+  resolveReferences,
+} from "../../src/ingest/cross-ref/index.js";
+import { ensureUnresolvedRefsTable } from "../../src/ingest/cross-ref/schema.js";
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+  ensureUnresolvedRefsTable(graph);
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEpisode(
+  sourceType: string,
+  sourceRef: string,
+  content: string,
+  timestamp = "2024-01-01T00:00:00Z",
+) {
+  return addEpisode(graph, {
+    source_type: sourceType,
+    source_ref: sourceRef,
+    content,
+    timestamp,
+  });
+}
+
+function makeEntity(
+  canonicalName: string,
+  entityType: string,
+  episodeId: string,
+) {
+  return addEntity(
+    graph,
+    { canonical_name: canonicalName, entity_type: entityType },
+    [{ episode_id: episodeId, extractor: "test", confidence: 1.0 }],
+  );
+}
+
+function getUnresolvedRefs(targetSourceType?: string, targetRef?: string) {
+  if (targetSourceType && targetRef) {
+    return graph.db
+      .query<
+        { id: string; source_episode_id: string; resolved_at: string | null },
+        [string, string]
+      >(
+        "SELECT id, source_episode_id, resolved_at FROM unresolved_refs WHERE target_source_type = ? AND target_ref = ?",
+      )
+      .all(targetSourceType, targetRef);
+  }
+  return graph.db
+    .query<
+      { id: string; source_episode_id: string; resolved_at: string | null },
+      []
+    >("SELECT id, source_episode_id, resolved_at FROM unresolved_refs")
+    .all();
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Each built-in pattern matches its canonical example
+// ---------------------------------------------------------------------------
+
+describe("built-in patterns — canonical examples", () => {
+  test("full GitHub PR URL emits edge at 0.95 confidence", () => {
+    // Create target episode + entity
+    const targetEp = makeEpisode(
+      "github_pr",
+      "https://github.com/owner/repo/pull/42",
+      "PR body",
+    );
+    const targetEntity = makeEntity(
+      "https://github.com/owner/repo/pull/42",
+      "pull_request",
+      targetEp.id,
+    );
+
+    // Create source episode + entity referencing the PR
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "abc1234567890123456789012345678901234abc1",
+      "Fix bug, see https://github.com/owner/repo/pull/42 for context",
+    );
+    const sourceEntity = makeEntity(
+      "abc1234567890123456789012345678901234abc1",
+      "commit",
+      sourceEp.id,
+    );
+
+    const result = resolveReferences(graph, [sourceEp.id]);
+
+    expect(result.edgesCreated).toBe(1);
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges).toHaveLength(1);
+    expect(edges[0].target_id).toBe(targetEntity.id);
+    expect(edges[0].confidence).toBe(0.95);
+  });
+
+  test("full GitHub issue URL emits edge at 0.95 confidence", () => {
+    const targetEp = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/10",
+      "Issue body",
+    );
+    const targetEntity = makeEntity(
+      "https://github.com/owner/repo/issues/10",
+      "issue",
+      targetEp.id,
+    );
+
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "def1234567890123456789012345678901234def1",
+      "Closes https://github.com/owner/repo/issues/10",
+    );
+    const sourceEntity = makeEntity(
+      "def1234567890123456789012345678901234def1",
+      "commit",
+      sourceEp.id,
+    );
+
+    const result = resolveReferences(graph, [sourceEp.id]);
+
+    expect(result.edgesCreated).toBe(1);
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges).toHaveLength(1);
+    expect(edges[0].target_id).toBe(targetEntity.id);
+    expect(edges[0].confidence).toBe(0.95);
+  });
+
+  test("b/NNNNNN buganizer shorthand emits edge at 0.9 confidence", () => {
+    const targetEp = makeEpisode(
+      "buganizer_issue",
+      "b/123456",
+      "Buganizer issue content",
+    );
+    const _targetEntity = makeEntity("b/123456", "issue", targetEp.id);
+
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "aaa1234567890123456789012345678901234aaa1",
+      "Fix for b/123456 — memory leak in parser",
+    );
+    const sourceEntity = makeEntity(
+      "aaa1234567890123456789012345678901234aaa1",
+      "commit",
+      sourceEp.id,
+    );
+
+    const result = resolveReferences(graph, [sourceEp.id]);
+
+    expect(result.edgesCreated).toBe(1);
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges[0].confidence).toBe(0.9);
+  });
+
+  test("go/cl/NNNN gerrit shorthand emits edge at 0.9 confidence", () => {
+    const targetEp = makeEpisode("gerrit_change", "go/cl/999", "Gerrit CL");
+    const _targetEntity = makeEntity("go/cl/999", "change", targetEp.id);
+
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "bbb1234567890123456789012345678901234bbb1",
+      "Cherry-pick from go/cl/999",
+    );
+    const sourceEntity = makeEntity(
+      "bbb1234567890123456789012345678901234bbb1",
+      "commit",
+      sourceEp.id,
+    );
+
+    const result = resolveReferences(graph, [sourceEp.id]);
+
+    expect(result.edgesCreated).toBe(1);
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges[0].confidence).toBe(0.9);
+  });
+
+  test("#N repo-scoped reference matches issue/pull_request entity via _lookupOverride", () => {
+    const targetEp = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/7",
+      "Issue 7",
+    );
+    const targetEntity = makeEntity(
+      "https://github.com/owner/repo/issues/7",
+      "issue",
+      targetEp.id,
+    );
+
+    const sourceEp = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/8",
+      "Related to #7 from the issue body",
+    );
+    const sourceEntity = makeEntity(
+      "https://github.com/owner/repo/issues/8",
+      "issue",
+      sourceEp.id,
+    );
+
+    const result = resolveReferences(graph, [sourceEp.id]);
+
+    expect(result.edgesCreated).toBe(1);
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges).toHaveLength(1);
+    expect(edges[0].target_id).toBe(targetEntity.id);
+    expect(edges[0].confidence).toBe(0.85);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Full SHA vs short SHA confidence values
+// ---------------------------------------------------------------------------
+
+describe("SHA confidence levels", () => {
+  test("full 40-char SHA produces confidence 0.9", () => {
+    const fullSha = "abcdef1234567890abcdef1234567890abcdef12";
+    const targetEp = makeEpisode("git_commit", fullSha, `commit ${fullSha}`);
+    const targetEntity = makeEntity(fullSha, "commit", targetEp.id);
+
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "1111111111111111111111111111111111111111",
+      `Reverts ${fullSha}`,
+    );
+    const sourceEntity = makeEntity(
+      "1111111111111111111111111111111111111111",
+      "commit",
+      sourceEp.id,
+    );
+
+    const _result = resolveReferences(graph, [sourceEp.id]);
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+
+    // Should match the 40-char pattern at 0.9
+    expect(edges.length).toBeGreaterThan(0);
+    const fullShaEdge = edges.find((e) => e.target_id === targetEntity.id);
+    expect(fullShaEdge).toBeDefined();
+    expect(fullShaEdge?.confidence).toBe(0.9);
+  });
+
+  test("short 7-11 char SHA produces confidence 0.75", () => {
+    const shortSha = "abcdef1";
+    const fullSha = "abcdef1234567890abcdef1234567890abcdef99";
+    const targetEp = makeEpisode("git_commit", fullSha, `commit ${fullSha}`);
+    const _targetEntity = makeEntity(fullSha, "commit", targetEp.id);
+
+    // Only use short-SHA pattern (filter to it)
+    const shortShaPatternFound = BUILT_IN_PATTERNS.find(
+      (p) => p.sourceType === "git_commit" && p.confidence === 0.75,
+    );
+    if (!shortShaPatternFound) {
+      throw new Error("short SHA pattern not found in BUILT_IN_PATTERNS");
+    }
+    const shortShaPattern: ReferencePattern = shortShaPatternFound;
+
+    // Create episode whose content has the short sha
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "2222222222222222222222222222222222222222",
+      `See abcdef1 for the fix`,
+    );
+    const sourceEntity = makeEntity(
+      "2222222222222222222222222222222222222222",
+      "commit",
+      sourceEp.id,
+    );
+
+    // Run only the short-SHA pattern (so we test that pattern specifically)
+    resolveReferences(graph, [sourceEp.id], [shortShaPattern]);
+
+    const _edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    // Short SHA won't match because source_ref is full SHA - need the source_ref to be the short sha
+    // The lookup uses source_ref == normalized match, so let's use a different approach:
+    // create an episode with source_ref = shortSha
+    const targetEp2 = makeEpisode("git_commit", shortSha, `commit ${shortSha}`);
+    const _targetEntity2 = makeEntity(
+      `commit-short-${shortSha}`,
+      "commit",
+      targetEp2.id,
+    );
+
+    // Re-run with entity that has source_ref = shortSha
+    const sourceEp2 = makeEpisode(
+      "git_commit",
+      "3333333333333333333333333333333333333333",
+      `See ${shortSha} for the fix`,
+    );
+    const sourceEntity2 = makeEntity(
+      "3333333333333333333333333333333333333333",
+      "commit",
+      sourceEp2.id,
+    );
+
+    const _result2 = resolveReferences(
+      graph,
+      [sourceEp2.id],
+      [shortShaPattern],
+    );
+
+    const edges2 = findEdges(graph, {
+      source_id: sourceEntity2.id,
+      relation_type: "references",
+    });
+    expect(edges2.length).toBeGreaterThan(0);
+    expect(edges2[0].confidence).toBe(0.75);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: Self-reference guard
+// ---------------------------------------------------------------------------
+
+describe("self-reference guard", () => {
+  test("episode referencing its own source_ref does not create edge", () => {
+    const sha = "cafebabe12345678cafebabe12345678cafebabe";
+
+    // Episode with source_ref = sha, content that mentions sha
+    const ep = makeEpisode(
+      "git_commit",
+      sha,
+      `commit ${sha}\nThis reverts ${sha}`,
+    );
+    const entity = makeEntity(sha, "commit", ep.id);
+
+    const _result = resolveReferences(graph, [ep.id]);
+
+    // No self-reference edge should be created
+    const edges = findEdges(graph, {
+      source_id: entity.id,
+      relation_type: "references",
+    });
+    expect(edges).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: Unresolved refs when target not in graph
+// ---------------------------------------------------------------------------
+
+describe("unresolved_refs", () => {
+  test("reference to entity not in graph lands in unresolved_refs", () => {
+    const sourceEp = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/99",
+      "Related to https://github.com/owner/repo/pull/100 which fixed this",
+    );
+    const _sourceEntity = makeEntity(
+      "https://github.com/owner/repo/issues/99",
+      "issue",
+      sourceEp.id,
+    );
+
+    const result = resolveReferences(graph, [sourceEp.id]);
+
+    expect(result.unresolved).toBeGreaterThan(0);
+    // The PR URL pattern captures the PR number (100), which normalizeRef returns as-is
+    // The resolver stores the normalized ref (capture group 1) in unresolved_refs
+    const allRows = getUnresolvedRefs();
+    const prRow = allRows.find(
+      (r: { source_episode_id: string; resolved_at: string | null }) =>
+        r.source_episode_id === sourceEp.id,
+    );
+    expect(prRow).toBeDefined();
+    expect(prRow?.resolved_at).toBeNull();
+  });
+
+  test("later-ingested target drains matching unresolved_refs and sets resolved_at", () => {
+    const prUrl = "https://github.com/owner/repo/pull/51";
+
+    // First: source episode references a PR that doesn't exist yet
+    const sourceEp = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/50",
+      `Fixed by ${prUrl}`,
+    );
+    const sourceEntity = makeEntity(
+      "https://github.com/owner/repo/issues/50",
+      "issue",
+      sourceEp.id,
+    );
+
+    resolveReferences(graph, [sourceEp.id]);
+
+    // The unresolved_ref is stored with the full URL as target_ref
+    const rows = getUnresolvedRefs("github_pr", prUrl);
+    expect(rows.length).toBe(1);
+    expect(rows[0].resolved_at).toBeNull();
+
+    // Now the target PR arrives
+    const targetEp = makeEpisode("github_pr", prUrl, "PR #51: Fix the bug");
+    const targetEntity = makeEntity(prUrl, "pull_request", targetEp.id);
+
+    // Scanning this new episode triggers drain for the pending ref
+    resolveReferences(graph, [targetEp.id]);
+
+    // The unresolved_ref should now be resolved
+    const rowsAfter = getUnresolvedRefs("github_pr", prUrl);
+    expect(rowsAfter.length).toBe(1);
+    expect(rowsAfter[0].resolved_at).not.toBeNull();
+
+    // An edge should have been created
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges.length).toBeGreaterThan(0);
+    const refEdge = edges.find((e) => e.target_id === targetEntity.id);
+    expect(refEdge).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: Redacted episode target does not emit edge
+// ---------------------------------------------------------------------------
+
+describe("redacted episode guard", () => {
+  test("target episode with status=redacted does not emit edge", () => {
+    // Create target episode and mark it redacted
+    const targetEp = makeEpisode(
+      "git_commit",
+      "deadbeef12345678deadbeef12345678deadbeef",
+      "commit deadbeef12345678deadbeef12345678deadbeef",
+    );
+    const _targetEntity = makeEntity(
+      "deadbeef12345678deadbeef12345678deadbeef",
+      "commit",
+      targetEp.id,
+    );
+
+    // Redact the target episode
+    graph.db
+      .prepare(
+        "UPDATE episodes SET status = 'redacted', content = '' WHERE id = ?",
+      )
+      .run(targetEp.id);
+
+    const sourceEp = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/200",
+      "Relates to commit deadbeef12345678deadbeef12345678deadbeef",
+    );
+    const sourceEntity = makeEntity(
+      "https://github.com/owner/repo/issues/200",
+      "issue",
+      sourceEp.id,
+    );
+
+    resolveReferences(graph, [sourceEp.id]);
+
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    // Should be 0 because target is redacted (findTargetEntityBySourceRef filters it)
+    expect(edges).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: Plugin pattern — compilePluginPattern
+// ---------------------------------------------------------------------------
+
+describe("plugin patterns", () => {
+  test("plugin pattern compiled from manifest string produces equivalent behavior", () => {
+    const manifest = {
+      source_type: "custom_tracker",
+      pattern: "TICKET-(\\d+)",
+      flags: "g",
+      normalize_template: "TICKET-$1",
+      confidence: 0.8,
+    };
+
+    const compiled = compilePluginPattern(manifest, []);
+
+    // Create target episode with matching source_ref
+    const targetEp = makeEpisode(
+      "custom_tracker",
+      "TICKET-42",
+      "Custom tracker ticket 42",
+    );
+    const targetEntity = makeEntity("TICKET-42", "ticket", targetEp.id);
+
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "eeee111111111111111111111111111111111111",
+      "Fix for TICKET-42 — see tracker for details",
+    );
+    const sourceEntity = makeEntity(
+      "eeee111111111111111111111111111111111111",
+      "commit",
+      sourceEp.id,
+    );
+
+    const result = resolveReferences(graph, [sourceEp.id], [compiled]);
+
+    expect(result.edgesCreated).toBe(1);
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges).toHaveLength(1);
+    expect(edges[0].target_id).toBe(targetEntity.id);
+    expect(edges[0].confidence).toBe(0.8);
+  });
+
+  test("plugin pattern collision on (source_type, pattern.source) raises error", () => {
+    // The built-in pattern for github_pr has a specific pattern source
+    const builtInPrPatternFound = BUILT_IN_PATTERNS.find(
+      (p) => p.sourceType === "github_pr",
+    );
+    if (!builtInPrPatternFound) {
+      throw new Error("github_pr pattern not found in BUILT_IN_PATTERNS");
+    }
+    const builtInPrPattern = builtInPrPatternFound;
+
+    const collidingManifest = {
+      source_type: "github_pr",
+      pattern: builtInPrPattern.pattern.source,
+      flags: builtInPrPattern.pattern.flags,
+      normalize_template: "$1",
+      confidence: 0.5,
+    };
+
+    expect(() =>
+      compilePluginPattern(collidingManifest, BUILT_IN_PATTERNS),
+    ).toThrow(/Plugin pattern collision/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: Deduplication — same (source, target) from two episodes → one edge, two evidence links
+// ---------------------------------------------------------------------------
+
+describe("deduplication", () => {
+  test("same (source_entity, target_entity) from two episodes produces one edge, two evidence links", () => {
+    const targetEp = makeEpisode(
+      "github_pr",
+      "https://github.com/owner/repo/pull/77",
+      "PR body",
+    );
+    const _targetEntity = makeEntity(
+      "https://github.com/owner/repo/pull/77",
+      "pull_request",
+      targetEp.id,
+    );
+
+    // Two source episodes that both reference the same PR
+    const sourceEp1 = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/78",
+      "See https://github.com/owner/repo/pull/77 for context",
+    );
+    const sourceEntity = makeEntity(
+      "https://github.com/owner/repo/issues/78",
+      "issue",
+      sourceEp1.id,
+    );
+
+    const sourceEp2 = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/79",
+      "Also related to https://github.com/owner/repo/pull/77",
+    );
+    // Link second episode to SAME entity (same issue author referencing same entity)
+    graph.db
+      .prepare(
+        "INSERT INTO entity_evidence (entity_id, episode_id, extractor, confidence, created_at) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(
+        sourceEntity.id,
+        sourceEp2.id,
+        "test",
+        1.0,
+        new Date().toISOString(),
+      );
+
+    resolveReferences(graph, [sourceEp1.id, sourceEp2.id]);
+
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges).toHaveLength(1);
+
+    // Check evidence count — should have 2 evidence links
+    const evidenceLinks = graph.db
+      .query<{ count: number }, [string]>(
+        "SELECT COUNT(*) as count FROM edge_evidence WHERE edge_id = ?",
+      )
+      .get(edges[0].id);
+    expect(evidenceLinks?.count).toBe(2);
+  });
+
+  test("same episode with same ref twice in content produces one edge", () => {
+    const targetEp = makeEpisode(
+      "github_pr",
+      "https://github.com/owner/repo/pull/88",
+      "PR body",
+    );
+    const _targetEntity = makeEntity(
+      "https://github.com/owner/repo/pull/88",
+      "pull_request",
+      targetEp.id,
+    );
+
+    // Source episode references same URL twice
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "ffff111111111111111111111111111111111111",
+      "Fix: closes https://github.com/owner/repo/pull/88 - see also https://github.com/owner/repo/pull/88",
+    );
+    const sourceEntity = makeEntity(
+      "ffff111111111111111111111111111111111111",
+      "commit",
+      sourceEp.id,
+    );
+
+    const result = resolveReferences(graph, [sourceEp.id]);
+
+    expect(result.edgesCreated).toBe(1);
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: drainUnresolved re-scans all episodes
+// ---------------------------------------------------------------------------
+
+describe("drainUnresolved", () => {
+  test("drainUnresolved resolves previously unresolved refs after target arrives", () => {
+    const prUrl = "https://github.com/owner/repo/pull/301";
+
+    // Create source episode with a reference that can't yet be resolved
+    const sourceEp = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/300",
+      `Blocked by ${prUrl}`,
+    );
+    const sourceEntity = makeEntity(
+      "https://github.com/owner/repo/issues/300",
+      "issue",
+      sourceEp.id,
+    );
+
+    // Initial scan — should produce unresolved
+    resolveReferences(graph, [sourceEp.id]);
+    const unresolved = getUnresolvedRefs("github_pr", prUrl);
+    expect(unresolved.length).toBe(1);
+
+    // Target arrives (added directly, not via resolveReferences yet)
+    const targetEp = makeEpisode("github_pr", prUrl, "PR #301");
+    const _targetEntity = makeEntity(prUrl, "pull_request", targetEp.id);
+
+    // drainUnresolved should wire up the pending ref
+    const result = drainUnresolved(graph);
+
+    expect(result.edgesCreated).toBeGreaterThan(0);
+    const rows = getUnresolvedRefs("github_pr", prUrl);
+    expect(rows[0].resolved_at).not.toBeNull();
+
+    const edges = findEdges(graph, {
+      source_id: sourceEntity.id,
+      relation_type: "references",
+    });
+    expect(edges.length).toBeGreaterThan(0);
+  });
+
+  test("drainUnresolved returns remaining unresolved count for unresolvable refs", () => {
+    const sourceEp = makeEpisode(
+      "github_issue",
+      "https://github.com/owner/repo/issues/999",
+      "See https://github.com/owner/repo/pull/1000 for details",
+    );
+    makeEntity(
+      "https://github.com/owner/repo/issues/999",
+      "issue",
+      sourceEp.id,
+    );
+
+    resolveReferences(graph, [sourceEp.id]);
+
+    // Target PR never arrives — drain should show remaining unresolved
+    const result = drainUnresolved(graph);
+
+    // unresolved_refs has at least 1 row still unresolved
+    expect(result.unresolved).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: resolveReferences with no patterns returns empty result
+// ---------------------------------------------------------------------------
+
+describe("empty patterns", () => {
+  test("resolveReferences with empty patterns array returns zero edges and zero unresolved", () => {
+    const ep = makeEpisode(
+      "git_commit",
+      "aaaa111111111111111111111111111111111111",
+      "Some commit body with https://github.com/owner/repo/pull/5",
+    );
+    makeEntity("aaaa111111111111111111111111111111111111", "commit", ep.id);
+
+    const result = resolveReferences(graph, [ep.id], []);
+    expect(result.edgesCreated).toBe(0);
+    expect(result.unresolved).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 10: Redacted source episode is skipped
+// ---------------------------------------------------------------------------
+
+describe("redacted source episode", () => {
+  test("redacted source episode is not scanned", () => {
+    const targetEp = makeEpisode(
+      "github_pr",
+      "https://github.com/owner/repo/pull/400",
+      "PR body",
+    );
+    makeEntity(
+      "https://github.com/owner/repo/pull/400",
+      "pull_request",
+      targetEp.id,
+    );
+
+    const sourceEp = makeEpisode(
+      "git_commit",
+      "bbbb111111111111111111111111111111111111",
+      "Fix: https://github.com/owner/repo/pull/400",
+    );
+    makeEntity(
+      "bbbb111111111111111111111111111111111111",
+      "commit",
+      sourceEp.id,
+    );
+
+    // Redact the source episode
+    graph.db
+      .prepare(
+        "UPDATE episodes SET status = 'redacted', content = '' WHERE id = ?",
+      )
+      .run(sourceEp.id);
+
+    const result = resolveReferences(graph, [sourceEp.id]);
+    expect(result.edgesCreated).toBe(0);
+    expect(result.unresolved).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements a pattern-registry-based cross-source reference resolver (`packages/engram-core/src/ingest/cross-ref/`) that scans episode content for references to entities from other adapters and emits `references` edges
- Adds `RELATION_TYPES` vocab registry with canonical string constants for all edge relation types
- Wires `resolveReferences()` into `ingestGitRepo()` and `GitHubAdapter.enrich()`, removing the now-redundant inline SHA/`#N` detection from the GitHub adapter
- Adds `engram reconcile --cross-refs` flag to drain `unresolved_refs` and re-scan all episodes
- Built-in patterns: full GitHub PR/issue URLs, Gerrit CL URLs, Google Docs URLs, Linear/Jira issue URLs, `b/N` (Buganizer), `go/cl/N` (Gerrit shorthand), full 40-char SHAs (0.9 confidence), short SHAs (0.75 confidence), repo-scoped `#N` refs
- Plugin-safe `PluginReferencePattern` format uses string patterns + `$1` templates (no closures)
- Unresolved references stored in `unresolved_refs` table (idempotent `CREATE TABLE IF NOT EXISTS`); resolved when matching episode arrives
- 19 unit tests covering all acceptance criteria

## Acceptance Criteria

- [x] `resolveReferences(graph, episodeIds, patterns)` implemented in `packages/engram-core/src/ingest/cross-ref/resolver.ts`; returns `{ edgesCreated, unresolved }`
- [x] Built-in pattern registry covers all specified source types
- [x] Each pattern carries a `confidence` field; emitted edges use it
- [x] Ambiguous short SHA matches emit one edge per candidate at `min(pattern.confidence, 0.6)` — see resolver.ts (multiple entity matches per normalizedRef)
- [x] Self-reference guard: pattern match resolving to source episode's primary entity is skipped
- [x] Target resolution goes through entity_evidence → episodes chain (references bind to entities)
- [x] Plugin manifests with `reference_patterns` compiled via `compilePluginPattern()`; collisions raise load error
- [x] `unresolved_refs` table added via idempotent `CREATE TABLE IF NOT EXISTS`; partial index on unresolved rows
- [x] New episode landing drains matching `unresolved_refs` entries via `drainUnresolvedForEpisode()`
- [x] `relation_type: 'references'` added to `RELATION_TYPES` in `packages/engram-core/src/vocab/relation-types.ts`
- [x] `ingestGit()` and `GitHubAdapter.enrich()` call `resolveReferences()` at end of run
- [x] `engram reconcile --cross-refs` re-runs `resolveReferences` and drains `unresolved_refs`
- [x] Dedup: duplicate `(source_entity, target_entity, 'references')` produces one active edge with additional evidence link

## Test plan

- [x] Run `bun test packages/engram-core/test/cross-ref/` — 19 pass
- [x] Run `bun run build` — passes cleanly
- [x] Run `bunx biome check` on all new/changed files — no issues
- [x] Verify pre-existing failures are pre-existing (NullGenerator tests require API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)