### PR TITLE
feat(ingest): migrate Gerrit adapter to in-repo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ discussions, review comments, linked issues, rationale behind decisions.
 | Source | Status | Scope flag | Notes |
 |---|---|---|---|
 | GitHub | Built-in | `--scope owner/repo` | Public works without a token. |
-| Gerrit | Built-in | `--scope <project>` | Basic or bearer auth; `--endpoint <url>`. |
+| Gerrit | Plugin | `--scope <project>` | Basic or bearer auth; `--endpoint <url>`. Install via `engram plugin install gerrit`. |
 | GitLab | Planned | — | — |
 | Jira | Planned | — | — |
 | Linear | Planned | — | — |
@@ -227,7 +227,8 @@ engram ingest enrich github --scope owner/repo
 # GitHub (private or high-rate-limit)
 engram ingest enrich github --scope owner/repo --token $GITHUB_TOKEN
 
-# Gerrit
+# Gerrit (install the plugin first)
+engram plugin install gerrit
 engram ingest enrich gerrit --scope chromium/src \
   --endpoint https://gerrit-review.googlesource.com \
   --username alice --password $GERRIT_PASSWORD
@@ -301,9 +302,13 @@ engram export wiki --out ./wiki
 
 ## Plugins
 
-Engram ships with GitHub and Gerrit adapters. Anything else — GitLab, Jira,
-Linear, a proprietary review system, a custom knowledge source — can live
-as a plugin without forking engram.
+Engram ships with a GitHub built-in adapter and a Gerrit first-party plugin.
+Anything else — GitLab, Jira, Linear, a proprietary review system, a custom
+knowledge source — can live as a plugin without forking engram.
+
+The Gerrit adapter (`packages/plugins/gerrit/`) is the reference implementation
+for the plugin contract (ADR-008) — proof that the contract is adequate for a
+full-featured first-party adapter.
 
 ### Discovery
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "engram",
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "packages/plugins/*"
   ],
   "scripts": {
     "build": "bun run --filter '*' build",

--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -25,7 +25,6 @@ import type {
 import {
   closeGraph,
   EnrichmentAdapterError,
-  GerritAdapter,
   GitHubAdapter,
   ingestGitRepo,
   ingestMarkdown,
@@ -563,125 +562,6 @@ See also:
       );
     } catch (err) {
       s.stop("GitHub enrichment failed");
-      handleEnrichError(err, adapter.name, adapter.supportedAuth);
-      closeGraph(graph);
-      process.exit(1);
-    }
-
-    closeGraph(graph);
-    if (process.stdout.isTTY) outro("Done");
-  });
-
-  // ---------------------------------------------------------------------------
-  // ingest enrich gerrit
-  // ---------------------------------------------------------------------------
-
-  addEnrichFlags(
-    enrich
-      .command("gerrit")
-      .description("Enrich with Gerrit code review changes")
-      .addHelpText(
-        "after",
-        `
-Auth flags (select based on your setup):
-  --token <token>                  Bearer token (or set GERRIT_TOKEN)
-  --username <u> --password <p>    HTTP Basic auth (or set GERRIT_USERNAME / GERRIT_PASSWORD)
-
-Scope:
-  --scope <project>      Gerrit project name (e.g. 'chromium/src')
-
-Examples:
-  # Enrich using HTTP Basic auth
-  engram ingest enrich gerrit --scope chromium/src --username alice --password s3cr3t
-
-  # Enrich a public Gerrit instance (no auth)
-  engram ingest enrich gerrit --scope myproject
-
-  # Specify a custom Gerrit endpoint
-  engram ingest enrich gerrit --scope myproject --endpoint https://gerrit.example.com
-
-When to use:
-  Run after engram ingest git to add Gerrit code-review discussions.
-
-See also:
-  engram ingest git    Ingest git history first`,
-      )
-      .option(
-        "--endpoint <url>",
-        "Gerrit base URL (default: https://gerrit-review.googlesource.com)",
-      ),
-  ).action(async (opts: IngestEnrichOpts & { endpoint?: string }) => {
-    if (process.stdout.isTTY) intro("engram ingest enrich gerrit");
-
-    // Handle deprecated --repo alias
-    if (opts.repo && !opts.scope) {
-      console.warn("Warning: --repo is deprecated, use --scope instead.");
-      opts.scope = opts.repo;
-    }
-
-    const adapter = new GerritAdapter();
-
-    // Build auth credential from flags/env
-    let auth: ReturnType<typeof buildAuthCredential>;
-    try {
-      auth = buildAuthCredential(opts, adapter.name, adapter.supportedAuth);
-    } catch (err) {
-      log.error(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-
-    // Validate scope before opening graph
-    if (!opts.scope) {
-      log.error(
-        `--scope is required for gerrit adapter.\n${adapter.scopeSchema.description}`,
-      );
-      process.exit(1);
-    }
-    try {
-      adapter.scopeSchema.validate(opts.scope);
-    } catch (err) {
-      log.error(
-        `Invalid scope for gerrit: ${err instanceof Error ? err.message : String(err)}\n${adapter.scopeSchema.description}`,
-      );
-      process.exit(1);
-    }
-
-    if (opts.verbose) {
-      log.info(`Auth: ${auth.kind}`);
-    }
-
-    const dbPath = resolveDbPath(path.resolve(opts.db));
-    let graph: EngramGraph | undefined;
-    try {
-      graph = openGraph(dbPath);
-    } catch (err) {
-      log.error(
-        `Cannot open graph: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      process.exit(1);
-    }
-
-    const s = spinner();
-    s.start(`Fetching from Gerrit (${opts.scope})`);
-
-    try {
-      const result = await adapter.enrich(graph, {
-        auth,
-        scope: opts.scope,
-        since: opts.since,
-        dryRun: opts.dryRun,
-        endpoint: opts.endpoint,
-      });
-      s.stop("Gerrit enrichment complete");
-      log.info(
-        [
-          `Episodes: ${result.episodesCreated} created, ${result.episodesSkipped} skipped`,
-          `Entities: ${result.entitiesCreated} created`,
-          `Edges:    ${result.edgesCreated} created`,
-        ].join("\n"),
-      );
-    } catch (err) {
-      s.stop("Gerrit enrichment failed");
       handleEnrichError(err, adapter.name, adapter.supportedAuth);
       closeGraph(graph);
       process.exit(1);

--- a/packages/engram-cli/test/ingest/ingest-v2.test.ts
+++ b/packages/engram-cli/test/ingest/ingest-v2.test.ts
@@ -315,7 +315,7 @@ describe("auth-kind mismatch does not call enrich()", () => {
 // ---------------------------------------------------------------------------
 
 describe("ingest enrich command registration", () => {
-  it("registers gerrit as an enrich subcommand", async () => {
+  it("registers github as an enrich subcommand (gerrit is now a plugin)", async () => {
     const { registerIngest } = await import("../../src/commands/ingest.js");
     const program = new Command().exitOverride();
     registerIngest(program);
@@ -330,7 +330,10 @@ describe("ingest enrich command registration", () => {
 
     const subNames = enrich.commands.map((c) => c.name());
     expect(subNames).toContain("github");
-    expect(subNames).toContain("gerrit");
+    // gerrit is no longer a hardcoded built-in subcommand — it is now a plugin
+    // discovered from packages/plugins/gerrit/ and auto-registered at runtime
+    // when installed via `engram plugin install gerrit`.
+    expect(subNames).not.toContain("gerrit");
   });
 
   it("github enrich subcommand has --scope flag", async () => {

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -152,10 +152,6 @@ export {
   EnrichmentAdapterError,
 } from "./ingest/adapter.js";
 export {
-  GerritAdapter,
-  gerritScopeSchema,
-} from "./ingest/adapters/gerrit.js";
-export {
   GitHubAdapter,
   GitHubAuthError,
   githubScopeSchema,

--- a/packages/engram-core/test/ingest/adapter-contract.test.ts
+++ b/packages/engram-core/test/ingest/adapter-contract.test.ts
@@ -6,9 +6,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { GerritAdapter } from "../../../plugins/gerrit/src/index.js";
 import type { EnrichmentAdapter } from "../../src/ingest/adapter.js";
 import { EnrichmentAdapterError } from "../../src/ingest/adapter.js";
-import { GerritAdapter } from "../../src/ingest/adapters/gerrit.js";
 import {
   GitHubAdapter,
   GitHubAuthError,

--- a/packages/plugins/gerrit/manifest.json
+++ b/packages/plugins/gerrit/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "gerrit",
+  "version": "0.1.0",
+  "contract_version": 1,
+  "transport": "js-module",
+  "entry": "src/index.ts",
+  "capabilities": {
+    "supported_auth": ["bearer", "basic", "none"],
+    "supports_cursor": true,
+    "scope_schema": {
+      "description": "Gerrit project name (e.g. 'my-project' or 'org/sub-project')",
+      "pattern": "^[^/][^/]*(/[^/]+)*[^/]$|^[^/]$"
+    }
+  }
+}

--- a/packages/plugins/gerrit/package.json
+++ b/packages/plugins/gerrit/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@engram/plugin-gerrit",
+  "version": "0.1.0",
+  "description": "Gerrit enrichment adapter for engram (in-repo plugin)",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "echo 'plugin: no build step required'",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "engram-core": "workspace:*",
+    "ulid": "^2.3.0"
+  }
+}

--- a/packages/plugins/gerrit/src/helpers.ts
+++ b/packages/plugins/gerrit/src/helpers.ts
@@ -1,25 +1,26 @@
 /**
- * gerrit-helpers.ts — Internal helpers for the Gerrit enrichment adapter.
+ * helpers.ts — Internal helpers for the Gerrit enrichment adapter.
  *
- * Extracted to keep gerrit.ts under 500 lines. Not part of the public API.
+ * Ported from packages/engram-core/src/ingest/adapters/gerrit-helpers.ts
+ * into the in-repo plugin package.
  */
 
-import { ulid } from "ulid";
-import type { EngramGraph } from "../../format/index.js";
-import { ENGINE_VERSION } from "../../format/version.js";
-import { addEntityAlias, resolveEntity } from "../../graph/aliases.js";
-import { addEdge } from "../../graph/edges.js";
-import { addEntity, type EvidenceInput } from "../../graph/entities.js";
-import { addEpisode } from "../../graph/episodes.js";
+import type { EngramGraph, EvidenceInput, IngestResult } from "engram-core";
 import {
+  addEdge,
+  addEntity,
+  addEntityAlias,
+  addEpisode,
+  ENGINE_VERSION,
   ENTITY_TYPES,
+  EnrichmentAdapterError,
   EPISODE_SOURCE_TYPES,
   INGESTION_SOURCE_TYPES,
   RELATION_TYPES,
-} from "../../vocab/index.js";
-import { EnrichmentAdapterError } from "../adapter.js";
-import { writeCursor } from "../cursor.js";
-import type { IngestResult } from "../git.js";
+  resolveEntity,
+  writeCursor,
+} from "engram-core";
+import { ulid } from "ulid";
 
 // ---------------------------------------------------------------------------
 // Internal types (Gerrit REST API shapes — only fields we use)

--- a/packages/plugins/gerrit/src/index.ts
+++ b/packages/plugins/gerrit/src/index.ts
@@ -33,7 +33,6 @@ import {
   createIngestionRun,
   type FetchFn,
   failIngestionRun,
-  GerritAuthError,
   ingestChange,
   PAGE_SIZE,
 } from "./helpers.js";
@@ -204,10 +203,6 @@ export class GerritAdapter implements EnrichmentAdapter {
     }
   }
 }
-
-// Suppress unused import warning — GerritAuthError is re-exported above and
-// used internally by apiGet in helpers.ts.
-void GerritAuthError;
 
 // Default export required by the js-module plugin transport contract.
 export default new GerritAdapter();

--- a/packages/plugins/gerrit/src/index.ts
+++ b/packages/plugins/gerrit/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * gerrit.ts — Gerrit enrichment adapter.
+ * index.ts — Gerrit enrichment adapter (in-repo plugin).
  *
  * Fetches code-review changes from the Gerrit REST API and ingests them into
  * an EngramGraph. Uses ingestion_runs cursors (offset-based) for resumability.
@@ -8,22 +8,25 @@
  * Token is NEVER written to the graph.
  *
  * Note: Gerrit prefixes all JSON responses with ")]}'\n" for XSSI protection.
- * This adapter strips the prefix before parsing (handled in gerrit-helpers.ts).
+ * This adapter strips the prefix before parsing (handled in helpers.ts).
  *
- * Internal helpers live in gerrit-helpers.ts.
+ * Default export: GerritAdapter instance (required by js-module plugin contract).
  */
 
-import type { EngramGraph } from "../../format/index.js";
-import { INGESTION_SOURCE_TYPES } from "../../vocab/index.js";
 import type {
   AuthCredential,
+  EngramGraph,
   EnrichmentAdapter,
   EnrichOpts,
+  IngestResult,
   ScopeSchema,
-} from "../adapter.js";
-import { applyCompatShim, assertAuthKind } from "../adapter.js";
-import { readNumericCursor } from "../cursor.js";
-import type { IngestResult } from "../git.js";
+} from "engram-core";
+import {
+  applyCompatShim,
+  assertAuthKind,
+  INGESTION_SOURCE_TYPES,
+  readNumericCursor,
+} from "engram-core";
 import {
   apiGet,
   completeIngestionRun,
@@ -33,9 +36,9 @@ import {
   GerritAuthError,
   ingestChange,
   PAGE_SIZE,
-} from "./gerrit-helpers.js";
+} from "./helpers.js";
 
-export { GerritAuthError } from "./gerrit-helpers.js";
+export { GerritAuthError } from "./helpers.js";
 
 // ---------------------------------------------------------------------------
 // Scope schema
@@ -203,5 +206,8 @@ export class GerritAdapter implements EnrichmentAdapter {
 }
 
 // Suppress unused import warning — GerritAuthError is re-exported above and
-// used internally by apiGet in gerrit-helpers.ts.
+// used internally by apiGet in helpers.ts.
 void GerritAuthError;
+
+// Default export required by the js-module plugin transport contract.
+export default new GerritAdapter();

--- a/packages/plugins/gerrit/test/gerrit.test.ts
+++ b/packages/plugins/gerrit/test/gerrit.test.ts
@@ -1,18 +1,19 @@
 /**
- * gerrit.test.ts — Tests for GerritAdapter with mocked fetch.
+ * gerrit.test.ts — Tests for the Gerrit plugin adapter with mocked fetch.
  *
  * All tests use mock fetch — no real Gerrit API calls are made.
+ * Ported from packages/engram-core/test/ingest/gerrit.test.ts.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { resolveEntity } from "../../src/graph/aliases.js";
+import type { EngramGraph } from "engram-core";
 import {
   closeGraph,
   createGraph,
-  type EngramGraph,
+  resolveEntity,
   verifyGraph,
-} from "../../src/index.js";
-import { GerritAdapter } from "../../src/ingest/adapters/gerrit.js";
+} from "engram-core";
+import { GerritAdapter } from "../src/index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

- Moves `GerritAdapter` from `packages/engram-core/src/ingest/adapters/` to `packages/plugins/gerrit/` as the reference implementation of ADR-008
- `engram-core` no longer imports or exports Gerrit-specific code
- The hardcoded `engram ingest enrich gerrit` CLI subcommand is removed; Gerrit is now auto-registered via the plugin loader when installed with `engram plugin install gerrit`
- Root `package.json` workspaces updated to include `packages/plugins/*`

## Acceptance Criteria

- [x] `packages/plugins/gerrit/` exists with `manifest.json`, `package.json`, `src/index.ts`, `src/helpers.ts`, and `test/gerrit.test.ts`
- [x] `engram-core` no longer imports Gerrit-specific code or dependencies
- [x] `bun run build` succeeds from a clean state
- [x] `bun test` passes (11 Gerrit adapter tests now run from the plugin package; 1060 total pass, 1 pre-existing unrelated failure in project.test.ts)
- [x] `engram plugin list` will show gerrit as discovered once installed via `engram plugin install gerrit`
- [x] `README.md` adapter section updated to note Gerrit is a plugin, not built-in

## Test plan

- [x] Run `bun run build` — all packages build cleanly
- [x] Run `bun test packages/plugins/gerrit` — all 11 adapter tests pass
- [x] Run `bun test` — 1060 pass, 1 pre-existing failure (unrelated to this PR)
- [x] Run `bun run lint` — no errors

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)