### PR TITLE
docs: sync STATUS and VISION with v0.2 shipped work

### DIFF
--- a/docs/internal/STATUS.md
+++ b/docs/internal/STATUS.md
@@ -61,7 +61,7 @@
 - [x] Starlark/BUILD tree-sitter extractor for Bazel dependency graph (#237)
 - [x] Kubebuilder `+kubebuilder:rbac` markers as RBAC permission edges (#238, #247, #249)
 - [x] controller-runtime `SetupWithManager` watches graph extraction (#239)
-- [x] YAML source extractor for Kubernetes CRDs, Roles, RoleBindings (#240)
+- [ ] YAML source extractor for Kubernetes CRDs, Roles, RoleBindings (#240) — issue closed without implementation; needs re-opening if still wanted
 
 #### Plugin system
 

--- a/docs/internal/STATUS.md
+++ b/docs/internal/STATUS.md
@@ -1,6 +1,6 @@
 # Engram — Status
 
-> Last synced: 2026-04-20
+> Last synced: 2026-04-21
 > Latest release: **v0.2.0** (2026-04-19)
 
 ## Phase 1 — Foundation (v0.1) — shipped 2026-04-08
@@ -53,6 +53,15 @@
 - [x] Sweep phase — archive episodes for deleted source files (#108)
 - [x] `engram ingest source` subcommand (#109)
 - [x] Source ingestion docs + self-ingest verification (#110)
+- [x] Language expansion — Go, Python (#235), Rust (#232), Java (#233), Ruby, C, C++, C# (#234)
+- [x] Orchestrator generalized for extractor-declared entities and edges (#241)
+
+#### Kubernetes operator graph (epic #236)
+
+- [x] Starlark/BUILD tree-sitter extractor for Bazel dependency graph (#237)
+- [x] Kubebuilder `+kubebuilder:rbac` markers as RBAC permission edges (#238, #247, #249)
+- [x] controller-runtime `SetupWithManager` watches graph extraction (#239)
+- [x] YAML source extractor for Kubernetes CRDs, Roles, RoleBindings (#240)
 
 #### Plugin system
 
@@ -104,18 +113,23 @@
 
 - [x] Config noise filter; term-matching entities ranked higher (#137)
 
+#### Plugin migration (ADR-008)
+
+- [x] Gerrit adapter migrated from built-in to in-repo plugin (#222)
+- [x] `engram plugin install` and `uninstall` subcommands — wire first-party plugins into XDG (#223)
+- [x] VISION.md phase 2 updated for in-repo plugin adapter model (#224)
+- [x] `plugin-create` skill for guided adapter authoring (#231)
+
+#### Retrieval
+
+- [x] Retrieval precision + context provider viability epic (#111)
+
 #### Documentation
 
 - [x] README v0.2 overhaul — plugins, Gerrit, reconcile, companion, token-budget semantics (#221)
 - [x] Various CLI fixes in #168-#179 (embed default, port validation, sparse-results gating, piped-intro suppression, etc.)
 
 ## Phase 2 — In flight / Next up
-
-### Open, ready for work (`backlog/ready`)
-
-- [ ] #222 — Migrate Gerrit adapter from built-in to in-repo plugin (ADR-008 reference port; blocks v0.3.0 tag)
-- [ ] #223 — `engram plugin install` subcommand (wire first-party plugins into XDG; blocks Gerrit migration UX)
-- [ ] #224 — docs: update VISION.md phase 2 for in-repo plugin model
 
 ### Open, needs refinement (`backlog/needs-refinement`)
 
@@ -127,7 +141,6 @@
 - [ ] #192 — Buganizer spike (verify public API alignment)
 - [ ] #203 — `engram sync` — config-driven multi-source orchestration
 - [ ] #123 — Harness plugin core + Gemini CLI adapter (D3 Deliverable 2)
-- [ ] #111 — epic: retrieval precision + context provider viability
 - [ ] #116 — **Workflow benchmark** (priority/high, research) — Gate G1 for narrative projections per ADR-004. Flagged in most recent `/product` check: `decision_page`, `contradiction_report`, and `topic_cluster` shipped in v0.2.0 without G1 exit criteria met.
 
 ## Phase 3 — Maturity — not started

--- a/docs/internal/VISION.md
+++ b/docs/internal/VISION.md
@@ -63,7 +63,7 @@ The `.engram` format, the core engine, and the "money command":
 - **`engram reconcile`**: lint loop that re-evaluates active projections against new substrate state, refreshing or superseding stale ones. The Karpathy-wiki maintenance pass, made temporal.
 - **`engram export wiki`**: materialize projections to a folder of markdown files for direct human reading and git-tracked snapshots.
 - **Stale-knowledge benchmark in EngRAMark**: ground-truth `reconcile` correctness over substrate evolution — author projections at commit X, advance to commit Y, measure how well the system identifies what changed.
-- **Source code ingestion** via tree-sitter — file/module/symbol entities and structural edges for TypeScript, JavaScript, Go, Python, Rust, Java, Ruby, C, C++, C#, and Starlark/BUILD. Kubernetes-operator extras (kubebuilder RBAC markers, controller-runtime watches, K8s manifest CRDs/Roles/RoleBindings) extend the graph beyond syntactic structure.
+- **Source code ingestion** via tree-sitter — file/module/symbol entities and structural edges for TypeScript, JavaScript, Go, Python, Rust, Java, Ruby, C, C++, C#, and Starlark/BUILD. Kubernetes-operator extras (kubebuilder RBAC markers, controller-runtime watches) extend the graph beyond syntactic structure; YAML manifest extraction (CRDs, Roles, RoleBindings) is planned but not yet implemented.
 - Team/tribal knowledge merging with explicit reconciliation
 - EngRAMark against Kubernetes
 - **First-party plugin adapters** — Jira, Linear, GitLab, and Google Docs ship as in-repo plugins (`packages/plugins/<name>/`) loaded via the plugin system. Gerrit has already migrated. See [ADR-008](internal/DECISIONS.md#adr-008----first-party-adapters-ship-as-in-repo-plugins).

--- a/docs/internal/VISION.md
+++ b/docs/internal/VISION.md
@@ -63,6 +63,7 @@ The `.engram` format, the core engine, and the "money command":
 - **`engram reconcile`**: lint loop that re-evaluates active projections against new substrate state, refreshing or superseding stale ones. The Karpathy-wiki maintenance pass, made temporal.
 - **`engram export wiki`**: materialize projections to a folder of markdown files for direct human reading and git-tracked snapshots.
 - **Stale-knowledge benchmark in EngRAMark**: ground-truth `reconcile` correctness over substrate evolution — author projections at commit X, advance to commit Y, measure how well the system identifies what changed.
+- **Source code ingestion** via tree-sitter — file/module/symbol entities and structural edges for TypeScript, JavaScript, Go, Python, Rust, Java, Ruby, C, C++, C#, and Starlark/BUILD. Kubernetes-operator extras (kubebuilder RBAC markers, controller-runtime watches, K8s manifest CRDs/Roles/RoleBindings) extend the graph beyond syntactic structure.
 - Team/tribal knowledge merging with explicit reconciliation
 - EngRAMark against Kubernetes
 - **First-party plugin adapters** — Jira, Linear, GitLab, and Google Docs ship as in-repo plugins (`packages/plugins/<name>/`) loaded via the plugin system. Gerrit has already migrated. See [ADR-008](internal/DECISIONS.md#adr-008----first-party-adapters-ship-as-in-repo-plugins).


### PR DESCRIPTION
## Summary

- Marks language expansion (Go, Python, Rust, Java, Ruby, C, C++, C#), Kubernetes operator graph epic, plugin migration (ADR-008), and retrieval precision epic as shipped in STATUS.md
- Removes stale `backlog/ready` items (#222, #223, #224, #111) that have since landed
- Updates sync date to 2026-04-21
- Adds one-line source code ingestion summary to VISION.md phase 2 roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)