### PR TITLE
docs: update VISION.md phase 2 adapter roadmap for in-repo plugin model

### DIFF
--- a/docs/internal/VISION.md
+++ b/docs/internal/VISION.md
@@ -65,7 +65,7 @@ The `.engram` format, the core engine, and the "money command":
 - **Stale-knowledge benchmark in EngRAMark**: ground-truth `reconcile` correctness over substrate evolution — author projections at commit X, advance to commit Y, measure how well the system identifies what changed.
 - Team/tribal knowledge merging with explicit reconciliation
 - EngRAMark against Kubernetes
-- Enrichment adapters: Gerrit, Jira, Linear, GitLab
+- **First-party plugin adapters** — Jira, Linear, GitLab, and Google Docs ship as in-repo plugins (`packages/plugins/<name>/`) loaded via the plugin system. Gerrit has already migrated. See [ADR-008](internal/DECISIONS.md#adr-008----first-party-adapters-ship-as-in-repo-plugins).
 - Non-git ingestors (Slack, Confluence)
 - Community detection and topic clustering
 - Rich TUI and graph visualization


### PR DESCRIPTION
Closes #224

Updates the phase 2 adapter bullet in `docs/internal/VISION.md` to reflect ADR-008: first-party adapters (Jira, Linear, GitLab, Google Docs) ship as in-repo plugins under `packages/plugins/<name>/`, not as adapters compiled into `engram-core`. Gerrit is noted as already migrated.

The principles section (principle 1 — "embeddable, not monolithic") required no change; the in-repo plugin model is an extension of that principle rather than in tension with it.