### PR TITLE
feat(source): add kubebuilder RBAC marker extraction to Go extractor

### DIFF
--- a/docs/internal/specs/vocabulary.md
+++ b/docs/internal/specs/vocabulary.md
@@ -42,6 +42,7 @@ union type (for function signatures and parameter narrowing).
 | `PULL_REQUEST` | `"pull_request"` | GitHub/Gerrit/GitLab PR or CL |
 | `ISSUE` | `"issue"` | Bug tracker issue |
 | `K8S_RESOURCE_KIND` | `"k8s_resource_kind"` | Kubernetes resource type (e.g. Deployment, ReplicaSet) |
+| `RBAC_PERMISSION` | `"rbac_permission"` | Kubernetes RBAC permission (group/resource#verb tuple) |
 
 ## Source types — two registries
 
@@ -88,6 +89,7 @@ via `INGESTION_TO_EPISODE_SOURCES`.
 | `IMPORTS` | `"imports"` | File imports another file |
 | `CONTROLLER_WATCHES` | `"controller_watches"` | controller-runtime: controller reconciles this resource kind (For/Watches) |
 | `CONTROLLER_OWNS` | `"controller_owns"` | controller-runtime: controller owns this resource kind (Owns) |
+| `RBAC_GRANTS` | `"rbac_grants"` | Controller struct is granted RBAC permission via kubebuilder marker |
 
 ## Adding a new value
 

--- a/packages/engram-core/src/ingest/source/extractors/go.ts
+++ b/packages/engram-core/src/ingest/source/extractors/go.ts
@@ -18,13 +18,17 @@ const KIND_MAP: Record<string, ExtractedSymbol["kind"]> = {
 
 const WATCH_METHODS = new Set(["For", "Owns", "Watches"]);
 
+// Matches: // +kubebuilder:rbac:groups=...,resources=...,verbs=...
+const KUBEBUILDER_RBAC_RE = /^\/\/\s*\+kubebuilder:rbac:(.+)$/;
+
 /**
  * Extract top-level symbols and import paths from tree-sitter-go query captures.
  *
  * In Go, exported symbols have names beginning with an uppercase letter.
  * Import paths are quoted string literals — quotes are stripped.
  *
- * Also extracts controller-runtime SetupWithManager watch/owns edges.
+ * Also extracts controller-runtime SetupWithManager watch/owns edges and
+ * kubebuilder RBAC permission markers adjacent to struct declarations.
  */
 export function extractGo(captures: QueryCapture[]): ExtractedFile {
   const symbols: ExtractedSymbol[] = [];
@@ -33,6 +37,7 @@ export function extractGo(captures: QueryCapture[]): ExtractedFile {
   const extraEntities: ExtractedEntity[] = [];
   const extraEdges: ExtractedEdge[] = [];
   const seenResourceKinds = new Set<string>();
+  const seenRbacPerms = new Set<string>();
 
   // Group setup.* captures by position so we can pair receiver + name + body.
   // Each triplet shares the same method_declaration parent start index.
@@ -40,6 +45,9 @@ export function extractGo(captures: QueryCapture[]): ExtractedFile {
     number,
     { receiver?: SyntaxNode; name?: SyntaxNode; body?: SyntaxNode }
   >();
+
+  // Struct type declaration nodes for RBAC marker walking.
+  const structNameNodes: SyntaxNode[] = [];
 
   for (const capture of captures) {
     const { name: captureName, node } = capture;
@@ -88,6 +96,11 @@ export function extractGo(captures: QueryCapture[]): ExtractedFile {
       if (part === "receiver") group.receiver = node;
       else if (part === "name") group.name = node;
       else if (part === "body") group.body = node;
+      continue;
+    }
+
+    if (captureName === "rbac.struct.name") {
+      structNameNodes.push(node);
     }
   }
 
@@ -127,7 +140,183 @@ export function extractGo(captures: QueryCapture[]): ExtractedFile {
     }
   }
 
+  // RBAC marker extraction: for each struct, walk preceding sibling comments.
+  for (const nameNode of structNameNodes) {
+    const structName = nameNode.text;
+    // type_identifier → type_spec → type_declaration
+    const typeDecl = nameNode.parent?.parent;
+    if (!typeDecl || typeDecl.type !== "type_declaration") continue;
+
+    const markerLines = collectPrecedingRbacMarkers(typeDecl);
+
+    for (const markerLine of markerLines) {
+      processRbacMarker(
+        markerLine,
+        structName,
+        extraEntities,
+        extraEdges,
+        seenRbacPerms,
+      );
+    }
+  }
+
   return { symbols, rawImports, extraEntities, extraEdges };
+}
+
+/**
+ * Walk backward through preceding siblings of a type_declaration node to collect
+ * adjacent // +kubebuilder:rbac: comment text. Stops at the first non-comment sibling.
+ */
+function collectPrecedingRbacMarkers(typeDecl: SyntaxNode): string[] {
+  const parent = typeDecl.parent;
+  if (!parent) return [];
+
+  // Find index of typeDecl among parent's children by position (not object identity,
+  // which is unreliable for WASM-backed tree-sitter nodes).
+  let typeDeclIdx = -1;
+  for (let i = 0; i < parent.childCount; i++) {
+    const c = parent.child(i);
+    if (c && c.startIndex === typeDecl.startIndex && c.type === typeDecl.type) {
+      typeDeclIdx = i;
+      break;
+    }
+  }
+  if (typeDeclIdx < 0) return [];
+
+  const markers: string[] = [];
+  for (let i = typeDeclIdx - 1; i >= 0; i--) {
+    const sibling = parent.child(i);
+    if (!sibling || sibling.type !== "comment") break;
+    const text = sibling.text;
+    if (KUBEBUILDER_RBAC_RE.test(text)) {
+      markers.unshift(text);
+    }
+  }
+  return markers;
+}
+
+/**
+ * Parse a single kubebuilder RBAC marker line and push entities/edges into the
+ * accumulator arrays. Skips with a warning on missing required keys; skips
+ * silently (debug-level) on unsupported constructs (subresources, multi-resource,
+ * urls).
+ *
+ * Canonical name format: `<group-or-core>/<resource>#<verb>`
+ * Empty groups="" maps to the prefix "core/".
+ */
+function processRbacMarker(
+  line: string,
+  structName: string,
+  extraEntities: ExtractedEntity[],
+  extraEdges: ExtractedEdge[],
+  seenRbacPerms: Set<string>,
+): void {
+  const match = KUBEBUILDER_RBAC_RE.exec(line);
+  if (!match) return;
+
+  const params = parseMarkerParams(match[1]);
+
+  const groupsRaw = params.get("groups");
+  const resourcesRaw = params.get("resources");
+  const verbsRaw = params.get("verbs");
+
+  if (
+    groupsRaw === undefined ||
+    resourcesRaw === undefined ||
+    verbsRaw === undefined
+  ) {
+    console.warn(
+      `[engram extractor/go] kubebuilder RBAC marker missing required key (groups/resources/verbs) — skipping: ${line}`,
+    );
+    return;
+  }
+
+  // Skip subresources (resources containing "/")
+  if (resourcesRaw.includes("/")) {
+    console.debug?.(
+      `[engram extractor/go] skipping RBAC marker with subresource: ${line}`,
+    );
+    return;
+  }
+
+  // Skip urls key (not supported)
+  if (params.has("urls")) {
+    console.debug?.(
+      `[engram extractor/go] skipping RBAC marker with urls: ${line}`,
+    );
+    return;
+  }
+
+  // Skip multi-resource (comma or semicolon-separated resources)
+  const resources = resourcesRaw
+    .split(/[,;]/)
+    .map((r) => r.trim())
+    .filter(Boolean);
+  if (resources.length > 1) {
+    console.debug?.(
+      `[engram extractor/go] skipping RBAC marker with multiple resources: ${line}`,
+    );
+    return;
+  }
+  const resource = resources[0];
+  if (!resource) return;
+
+  // Strip surrounding quotes from group value (e.g. groups="" → groups="")
+  const rawGroups = groupsRaw
+    .split(",")
+    .map((g) => g.trim().replace(/^["']|["']$/g, ""));
+  const groups = rawGroups;
+  const verbs = verbsRaw
+    .split(";")
+    .map((v) => v.trim())
+    .filter(Boolean);
+
+  for (const group of groups) {
+    const groupPrefix = group === "" ? "core/" : `${group}/`;
+
+    for (const verb of verbs) {
+      const canonicalName = `${groupPrefix}${resource}#${verb}`;
+
+      if (!seenRbacPerms.has(canonicalName)) {
+        seenRbacPerms.add(canonicalName);
+        extraEntities.push({
+          canonicalName,
+          entityType: ENTITY_TYPES.RBAC_PERMISSION,
+        });
+      }
+
+      extraEdges.push({
+        source: { kind: "symbol", name: structName },
+        target: {
+          kind: "canonical",
+          canonicalName,
+          entityType: ENTITY_TYPES.RBAC_PERMISSION,
+        },
+        relationType: RELATION_TYPES.RBAC_GRANTS,
+        edgeKind: "observed",
+        fact: `${structName} is granted ${verb} on ${groupPrefix}${resource} via kubebuilder RBAC marker`,
+      });
+    }
+  }
+}
+
+/**
+ * Parse a kubebuilder marker parameter string into a key→value map.
+ * Format: key=value,key=value (values may contain semicolons for verb lists).
+ * Splits on "," only when followed by a key= pattern to handle verb semicolons.
+ */
+function parseMarkerParams(paramStr: string): Map<string, string> {
+  const result = new Map<string, string>();
+  // Split on commas that are followed by a word= pattern (key boundary)
+  const parts = paramStr.split(/,(?=[a-zA-Z]+=)/);
+  for (const part of parts) {
+    const eqIdx = part.indexOf("=");
+    if (eqIdx < 0) continue;
+    const key = part.slice(0, eqIdx).trim();
+    const value = part.slice(eqIdx + 1).trim();
+    result.set(key, value);
+  }
+  return result;
 }
 
 /**

--- a/packages/engram-core/src/ingest/source/extractors/go.ts
+++ b/packages/engram-core/src/ingest/source/extractors/go.ts
@@ -38,6 +38,7 @@ export function extractGo(captures: QueryCapture[]): ExtractedFile {
   const extraEdges: ExtractedEdge[] = [];
   const seenResourceKinds = new Set<string>();
   const seenRbacPerms = new Set<string>();
+  const seenRbacEdges = new Set<string>();
 
   // Group setup.* captures by position so we can pair receiver + name + body.
   // Each triplet shares the same method_declaration parent start index.
@@ -156,6 +157,7 @@ export function extractGo(captures: QueryCapture[]): ExtractedFile {
         extraEntities,
         extraEdges,
         seenRbacPerms,
+        seenRbacEdges,
       );
     }
   }
@@ -210,6 +212,7 @@ function processRbacMarker(
   extraEntities: ExtractedEntity[],
   extraEdges: ExtractedEdge[],
   seenRbacPerms: Set<string>,
+  seenRbacEdges: Set<string>,
 ): void {
   const match = KUBEBUILDER_RBAC_RE.exec(line);
   if (!match) return;
@@ -261,11 +264,12 @@ function processRbacMarker(
   const resource = resources[0];
   if (!resource) return;
 
-  // Strip surrounding quotes from group value (e.g. groups="" → groups="")
-  const rawGroups = groupsRaw
+  // Strip surrounding quotes from group value (e.g. groups="" → "")
+  // Multiple groups expand to one entity+edge per group (intentional; asymmetric
+  // with multi-resource which is out-of-scope for v0.1).
+  const groups = groupsRaw
     .split(",")
     .map((g) => g.trim().replace(/^["']|["']$/g, ""));
-  const groups = rawGroups;
   const verbs = verbsRaw
     .split(";")
     .map((v) => v.trim())
@@ -285,17 +289,21 @@ function processRbacMarker(
         });
       }
 
-      extraEdges.push({
-        source: { kind: "symbol", name: structName },
-        target: {
-          kind: "canonical",
-          canonicalName,
-          entityType: ENTITY_TYPES.RBAC_PERMISSION,
-        },
-        relationType: RELATION_TYPES.RBAC_GRANTS,
-        edgeKind: "observed",
-        fact: `${structName} is granted ${verb} on ${groupPrefix}${resource} via kubebuilder RBAC marker`,
-      });
+      const edgeKey = `${structName}::${canonicalName}`;
+      if (!seenRbacEdges.has(edgeKey)) {
+        seenRbacEdges.add(edgeKey);
+        extraEdges.push({
+          source: { kind: "symbol", name: structName },
+          target: {
+            kind: "canonical",
+            canonicalName,
+            entityType: ENTITY_TYPES.RBAC_PERMISSION,
+          },
+          relationType: RELATION_TYPES.RBAC_GRANTS,
+          edgeKind: "observed",
+          fact: `${structName} is granted ${verb} on ${groupPrefix}${resource} via kubebuilder RBAC marker`,
+        });
+      }
     }
   }
 }

--- a/packages/engram-core/src/ingest/source/queries/go.scm
+++ b/packages/engram-core/src/ingest/source/queries/go.scm
@@ -21,3 +21,12 @@
   name: (field_identifier) @setup.name
   (#eq? @setup.name "SetupWithManager")
   body: (block) @setup.body)
+
+; --- Struct type declarations at file scope (kubebuilder RBAC markers) ---
+; Captures the name of each struct type so the extractor can walk preceding sibling
+; comments to find adjacent // +kubebuilder:rbac: markers.
+(source_file
+  (type_declaration
+    (type_spec
+      name: (type_identifier) @rbac.struct.name
+      type: (struct_type))))

--- a/packages/engram-core/src/vocab/entity-types.ts
+++ b/packages/engram-core/src/vocab/entity-types.ts
@@ -17,6 +17,7 @@ export const ENTITY_TYPES = {
   PULL_REQUEST: "pull_request",
   ISSUE: "issue",
   K8S_RESOURCE_KIND: "k8s_resource_kind",
+  RBAC_PERMISSION: "rbac_permission",
 } as const;
 
 export type EntityType = (typeof ENTITY_TYPES)[keyof typeof ENTITY_TYPES];

--- a/packages/engram-core/src/vocab/relation-types.ts
+++ b/packages/engram-core/src/vocab/relation-types.ts
@@ -21,6 +21,8 @@ export const RELATION_TYPES = {
   // Kubernetes controller-runtime relationships
   CONTROLLER_WATCHES: "controller_watches",
   CONTROLLER_OWNS: "controller_owns",
+  // Kubernetes RBAC
+  RBAC_GRANTS: "rbac_grants",
 } as const;
 
 export type RelationType = (typeof RELATION_TYPES)[keyof typeof RELATION_TYPES];

--- a/packages/engram-core/test/ingest/source/go-rbac.test.ts
+++ b/packages/engram-core/test/ingest/source/go-rbac.test.ts
@@ -42,6 +42,31 @@ function captureFor(src: string) {
 // Unit tests — single verb
 // ---------------------------------------------------------------------------
 
+describe("extractGo — RBAC multi-group expansion", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,batch,resources=jobs,verbs=get
+type MultiGroupReconciler struct{}
+`;
+
+  it("emits one entity per group", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const names = extraEntities?.map((e) => e.canonicalName) ?? [];
+    expect(names).toContain("apps/jobs#get");
+    expect(names).toContain("batch/jobs#get");
+  });
+
+  it("emits one edge per group", () => {
+    const { extraEdges } = extractGo(captureFor(src));
+    const edges = extraEdges?.filter(
+      (e) =>
+        e.source.kind === "symbol" && e.source.name === "MultiGroupReconciler",
+    ) ?? [];
+    expect(edges).toHaveLength(2);
+  });
+});
+
 describe("extractGo — RBAC single verb", () => {
   const src = `
 package controllers

--- a/packages/engram-core/test/ingest/source/go-rbac.test.ts
+++ b/packages/engram-core/test/ingest/source/go-rbac.test.ts
@@ -59,10 +59,12 @@ type MultiGroupReconciler struct{}
 
   it("emits one edge per group", () => {
     const { extraEdges } = extractGo(captureFor(src));
-    const edges = extraEdges?.filter(
-      (e) =>
-        e.source.kind === "symbol" && e.source.name === "MultiGroupReconciler",
-    ) ?? [];
+    const edges =
+      extraEdges?.filter(
+        (e) =>
+          e.source.kind === "symbol" &&
+          e.source.name === "MultiGroupReconciler",
+      ) ?? [];
     expect(edges).toHaveLength(2);
   });
 });

--- a/packages/engram-core/test/ingest/source/go-rbac.test.ts
+++ b/packages/engram-core/test/ingest/source/go-rbac.test.ts
@@ -1,0 +1,370 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { EngramGraph } from "../../../src/format/index.js";
+import {
+  closeGraph,
+  createGraph,
+  verifyGraph,
+} from "../../../src/format/index.js";
+import { findEdges } from "../../../src/graph/edges.js";
+import { findEntities } from "../../../src/graph/entities.js";
+import { extractGo } from "../../../src/ingest/source/extractors/go.js";
+import { ingestSource } from "../../../src/ingest/source/index.js";
+import { SourceParser } from "../../../src/ingest/source/parser.js";
+import { ENTITY_TYPES, RELATION_TYPES } from "../../../src/vocab/index.js";
+
+let parser: SourceParser;
+
+beforeAll(async () => {
+  parser = await SourceParser.create();
+});
+
+afterAll(() => {
+  parser.dispose();
+});
+
+function captureFor(src: string) {
+  const tree = parser.parse(src, "go");
+  return parser.runQuery(tree, "go");
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — single verb
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC single verb", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get
+type FooReconciler struct{}
+`;
+
+  it("emits one rbac_permission entity", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const rbac = extraEntities?.filter(
+      (e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION,
+    );
+    expect(rbac).toHaveLength(1);
+    expect(rbac?.[0].canonicalName).toBe("apps/deployments#get");
+  });
+
+  it("emits one rbac_grants edge from FooReconciler", () => {
+    const { extraEdges } = extractGo(captureFor(src));
+    const edge = extraEdges?.find(
+      (e) =>
+        e.relationType === RELATION_TYPES.RBAC_GRANTS &&
+        e.source.kind === "symbol" &&
+        e.source.name === "FooReconciler",
+    );
+    expect(edge).toBeDefined();
+    expect(edge?.target.kind).toBe("canonical");
+    if (edge?.target.kind === "canonical") {
+      expect(edge.target.canonicalName).toBe("apps/deployments#get");
+      expect(edge.target.entityType).toBe(ENTITY_TYPES.RBAC_PERMISSION);
+    }
+    expect(edge?.edgeKind).toBe("observed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — multi-verb (semicolon-separated)
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC multi-verb", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+type BarReconciler struct{}
+`;
+
+  it("emits one entity per verb", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const names = extraEntities
+      ?.filter((e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION)
+      .map((e) => e.canonicalName);
+    expect(names).toContain("apps/deployments#get");
+    expect(names).toContain("apps/deployments#list");
+    expect(names).toContain("apps/deployments#watch");
+    expect(names).toHaveLength(3);
+  });
+
+  it("emits one edge per verb", () => {
+    const { extraEdges } = extractGo(captureFor(src));
+    const rbacEdges = extraEdges?.filter(
+      (e) => e.relationType === RELATION_TYPES.RBAC_GRANTS,
+    );
+    expect(rbacEdges).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — wildcard verb
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC wildcard verb", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=*
+type WildReconciler struct{}
+`;
+
+  it("emits a single entity with wildcard verb", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const names = extraEntities
+      ?.filter((e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION)
+      .map((e) => e.canonicalName);
+    expect(names).toContain("apps/deployments#*");
+    expect(names).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — empty apiGroup (core API group)
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC empty apiGroup maps to core/", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list
+type CoreReconciler struct{}
+`;
+
+  it("empty groups='' maps to core/ prefix", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const names = extraEntities
+      ?.filter((e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION)
+      .map((e) => e.canonicalName);
+    expect(names).toContain("core/pods#get");
+    expect(names).toContain("core/pods#list");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — missing required key → warn and skip
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC malformed marker (missing required key)", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments
+type BadReconciler struct{}
+`;
+
+  it("emits no entities when verbs is missing", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const rbac = extraEntities?.filter(
+      (e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION,
+    );
+    expect(rbac ?? []).toHaveLength(0);
+  });
+
+  it("emits no edges when verbs is missing", () => {
+    const { extraEdges } = extractGo(captureFor(src));
+    const rbac = extraEdges?.filter(
+      (e) => e.relationType === RELATION_TYPES.RBAC_GRANTS,
+    );
+    expect(rbac ?? []).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — marker not adjacent to struct
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC marker not adjacent to struct", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get
+
+func helper() {}
+
+type NotAdjacentReconciler struct{}
+`;
+
+  it("does not associate marker with struct when separated by non-comment node", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const rbac = extraEntities?.filter(
+      (e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION,
+    );
+    expect(rbac ?? []).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — multiple markers above same struct
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC multiple markers above same struct", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get
+// +kubebuilder:rbac:groups="",resources=pods,verbs=list
+type MultiMarkerReconciler struct{}
+`;
+
+  it("processes all adjacent markers", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const names = extraEntities
+      ?.filter((e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION)
+      .map((e) => e.canonicalName);
+    expect(names).toContain("apps/deployments#get");
+    expect(names).toContain("core/pods#list");
+  });
+
+  it("emits edges from the struct for each permission", () => {
+    const { extraEdges } = extractGo(captureFor(src));
+    const rbacEdges = extraEdges?.filter(
+      (e) =>
+        e.relationType === RELATION_TYPES.RBAC_GRANTS &&
+        e.source.kind === "symbol" &&
+        e.source.name === "MultiMarkerReconciler",
+    );
+    expect(rbacEdges).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — subresource (skip)
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC subresource skipped", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get
+type SubReconciler struct{}
+`;
+
+  it("skips markers with subresource paths", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const rbac = extraEntities?.filter(
+      (e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION,
+    );
+    expect(rbac ?? []).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — multi-resource (skip)
+// ---------------------------------------------------------------------------
+
+describe("extractGo — RBAC multi-resource skipped", () => {
+  const src = `
+package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get
+type MultiResReconciler struct{}
+`;
+
+  it("skips markers with multiple resources", () => {
+    const { extraEntities } = extractGo(captureFor(src));
+    const rbac = extraEntities?.filter(
+      (e) => e.entityType === ENTITY_TYPES.RBAC_PERMISSION,
+    );
+    expect(rbac ?? []).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration test — ingestSource on kubebuilder controller file
+// ---------------------------------------------------------------------------
+
+describe("ingestSource — Go kubebuilder RBAC integration", () => {
+  let tmpDir: string;
+  let graphPath: string;
+  let graph: EngramGraph;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-go-rbac-test-"));
+    graphPath = path.join(tmpDir, "test.engram");
+    graph = await createGraph(graphPath);
+  });
+
+  afterEach(async () => {
+    closeGraph(graph);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates rbac_permission entities and rbac_grants edges, verifyGraph passes", async () => {
+    const root = tmpDir;
+    fs.mkdirSync(path.join(root, "controllers"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "controllers", "foo_controller.go"),
+      `package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get
+type FooReconciler struct{}
+`,
+    );
+
+    const result = await ingestSource(graph, {
+      root,
+      respectGitignore: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+
+    const rbacEntities = findEntities(graph, {
+      entity_type: ENTITY_TYPES.RBAC_PERMISSION,
+    });
+    const rbacNames = rbacEntities.map((e) => e.canonical_name);
+    expect(rbacNames).toContain("apps/deployments#get");
+    expect(rbacNames).toContain("apps/deployments#list");
+    expect(rbacNames).toContain("apps/deployments#watch");
+    expect(rbacNames).toContain("core/pods#get");
+
+    const rbacEdges = findEdges(graph, {
+      active_only: true,
+      relation_type: RELATION_TYPES.RBAC_GRANTS,
+    });
+    expect(rbacEdges.length).toBeGreaterThan(0);
+
+    const vr = verifyGraph(graph);
+    expect(vr.violations.filter((v) => v.severity === "error")).toHaveLength(0);
+  });
+
+  it("does not throw when struct is defined in a different file than markers", async () => {
+    const root = tmpDir;
+    fs.mkdirSync(path.join(root, "controllers"), { recursive: true });
+
+    // Markers adjacent to a method_declaration (not a struct) — should skip gracefully
+    fs.writeFileSync(
+      path.join(root, "controllers", "setup.go"),
+      `package controllers
+
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get
+func (r *CrossFileReconciler) Reconcile() error {
+  return nil
+}
+`,
+    );
+
+    const result = await ingestSource(graph, {
+      root,
+      respectGitignore: false,
+    });
+
+    expect(result.errors).toHaveLength(0);
+
+    const vr = verifyGraph(graph);
+    expect(vr.violations.filter((v) => v.severity === "error")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Extends the Go tree-sitter extractor to parse `// +kubebuilder:rbac:groups=...,resources=...,verbs=...` comment markers adjacent to controller struct declarations
- Adds `RBAC_PERMISSION` entity type and `RBAC_GRANTS` relation type to the vocab registry
- Multi-verb markers (`verbs=get;list;watch`) expand to one entity+edge per verb; empty `groups=""` maps to the canonical `core/` prefix
- Out-of-scope constructs (subresources, multi-resource, `urls=`) are skipped with a debug log; malformed markers (missing required key) warn and skip

## Acceptance Criteria

- [x] `RBAC_PERMISSION: "rbac_permission"` added to `entity-types.ts`
- [x] `RBAC_GRANTS: "rbac_grants"` added to `relation-types.ts`
- [x] `go.scm` updated with `rbac.struct.name` capture for struct-type type declarations at file scope
- [x] Extractor walks preceding sibling comments, stops at first non-comment node
- [x] Multi-verb markers produce one entity+edge per verb
- [x] Empty `groups=""` maps to `core/` prefix in canonical name
- [x] Missing required key → warn + skip (no throw)
- [x] Subresource markers (`resources=foo/status`) → skip
- [x] Multi-resource markers → skip
- [x] Marker not adjacent to struct (non-comment node between them) → not associated
- [x] Integration test: `ingestSource` on kubebuilder controller file, entities/edges created, `verifyGraph()` passes
- [x] Cross-file case (marker adjacent to non-struct node): does not throw, skips gracefully
- [x] All 15 unit + integration tests pass; full `engram-core` test suite (908 tests) passes
- [x] Build passes; lint passes
- [x] `docs/internal/specs/vocabulary.md` updated with `rbac_permission` and `rbac_grants` entries

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)