### PR TITLE
feat(cli): engram plugin install and uninstall subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ that current code alone does not reveal.
 | `engram verify` | Validate `.engram/` integrity. |
 | `engram embed` | Manage vector embeddings. |
 | `engram rebuild-index` | Rebuild the FTS index. |
-| `engram plugin list` | List discovered plugins. |
+| `engram plugin list` | List discovered plugins (add `--available` for installable bundled plugins). |
+| `engram plugin install <name>` | Wire a bundled first-party plugin into XDG (or project with `--project`). |
+| `engram plugin uninstall <name>` | Remove an installed plugin (`--force` for user-authored). |
 
 Every command has `--help` with examples.
 
@@ -332,11 +334,46 @@ extensions, and security model.
 ```bash
 engram plugin list
 
-NAME        VERSION  TRANSPORT   SCOPE    STATUS
-----------  -------  ----------  -------  ------
-my-jira     0.1.0    executable  user     OK
-my-linear   0.2.0    js-module   project  OK
+NAME        VERSION  TRANSPORT   SCOPE    SOURCE    STATUS
+----------  -------  ----------  -------  --------  ------
+my-jira     0.1.0    executable  user     user      OK
+my-linear   0.2.0    js-module   project  symlinked OK
 ```
+
+### Install and uninstall
+
+First-party bundled plugins (those shipped in the engram install under
+`packages/plugins/`) can be wired into the XDG plugin directory with a
+single command — no manual symlinking required:
+
+```bash
+# List what is available to install
+engram plugin list --available
+
+# Install a bundled plugin user-wide (symlink into XDG_DATA_HOME/engram/plugins/)
+engram plugin install gerrit
+
+# Install into a specific project only
+engram plugin install gerrit --project /path/to/project
+
+# Uninstall a bundled or symlinked plugin
+engram plugin uninstall gerrit
+
+# Uninstall a user-authored (plain-directory) plugin — requires --force
+engram plugin uninstall my-custom --force
+```
+
+**Source column** — `engram plugin list` reports how each plugin was
+installed:
+
+| Source | Meaning |
+|---|---|
+| `bundled` | Symlink pointing into the engram install root (installed via `engram plugin install`). |
+| `symlinked` | A user-created symlink to an external directory. |
+| `user` | A plain directory created by the user. |
+
+On Windows, where symlinks may require elevated permissions, `engram plugin
+install` falls back to a recursive copy automatically.
 
 ## AI providers
 

--- a/packages/engram-cli/src/commands/plugin.ts
+++ b/packages/engram-cli/src/commands/plugin.ts
@@ -2,25 +2,80 @@
  * plugin.ts — `engram plugin` command group.
  *
  * Subcommands:
- *   - plugin list   Discover and display installed plugins with status
+ *   - plugin list      Discover and display installed plugins with status
+ *   - plugin install   Wire a bundled first-party plugin into XDG (or project)
+ *   - plugin uninstall Remove a previously installed plugin
  */
 
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { log } from "@clack/prompts";
 import type { Command } from "commander";
 import {
+  bundledPluginsRoot,
   discoverPlugins,
+  listBundledPlugins,
   loadManifest,
   ManifestValidationError,
+  projectPluginsRoot,
+  userPluginsRoot,
 } from "engram-core/plugins";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the destination plugins root based on whether --project is set.
+ */
+function resolveDestRoot(projectOpt: string | undefined): string {
+  if (projectOpt) {
+    return projectPluginsRoot(path.resolve(projectOpt));
+  }
+  return userPluginsRoot();
+}
+
+/**
+ * On Windows, symlinks may require elevated permissions. Fall back to a
+ * directory copy when symlinking fails.
+ */
+function installPlugin(src: string, dest: string): "symlink" | "copy" {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+
+  try {
+    fs.symlinkSync(src, dest, "junction");
+    return "symlink";
+  } catch {
+    // Fallback: recursive copy
+    copyDir(src, dest);
+    return "copy";
+  }
+}
+
+function copyDir(src: string, dest: string): void {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// plugin list
+// ---------------------------------------------------------------------------
 
 interface PluginListOpts {
   project?: string;
+  available?: boolean;
+  bundledRoot?: string;
 }
 
-export function registerPlugin(program: Command): void {
-  const plugin = program.command("plugin").description("Manage engram plugins");
-
+function registerList(plugin: Command): void {
   plugin
     .command("list")
     .description("List discovered plugins and their status")
@@ -28,14 +83,43 @@ export function registerPlugin(program: Command): void {
       "--project <path>",
       "project root to check for .engram/plugins/ (default: cwd)",
     )
+    .option(
+      "--available",
+      "also list bundled first-party plugins available to install",
+    )
+    .option("--bundled-root <path>", "override bundled plugins root (testing)")
     .action(async (opts: PluginListOpts) => {
       const projectRoot = path.resolve(opts.project ?? ".");
-      const discovered = discoverPlugins(projectRoot);
+
+      // Show available bundled plugins if requested
+      if (opts.available) {
+        const root = opts.bundledRoot ?? bundledPluginsRoot();
+        const available = listBundledPlugins(root ?? undefined);
+        if (available.length === 0) {
+          log.info(
+            "No bundled first-party plugins are available. " +
+              "(packages/plugins/ not found in the engram install root)",
+          );
+        } else {
+          process.stdout.write("Available bundled plugins:\n");
+          for (const name of available) {
+            process.stdout.write(`  ${name}\n`);
+          }
+          process.stdout.write(
+            "\nInstall with: engram plugin install <name>\n",
+          );
+        }
+        return;
+      }
+
+      const root = opts.bundledRoot ?? bundledPluginsRoot();
+      const discovered = discoverPlugins(projectRoot, root ?? undefined);
 
       if (discovered.length === 0) {
         log.info("No plugins found.");
         log.info(
-          "Install plugins in:\n" +
+          "Install a bundled plugin:  engram plugin install <name>\n" +
+            "Or place plugins manually in:\n" +
             "  ~/.local/share/engram/plugins/<name>/  (user-wide)\n" +
             "  .engram/plugins/<name>/                (project-local)",
         );
@@ -47,6 +131,7 @@ export function registerPlugin(program: Command): void {
         version: string;
         transport: string;
         scope: string;
+        source: string;
         status: string;
       }> = [];
 
@@ -58,6 +143,7 @@ export function registerPlugin(program: Command): void {
             version: manifest.version,
             transport: manifest.transport,
             scope: pd.scope,
+            source: pd.source,
             status: "OK",
           });
         } catch (err) {
@@ -66,6 +152,7 @@ export function registerPlugin(program: Command): void {
             version: "-",
             transport: "-",
             scope: pd.scope,
+            source: pd.source,
             status:
               err instanceof ManifestValidationError
                 ? `FAILED: ${err.message}`
@@ -75,11 +162,23 @@ export function registerPlugin(program: Command): void {
       }
 
       // Table formatting
-      const headers = ["NAME", "VERSION", "TRANSPORT", "SCOPE", "STATUS"];
+      const headers = [
+        "NAME",
+        "VERSION",
+        "TRANSPORT",
+        "SCOPE",
+        "SOURCE",
+        "STATUS",
+      ];
       const colWidths = headers.map((h, i) => {
-        const key = ["name", "version", "transport", "scope", "status"][
-          i
-        ] as keyof (typeof rows)[0];
+        const key = [
+          "name",
+          "version",
+          "transport",
+          "scope",
+          "source",
+          "status",
+        ][i] as keyof (typeof rows)[0];
         return Math.max(h.length, ...rows.map((r) => r[key].length));
       });
 
@@ -93,10 +192,188 @@ export function registerPlugin(program: Command): void {
         formatRow(headers),
         separator,
         ...rows.map((r) =>
-          formatRow([r.name, r.version, r.transport, r.scope, r.status]),
+          formatRow([
+            r.name,
+            r.version,
+            r.transport,
+            r.scope,
+            r.source,
+            r.status,
+          ]),
         ),
       ];
 
       process.stdout.write(`${lines.join("\n")}\n`);
     });
+}
+
+// ---------------------------------------------------------------------------
+// plugin install
+// ---------------------------------------------------------------------------
+
+interface PluginInstallOpts {
+  project?: string;
+  bundledRoot?: string; // internal override for tests
+}
+
+function registerInstall(plugin: Command): void {
+  plugin
+    .command("install <name>")
+    .description(
+      "Install a bundled first-party plugin into the XDG plugin directory " +
+        "(or project-local with --project)",
+    )
+    .option(
+      "--project <path>",
+      "install into <project>/.engram/plugins/ instead of user-wide",
+    )
+    .option("--bundled-root <path>", "override bundled plugins root (testing)")
+    .action(async (name: string, opts: PluginInstallOpts) => {
+      const root = opts.bundledRoot ?? bundledPluginsRoot();
+
+      if (!root) {
+        process.stderr.write(
+          "error: no bundled first-party plugins directory found\n" +
+            "  (packages/plugins/ was not found in the engram install root)\n" +
+            "  Ensure you are using a supported engram installation.\n",
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const available = listBundledPlugins(root);
+
+      if (!available.includes(name)) {
+        process.stderr.write(
+          `error: no bundled plugin named '${name}'; see \`engram plugin list --available\`\n`,
+        );
+        if (available.length > 0) {
+          process.stderr.write(`  Available: ${available.join(", ")}\n`);
+        } else {
+          process.stderr.write(
+            "  No bundled plugins are currently available.\n",
+          );
+        }
+        process.exitCode = 1;
+        return;
+      }
+
+      const src = path.join(root, name);
+      const destRoot = resolveDestRoot(opts.project);
+      const dest = path.join(destRoot, name);
+
+      if (fs.existsSync(dest)) {
+        process.stderr.write(
+          `error: plugin '${name}' is already installed at ${dest}\n` +
+            `  Run \`engram plugin uninstall ${name}\` first to reinstall.\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const method = installPlugin(src, dest);
+
+      log.success(
+        `Installed plugin '${name}' → ${dest} (${method === "symlink" ? "symlinked" : "copied"})`,
+      );
+    });
+}
+
+// ---------------------------------------------------------------------------
+// plugin uninstall
+// ---------------------------------------------------------------------------
+
+interface PluginUninstallOpts {
+  project?: string;
+  force?: boolean;
+  bundledRoot?: string; // internal override for tests
+}
+
+function registerUninstall(plugin: Command): void {
+  plugin
+    .command("uninstall <name>")
+    .description(
+      "Remove an installed plugin. " + "User-authored plugins require --force.",
+    )
+    .option(
+      "--project <path>",
+      "target project-local install (.engram/plugins/) instead of user-wide",
+    )
+    .option(
+      "--force",
+      "allow removal of user-authored (non-bundled, non-symlinked) plugins",
+    )
+    .option("--bundled-root <path>", "override bundled plugins root (testing)")
+    .action(async (name: string, opts: PluginUninstallOpts) => {
+      const destRoot = resolveDestRoot(opts.project);
+      const dest = path.join(destRoot, name);
+
+      if (!fs.existsSync(dest)) {
+        process.stderr.write(
+          `error: plugin '${name}' is not installed at ${dest}\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      // Determine how the plugin was installed
+      let stat: fs.Stats;
+      try {
+        stat = fs.lstatSync(dest);
+      } catch (err) {
+        process.stderr.write(
+          `error: cannot stat '${dest}': ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const isSymlink = stat.isSymbolicLink();
+
+      if (!isSymlink) {
+        // Plain directory — could be a bundled copy (Windows fallback) or user-authored.
+        // Without --force, only allow removal if it looks like a bundled copy.
+        const root = opts.bundledRoot ?? bundledPluginsRoot();
+        const available = root ? listBundledPlugins(root) : [];
+        const isBundledCopy = available.includes(name);
+
+        if (!isBundledCopy && !opts.force) {
+          process.stderr.write(
+            `error: '${name}' is a user-authored plugin and requires --force to remove.\n` +
+              `  Run: engram plugin uninstall ${name} --force\n`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+      }
+
+      // Remove: unlink for symlinks, rmdir for directories
+      try {
+        if (isSymlink) {
+          fs.unlinkSync(dest);
+        } else {
+          fs.rmSync(dest, { recursive: true, force: true });
+        }
+      } catch (err) {
+        process.stderr.write(
+          `error: failed to remove '${dest}': ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      log.success(`Uninstalled plugin '${name}' (removed ${dest})`);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerPlugin(program: Command): void {
+  const plugin = program.command("plugin").description("Manage engram plugins");
+
+  registerList(plugin);
+  registerInstall(plugin);
+  registerUninstall(plugin);
 }

--- a/packages/engram-cli/src/commands/plugin.ts
+++ b/packages/engram-cli/src/commands/plugin.ts
@@ -43,10 +43,12 @@ function installPlugin(src: string, dest: string): "symlink" | "copy" {
   fs.mkdirSync(path.dirname(dest), { recursive: true });
 
   try {
-    fs.symlinkSync(src, dest, "junction");
+    // Use "junction" only on Windows; POSIX directory symlinks use "dir"
+    const symlinkType = process.platform === "win32" ? "junction" : "dir";
+    fs.symlinkSync(src, dest, symlinkType);
     return "symlink";
   } catch {
-    // Fallback: recursive copy
+    // Fallback: recursive copy (common on Windows without elevated permissions)
     copyDir(src, dest);
     return "copy";
   }
@@ -91,9 +93,10 @@ function registerList(plugin: Command): void {
     .action(async (opts: PluginListOpts) => {
       const projectRoot = path.resolve(opts.project ?? ".");
 
-      // Show available bundled plugins if requested
+      const root = opts.bundledRoot ?? bundledPluginsRoot();
+
+      // Show available bundled plugins section when --available is requested
       if (opts.available) {
-        const root = opts.bundledRoot ?? bundledPluginsRoot();
         const available = listBundledPlugins(root ?? undefined);
         if (available.length === 0) {
           log.info(
@@ -106,13 +109,11 @@ function registerList(plugin: Command): void {
             process.stdout.write(`  ${name}\n`);
           }
           process.stdout.write(
-            "\nInstall with: engram plugin install <name>\n",
+            "\nInstall with: engram plugin install <name>\n\n",
           );
         }
-        return;
+        // Fall through to also show installed plugins below
       }
-
-      const root = opts.bundledRoot ?? bundledPluginsRoot();
       const discovered = discoverPlugins(projectRoot, root ?? undefined);
 
       if (discovered.length === 0) {
@@ -258,9 +259,18 @@ function registerInstall(plugin: Command): void {
         return;
       }
 
-      const src = path.join(root, name);
-      const destRoot = resolveDestRoot(opts.project);
+      const src = path.resolve(path.join(root, name));
+      const destRoot = path.resolve(resolveDestRoot(opts.project));
       const dest = path.join(destRoot, name);
+
+      // Guard against path traversal in `name`
+      if (!dest.startsWith(destRoot + path.sep)) {
+        process.stderr.write(
+          `error: plugin name '${name}' is invalid (path traversal detected)\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
 
       if (fs.existsSync(dest)) {
         process.stderr.write(
@@ -305,8 +315,17 @@ function registerUninstall(plugin: Command): void {
     )
     .option("--bundled-root <path>", "override bundled plugins root (testing)")
     .action(async (name: string, opts: PluginUninstallOpts) => {
-      const destRoot = resolveDestRoot(opts.project);
+      const destRoot = path.resolve(resolveDestRoot(opts.project));
       const dest = path.join(destRoot, name);
+
+      // Guard against path traversal in `name`
+      if (!dest.startsWith(destRoot + path.sep)) {
+        process.stderr.write(
+          `error: plugin name '${name}' is invalid (path traversal detected)\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
 
       if (!fs.existsSync(dest)) {
         process.stderr.write(

--- a/packages/engram-cli/test/commands/plugin.test.ts
+++ b/packages/engram-cli/test/commands/plugin.test.ts
@@ -1,0 +1,676 @@
+/**
+ * plugin.test.ts — Tests for `engram plugin` subcommands.
+ *
+ * Tests install, uninstall, collision, missing-source, and project-vs-user scope.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { registerPlugin } from "../../src/commands/plugin.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProgram(): Command {
+  const program = new Command().exitOverride();
+  registerPlugin(program);
+  return program;
+}
+
+async function captureOutput(
+  fn: () => Promise<void> | void,
+): Promise<{ stdout: string; stderr: string }> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  const origStdoutWrite = process.stdout.write.bind(process.stdout);
+  const origStderrWrite = process.stderr.write.bind(process.stderr);
+
+  process.stdout.write = (chunk: string | Uint8Array, ...args: unknown[]) => {
+    stdoutChunks.push(
+      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
+    );
+    return origStdoutWrite(
+      chunk,
+      ...(args as Parameters<typeof process.stdout.write>).slice(1),
+    );
+  };
+
+  process.stderr.write = (chunk: string | Uint8Array, ...args: unknown[]) => {
+    stderrChunks.push(
+      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
+    );
+    return origStderrWrite(
+      chunk,
+      ...(args as Parameters<typeof process.stderr.write>).slice(1),
+    );
+  };
+
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = origStdoutWrite;
+    process.stderr.write = origStderrWrite;
+  }
+
+  return { stdout: stdoutChunks.join(""), stderr: stderrChunks.join("") };
+}
+
+function makeTmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+/**
+ * Creates a fake bundled plugins root with the given plugin names.
+ * Each plugin gets a minimal manifest.json so install → loadManifest works.
+ */
+function makeBundledRoot(names: string[]): string {
+  const bundledRoot = makeTmpDir("engram-bundled-plugins-");
+  for (const name of names) {
+    const pluginDir = path.join(bundledRoot, name);
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "manifest.json"),
+      JSON.stringify({
+        name,
+        version: "0.1.0",
+        contract_version: 1,
+        transport: "js-module",
+        entry: "index.js",
+        capabilities: {
+          supported_auth: ["none"],
+          supports_cursor: true,
+          scope_schema: { description: "project name", pattern: ".*" },
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "// stub");
+  }
+  return bundledRoot;
+}
+
+/**
+ * Returns the XDG user plugins root, overriding XDG_DATA_HOME for isolation.
+ * Call restoreXdg() after each test.
+ */
+function overrideXdgUserDir(): { xdgRoot: string; restoreXdg: () => void } {
+  const xdgRoot = makeTmpDir("engram-xdg-");
+  const prev = process.env.XDG_DATA_HOME;
+  process.env.XDG_DATA_HOME = xdgRoot;
+  const restoreXdg = () => {
+    if (prev === undefined) delete process.env.XDG_DATA_HOME;
+    else process.env.XDG_DATA_HOME = prev;
+  };
+  return { xdgRoot, restoreXdg };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("plugin list", () => {
+  it("shows 'No plugins found' when no plugins are installed", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const projectDir = makeTmpDir("engram-proj-");
+    try {
+      const program = makeProgram();
+      const _infoMsg = "";
+      // Capture @clack/prompts log.info by patching stdout
+      const { stdout } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "list",
+            "--project",
+            projectDir,
+          ]);
+        } catch {
+          // exitOverride throws on exit
+        }
+      });
+      // Should not output a table row
+      expect(stdout).not.toContain("NAME");
+    } finally {
+      restoreXdg();
+      fs.rmSync(projectDir, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("shows installed plugins with source column", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["my-plugin"]);
+
+    try {
+      // Simulate an installed (symlinked) plugin in user plugins dir
+      const userPluginsDir = path.join(xdgRoot, "engram", "plugins");
+      fs.mkdirSync(userPluginsDir, { recursive: true });
+      const src = path.join(bundledRoot, "my-plugin");
+      const dest = path.join(userPluginsDir, "my-plugin");
+      fs.symlinkSync(src, dest, "junction");
+
+      const projectDir = makeTmpDir("engram-proj-");
+      const program = makeProgram();
+      const { stdout } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "list",
+            "--project",
+            projectDir,
+            "--bundled-root",
+            bundledRoot,
+          ] as string[]);
+        } catch {
+          // exitOverride throws
+        }
+      });
+
+      expect(stdout).toContain("NAME");
+      expect(stdout).toContain("SOURCE");
+      expect(stdout).toContain("my-plugin");
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("shows available bundled plugins with --available", async () => {
+    const bundledRoot = makeBundledRoot(["gerrit", "gitlab"]);
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+
+    try {
+      const program = makeProgram();
+      const { stdout } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "list",
+            "--available",
+            "--bundled-root",
+            bundledRoot,
+          ] as string[]);
+        } catch {
+          // exitOverride
+        }
+      });
+      expect(stdout).toContain("gerrit");
+      expect(stdout).toContain("gitlab");
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("plugin install", () => {
+  it("installs a bundled plugin into user plugins dir (symlink)", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["gerrit"]);
+
+    try {
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "install",
+            "gerrit",
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(stderr).toBe("");
+      const destDir = path.join(xdgRoot, "engram", "plugins", "gerrit");
+      expect(fs.existsSync(destDir)).toBe(true);
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("installs into project-local dir with --project", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["gerrit"]);
+    const projectDir = makeTmpDir("engram-proj-");
+
+    try {
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "install",
+            "gerrit",
+            "--bundled-root",
+            bundledRoot,
+            "--project",
+            projectDir,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(stderr).toBe("");
+      const destDir = path.join(projectDir, ".engram", "plugins", "gerrit");
+      expect(fs.existsSync(destDir)).toBe(true);
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(projectDir, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("exits non-zero for a non-existent bundled plugin", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["gerrit"]);
+
+    try {
+      const _prevExitCode = process.exitCode;
+      process.exitCode = undefined;
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "install",
+            "nonexistent",
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(stderr).toContain("nonexistent");
+      expect(stderr).toContain("engram plugin list --available");
+
+      process.exitCode = 0;
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("exits non-zero when no bundled plugins root is found", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    // Use a non-existent bundled root
+    const fakeBundledRoot = path.join(os.tmpdir(), "does-not-exist-xyzxyz");
+
+    try {
+      const _prevExitCode = process.exitCode;
+      process.exitCode = undefined;
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "install",
+            "gerrit",
+            "--bundled-root",
+            fakeBundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      // When bundled root doesn't exist, listBundledPlugins returns [] so
+      // install treats as "no bundled plugin named X"
+      expect(process.exitCode).toBe(1);
+      expect(stderr).toContain("gerrit");
+
+      process.exitCode = 0;
+    } finally {
+      restoreXdg();
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("exits non-zero when plugin is already installed (collision)", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["gerrit"]);
+
+    try {
+      const _prevExitCode = process.exitCode;
+      process.exitCode = undefined;
+
+      // Pre-create the dest directory to simulate an existing install
+      const destDir = path.join(xdgRoot, "engram", "plugins", "gerrit");
+      fs.mkdirSync(destDir, { recursive: true });
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "install",
+            "gerrit",
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(stderr).toContain("already installed");
+
+      process.exitCode = 0;
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("plugin uninstall", () => {
+  it("removes a symlinked (bundled) plugin without --force", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["gerrit"]);
+
+    try {
+      // Install first
+      const userPluginsDir = path.join(xdgRoot, "engram", "plugins");
+      fs.mkdirSync(userPluginsDir, { recursive: true });
+      const src = path.join(bundledRoot, "gerrit");
+      const dest = path.join(userPluginsDir, "gerrit");
+      fs.symlinkSync(src, dest, "junction");
+
+      expect(fs.existsSync(dest)).toBe(true);
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "uninstall",
+            "gerrit",
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(stderr).toBe("");
+      // After uninstall the dest should not exist
+      // (lstatSync won't follow symlinks, so even if src still exists, dest is gone)
+      let destExists = false;
+      try {
+        fs.lstatSync(dest);
+        destExists = true;
+      } catch {
+        // not found = good
+      }
+      expect(destExists).toBe(false);
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("removes a bundled-copy (non-symlink) plugin listed in bundled root", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["gerrit"]);
+
+    try {
+      // Simulate Windows-style copy (plain directory, not a symlink)
+      const userPluginsDir = path.join(xdgRoot, "engram", "plugins", "gerrit");
+      fs.mkdirSync(userPluginsDir, { recursive: true });
+      fs.writeFileSync(path.join(userPluginsDir, "manifest.json"), "{}");
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "uninstall",
+            "gerrit",
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(stderr).toBe("");
+      expect(
+        fs.existsSync(path.join(xdgRoot, "engram", "plugins", "gerrit")),
+      ).toBe(false);
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("exits non-zero for user-authored plugin without --force", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot([]); // empty bundled root
+
+    try {
+      const _prevExitCode = process.exitCode;
+      process.exitCode = undefined;
+
+      // A user-authored plugin (plain dir, not in bundled root)
+      const userPluginsDir = path.join(
+        xdgRoot,
+        "engram",
+        "plugins",
+        "my-custom",
+      );
+      fs.mkdirSync(userPluginsDir, { recursive: true });
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "uninstall",
+            "my-custom",
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(stderr).toContain("--force");
+      // Dir should still exist
+      expect(fs.existsSync(userPluginsDir)).toBe(true);
+
+      process.exitCode = 0;
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("removes user-authored plugin with --force", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot([]); // empty bundled root
+
+    try {
+      const userPluginsDir = path.join(
+        xdgRoot,
+        "engram",
+        "plugins",
+        "my-custom",
+      );
+      fs.mkdirSync(userPluginsDir, { recursive: true });
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "uninstall",
+            "my-custom",
+            "--force",
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(stderr).toBe("");
+      expect(fs.existsSync(userPluginsDir)).toBe(false);
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("exits non-zero when plugin is not installed", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["gerrit"]);
+
+    try {
+      const _prevExitCode = process.exitCode;
+      process.exitCode = undefined;
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "uninstall",
+            "gerrit",
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(stderr).toContain("not installed");
+
+      process.exitCode = 0;
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uninstalls from project-local scope with --project", async () => {
+    const { xdgRoot, restoreXdg } = overrideXdgUserDir();
+    const bundledRoot = makeBundledRoot(["gerrit"]);
+    const projectDir = makeTmpDir("engram-proj-");
+
+    try {
+      // Install into project-local
+      const projPluginsDir = path.join(
+        projectDir,
+        ".engram",
+        "plugins",
+        "gerrit",
+      );
+      fs.mkdirSync(projPluginsDir, { recursive: true });
+      fs.symlinkSync(
+        path.join(bundledRoot, "gerrit"),
+        `${projPluginsDir}-link`,
+        "junction",
+      );
+      // Recreate as symlink
+      fs.rmdirSync(projPluginsDir);
+      fs.symlinkSync(
+        path.join(bundledRoot, "gerrit"),
+        projPluginsDir,
+        "junction",
+      );
+
+      const program = makeProgram();
+      const { stderr } = await captureOutput(async () => {
+        try {
+          await program.parseAsync([
+            "node",
+            "engram",
+            "plugin",
+            "uninstall",
+            "gerrit",
+            "--project",
+            projectDir,
+            "--bundled-root",
+            bundledRoot,
+          ]);
+        } catch {
+          // exitOverride
+        }
+      });
+
+      expect(stderr).toBe("");
+      let destExists = false;
+      try {
+        fs.lstatSync(projPluginsDir);
+        destExists = true;
+      } catch {
+        // not found
+      }
+      expect(destExists).toBe(false);
+    } finally {
+      restoreXdg();
+      fs.rmSync(bundledRoot, { recursive: true, force: true });
+      fs.rmSync(projectDir, { recursive: true, force: true });
+      fs.rmSync(xdgRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/engram-core/src/plugins/discover.ts
+++ b/packages/engram-core/src/plugins/discover.ts
@@ -11,14 +11,30 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 
+/**
+ * How a plugin arrived in the plugins directory.
+ *
+ * - `bundled`   — a first-party plugin installed via `engram plugin install`
+ *                 (symlink or copy pointing into the engram install root)
+ * - `symlinked` — a user-created symlink to an external directory
+ * - `user`      — a plain directory created by the user (no symlink)
+ */
+export type PluginSource = "bundled" | "symlinked" | "user";
+
 export interface PluginDirectory {
   name: string;
   dir: string;
   /** 'project' | 'user' — project-local takes precedence on name collision */
   scope: "project" | "user";
+  /** How the plugin was installed */
+  source: PluginSource;
 }
 
-function xdgDataHome(): string {
+/**
+ * Returns the platform-appropriate XDG data home for engram.
+ * Exported so install/uninstall logic can use the same path resolution.
+ */
+export function xdgDataHome(): string {
   if (process.platform === "win32") {
     return path.join(
       process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local"),
@@ -31,9 +47,62 @@ function xdgDataHome(): string {
   );
 }
 
+/**
+ * Returns the XDG plugins root directory (user-wide).
+ */
+export function userPluginsRoot(): string {
+  return path.join(xdgDataHome(), "plugins");
+}
+
+/**
+ * Returns the project-local plugins root directory.
+ */
+export function projectPluginsRoot(projectRoot: string): string {
+  return path.join(projectRoot, ".engram", "plugins");
+}
+
+/**
+ * Detects whether an installed plugin directory is bundled (symlink to engram
+ * install root), a user symlink, or a plain user directory.
+ */
+function detectSource(dir: string, bundledPluginsRoot?: string): PluginSource {
+  let realTarget: string | null = null;
+  try {
+    const stat = fs.lstatSync(dir);
+    if (stat.isSymbolicLink()) {
+      realTarget = fs.realpathSync(dir);
+    }
+  } catch {
+    // Cannot stat — treat as user
+  }
+
+  if (realTarget !== null) {
+    // It's a symlink. Bundled means the target is inside the bundled plugins root.
+    if (bundledPluginsRoot) {
+      const realBundled = (() => {
+        try {
+          return fs.realpathSync(bundledPluginsRoot);
+        } catch {
+          return bundledPluginsRoot;
+        }
+      })();
+      if (
+        realTarget === realBundled ||
+        realTarget.startsWith(realBundled + path.sep)
+      ) {
+        return "bundled";
+      }
+    }
+    return "symlinked";
+  }
+
+  return "user";
+}
+
 function listPluginsIn(
   base: string,
   scope: "project" | "user",
+  bundledPluginsRoot?: string,
 ): PluginDirectory[] {
   const pluginsRoot = path.join(base, "plugins");
   if (!fs.existsSync(pluginsRoot)) return [];
@@ -46,24 +115,36 @@ function listPluginsIn(
   }
 
   return entries
-    .filter((e) => e.isDirectory())
-    .map((e) => ({
-      name: e.name,
-      dir: path.join(pluginsRoot, e.name),
-      scope,
-    }));
+    .filter((e) => e.isDirectory() || e.isSymbolicLink())
+    .map((e) => {
+      const dir = path.join(pluginsRoot, e.name);
+      return {
+        name: e.name,
+        dir,
+        scope,
+        source: detectSource(dir, bundledPluginsRoot),
+      };
+    });
 }
 
 /**
  * Discovers all installed plugin directories.
  *
  * @param projectRoot - optional path to project root containing .engram/
+ * @param bundledPluginsRoot - optional path to bundled plugins directory (for source detection)
  * @returns Deduplicated list of PluginDirectory, project-local wins on name collision.
  */
-export function discoverPlugins(projectRoot?: string): PluginDirectory[] {
-  const user = listPluginsIn(xdgDataHome(), "user");
+export function discoverPlugins(
+  projectRoot?: string,
+  bundledPluginsRoot?: string,
+): PluginDirectory[] {
+  const user = listPluginsIn(xdgDataHome(), "user", bundledPluginsRoot);
   const project = projectRoot
-    ? listPluginsIn(path.join(projectRoot, ".engram"), "project")
+    ? listPluginsIn(
+        path.join(projectRoot, ".engram"),
+        "project",
+        bundledPluginsRoot,
+      )
     : [];
 
   // Build map: name → entry, project-local overrides user on collision
@@ -72,4 +153,70 @@ export function discoverPlugins(projectRoot?: string): PluginDirectory[] {
   for (const p of project) byName.set(p.name, p);
 
   return Array.from(byName.values());
+}
+
+/**
+ * Returns the path to the bundled first-party plugins directory.
+ *
+ * In a development monorepo, looks for `packages/plugins/` relative to the
+ * directory two levels up from this file's location (i.e., the monorepo root).
+ *
+ * In a production install, looks for a `plugins/` directory sibling of the
+ * binary's parent directory.
+ *
+ * Returns null if no bundled plugins directory is found.
+ */
+export function bundledPluginsRoot(): string | null {
+  // Dev: __dirname is packages/engram-core/src/plugins/
+  // Go up to monorepo root: ../../../../
+  const candidates: string[] = [];
+
+  // Walk up from this file looking for a packages/plugins/ dir
+  let dir = path.dirname(
+    typeof __dirname !== "undefined" ? __dirname : process.cwd(),
+  );
+  for (let i = 0; i < 8; i++) {
+    const candidate = path.join(dir, "packages", "plugins");
+    candidates.push(candidate);
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  // Also check sibling of process.execPath's parent (production install)
+  if (process.execPath) {
+    const execDir = path.dirname(process.execPath);
+    candidates.push(path.join(execDir, "..", "plugins"));
+    candidates.push(path.join(execDir, "plugins"));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const stat = fs.statSync(candidate);
+      if (stat.isDirectory()) return candidate;
+    } catch {
+      // not found, try next
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Lists available bundled (first-party) plugins.
+ * Returns plugin names found in the bundled plugins root.
+ * Returns an empty array if no bundled plugins directory exists.
+ */
+export function listBundledPlugins(root?: string): string[] {
+  const bundledRoot = root ?? bundledPluginsRoot();
+  if (!bundledRoot) return [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(bundledRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
 }

--- a/packages/engram-core/src/plugins/index.ts
+++ b/packages/engram-core/src/plugins/index.ts
@@ -2,8 +2,15 @@
  * plugins/index.ts — barrel export for the plugin loader module.
  */
 
-export type { PluginDirectory } from "./discover.js";
-export { discoverPlugins } from "./discover.js";
+export type { PluginDirectory, PluginSource } from "./discover.js";
+export {
+  bundledPluginsRoot,
+  discoverPlugins,
+  listBundledPlugins,
+  projectPluginsRoot,
+  userPluginsRoot,
+  xdgDataHome,
+} from "./discover.js";
 export type {
   PluginCapabilities,
   PluginManifest,


### PR DESCRIPTION
## Summary

- Adds `engram plugin install <name>` subcommand that symlinks (or copies on Windows) a bundled first-party plugin from the engram install root into the XDG user-wide plugin directory (`$XDG_DATA_HOME/engram/plugins/`) or project-local (`.engram/plugins/`) with `--project`
- Adds `engram plugin uninstall <name>` that removes symlinked/bundled installs freely, but requires `--force` for user-authored (plain-directory) plugins
- Extends `engram plugin list` with a **SOURCE** column (`bundled` / `symlinked` / `user`) and a `--available` flag to list installable bundled plugins
- Extends `engram-core/plugins/discover.ts` with exported helpers: `xdgDataHome`, `userPluginsRoot`, `projectPluginsRoot`, `bundledPluginsRoot`, `listBundledPlugins`
- Updates README.md plugin section with install/uninstall flow and SOURCE column documentation

## Acceptance Criteria

- [x] `engram plugin install gerrit` creates a valid XDG entry (symlink) — works once `packages/plugins/gerrit/` exists; the mechanism is fully implemented
- [x] `engram plugin install nonexistent` exits non-zero with `"no bundled plugin named 'nonexistent'; see \`engram plugin list --available\`"`
- [x] `engram plugin uninstall gerrit` reverses the install (removes symlink or bundled-copy directory)
- [x] `engram plugin uninstall <user-authored>` exits non-zero without `--force`
- [x] `engram plugin list` shows SOURCE column distinguishing bundled/symlinked/user installs
- [x] `--project` flag installs into `.engram/plugins/` (project-local, higher precedence per ADR-006)
- [x] Works on Linux/macOS (symlink); Windows fallback to recursive copy when symlink fails
- [x] README.md plugin section updated with install/uninstall flow
- [x] Tests cover install, uninstall, collision (already installed), missing-source, user-authored guard, and project-vs-user scope (14 tests)

## Test plan

- [x] `bun test packages/engram-cli/test/commands/plugin.test.ts` — 14 pass, 0 fail
- [x] `bun run build` — clean build
- [x] `bun run lint` — no errors

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)