### PR TITLE
docs: update README for expanded source ingest language coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,16 +192,18 @@ tree-sitter, and creates file, module, and symbol entities. Respects
 `.gitignore` by default; always skips `node_modules`, build artifacts, and
 lockfiles.
 
-Supported languages: **TypeScript/JavaScript, Go, Python, Rust, Java, Ruby,
-C, C++, C#**, and **Starlark** (`BUILD`/`BUILD.bazel`/`BUCK` files).
+Supported languages: **TypeScript/JavaScript (including TSX/JSX), Go, Python,
+Rust, Java, Ruby, C, C++, C#**, and **Starlark** (`BUILD`/`BUILD.bazel`/`BUCK`
+files).
 
 Beyond generic symbol extraction, engram parses a few ecosystem-specific
 structures into first-class graph signal:
 
 - **Kubebuilder RBAC markers** in Go (`+kubebuilder:rbac:…`) become
   `rbac_permission` entities linked to their controller.
-- **controller-runtime** `SetupWithManager` watches become edges from a
-  reconciler to the resources it observes.
+- **controller-runtime** `SetupWithManager` relationships become edges from a
+  reconciler to resources it watches (`.For()`/`.Watches()`) and owns
+  (`.Owns()`).
 - **Bazel** `BUILD` rules become `bazel_target` entities with
   `build_depends_on` edges, yielding a navigable build-dependency graph.
 
@@ -506,7 +508,7 @@ Deeper reading:
 | Area | State |
 |---|---|
 | Git ingest (structural graph) | Stable |
-| Source ingest (TS/JS, Go, Python, Rust, Java, Ruby, C/C++, C#, Starlark) | Stable |
+| Source ingest (TS/JS/TSX/JSX, Go, Python, Rust, Java, Ruby, C/C++, C#, Starlark) | Stable |
 | GitHub enrichment | Stable |
 | Gerrit enrichment | Experimental |
 | Plugin loader (js-module + executable) | Experimental |

--- a/README.md
+++ b/README.md
@@ -192,8 +192,18 @@ tree-sitter, and creates file, module, and symbol entities. Respects
 `.gitignore` by default; always skips `node_modules`, build artifacts, and
 lockfiles.
 
-TypeScript and JavaScript are supported today. Additional grammars land in
-later versions.
+Supported languages: **TypeScript/JavaScript, Go, Python, Rust, Java, Ruby,
+C, C++, C#**, and **Starlark** (`BUILD`/`BUILD.bazel`/`BUCK` files).
+
+Beyond generic symbol extraction, engram parses a few ecosystem-specific
+structures into first-class graph signal:
+
+- **Kubebuilder RBAC markers** in Go (`+kubebuilder:rbac:…`) become
+  `rbac_permission` entities linked to their controller.
+- **controller-runtime** `SetupWithManager` watches become edges from a
+  reconciler to the resources it observes.
+- **Bazel** `BUILD` rules become `bazel_target` entities with
+  `build_depends_on` edges, yielding a navigable build-dependency graph.
 
 ```bash
 engram ingest source                            # current directory
@@ -496,7 +506,7 @@ Deeper reading:
 | Area | State |
 |---|---|
 | Git ingest (structural graph) | Stable |
-| Source ingest (TS/JS) | Stable |
+| Source ingest (TS/JS, Go, Python, Rust, Java, Ruby, C/C++, C#, Starlark) | Stable |
 | GitHub enrichment | Stable |
 | Gerrit enrichment | Experimental |
 | Plugin loader (js-module + executable) | Experimental |


### PR DESCRIPTION
## Summary

- The README's source ingest section still claimed only TypeScript and JavaScript were supported, but PRs #235, #243, #244, #245, and #248 added Go, Python, Rust, Java, Ruby, C, C++, C#, and Starlark/BUILD.
- Added a short callout for the ecosystem-specific extractors that landed in PRs #246, #247, and #249 (kubebuilder RBAC markers, controller-runtime `SetupWithManager` watches, Bazel build-dependency graph) — these were invisible in the README despite being the most differentiating recent work.
- Widened the Status table row to list actual supported languages instead of "(TS/JS)".

No other sections needed updates — #221 already brought the v2 adapter / plugin / reconcile / companion content current.

## Test plan

- [ ] Render the README on GitHub and confirm the language list and status row read correctly.
- [ ] Spot-check the three bullets match current extractor behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)