### PR TITLE
feat(ingest): google workspace scope grammar - folder and query discovery modes

### DIFF
--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -596,8 +596,11 @@ Auth modes (--auth):
   bearer  Pass a raw OAuth2/bearer token via --token or GOOGLE_WORKSPACE_TOKEN
 
 Scope:
-  --scope doc:<docId>           Single Google Doc
-  --scope docs:<id>,<id>,...    Multiple Google Docs
+  --scope doc:<docId>                 Single Google Doc
+  --scope docs:<id>,<id>,...          Multiple Google Docs (explicit list)
+  --scope folder:<folderId>           All Docs in a Drive folder (flat)
+  --scope folder:<folderId>?recursive=true  All Docs in folder tree (BFS)
+  --scope query:<drive-q>             Docs matching a Drive search query
 
 Examples:
   # Ingest a doc using ADC
@@ -608,11 +611,22 @@ Examples:
     --scope docs:1Bxi…,2Cyi… \\
     --auth bearer --token ya29.…
 
-  # Dry-run preview
-  engram ingest enrich google-workspace --scope doc:<id> --dry-run
+  # Ingest all Docs in a Drive folder (flat)
+  engram ingest enrich google-workspace --scope folder:1A2B3C4D5E6F7G8H
+
+  # Ingest all Docs in a folder tree (recursively)
+  engram ingest enrich google-workspace --scope "folder:1A2B3C4D5E6F7G8H?recursive=true"
+
+  # Ingest Docs matching a Drive search query
+  engram ingest enrich google-workspace --scope "query:name contains 'spec'"
+
+  # Dry-run preview (runs enumeration but skips content fetch)
+  engram ingest enrich google-workspace --scope folder:<id> --dry-run
 
 When to use:
   Index Google Docs for temporal context, ownership, and change tracking.
+  Use folder: or query: scopes for bulk ingest without listing every doc ID.
+  Subsequent runs use a modifiedTime cursor to fetch only changed docs.
   Combine with engram ingest git for full project history.
 
 See also:
@@ -620,7 +634,7 @@ See also:
     )
     .option(
       "--scope <value>",
-      "Google Workspace scope: doc:<id> or docs:<id>,<id>,...",
+      "Google Workspace scope: doc:<id>, docs:<id>,..., folder:<id>, or query:<q>",
     )
     .option(
       "--auth <mode>",

--- a/packages/engram-core/src/ingest/adapters/google-workspace-discovery.ts
+++ b/packages/engram-core/src/ingest/adapters/google-workspace-discovery.ts
@@ -1,0 +1,347 @@
+/**
+ * google-workspace-discovery.ts — Drive discovery helpers for folder and query scopes.
+ *
+ * Provides:
+ * - `enumerateFolderDocs()` — list all Google Docs in a Drive folder (flat or recursive BFS)
+ * - `enumerateQueryDocs()` — execute a Drive search query, AND-injecting mimeType constraint
+ *
+ * These functions are called from the GoogleWorkspaceAdapter when scope is
+ * `folder:<id>` or `query:<q>`. They return arrays of doc-id / modifiedTime pairs
+ * that the adapter then fans out to the existing per-doc ingest logic.
+ *
+ * Cursor semantics:
+ *   Callers pass a `since` ISO8601 cursor. Discovery functions append
+ *   `modifiedTime > '<cursor>'` to the Drive query so only changed docs are returned.
+ *   After a run, the adapter stores `max(modifiedTime)` seen across all docs as the
+ *   new cursor.
+ */
+
+import { EnrichmentAdapterError } from "../adapter.js";
+import type { GWFetchFn } from "./google-workspace-helpers.js";
+import { apiGetGW } from "./google-workspace-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Drive API types (only fields we use)
+// ---------------------------------------------------------------------------
+
+export interface DriveFileItem {
+  id: string;
+  modifiedTime?: string;
+}
+
+interface DriveFilesListResponse {
+  files?: DriveFileItem[];
+  nextPageToken?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Parsed folder scope
+// ---------------------------------------------------------------------------
+
+export interface ParsedFolderScope {
+  folderId: string;
+  recursive: boolean;
+}
+
+/**
+ * Parse a `folder:<id>` or `folder:<id>?recursive=true` scope string.
+ * Throws on unrecognised query params.
+ */
+export function parseFolderScope(scope: string): ParsedFolderScope {
+  // Strip the "folder:" prefix
+  const rest = scope.slice("folder:".length);
+
+  const qIdx = rest.indexOf("?");
+  if (qIdx === -1) {
+    const folderId = rest.trim();
+    if (!folderId) {
+      throw new Error("folder scope must include a folder ID: folder:<id>");
+    }
+    return { folderId, recursive: false };
+  }
+
+  const folderId = rest.slice(0, qIdx).trim();
+  if (!folderId) {
+    throw new Error("folder scope must include a folder ID: folder:<id>");
+  }
+
+  const queryString = rest.slice(qIdx + 1);
+  const params = new URLSearchParams(queryString);
+
+  // Validate: only 'recursive' is a recognised key
+  for (const key of params.keys()) {
+    if (key !== "recursive") {
+      throw new Error(
+        `Unknown query parameter in folder scope: '${key}'. Valid keys: recursive`,
+      );
+    }
+  }
+
+  const recursiveVal = params.get("recursive");
+  let recursive = false;
+  if (recursiveVal !== null) {
+    if (recursiveVal !== "true" && recursiveVal !== "false") {
+      throw new Error(
+        `Invalid value for recursive in folder scope: '${recursiveVal}'. Use true or false`,
+      );
+    }
+    recursive = recursiveVal === "true";
+  }
+
+  return { folderId, recursive };
+}
+
+// ---------------------------------------------------------------------------
+// Drive list helper (one page)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch one page of Drive files matching `query`.
+ * Handles 400 (malformed query) → data_error, 404 (folder not found) → data_error.
+ */
+async function driveListPage(
+  fetchFn: GWFetchFn,
+  token: string,
+  query: string,
+  pageToken: string | undefined,
+  fields: string,
+): Promise<DriveFilesListResponse> {
+  const params = new URLSearchParams({
+    q: query,
+    fields,
+    pageSize: "100",
+    supportsAllDrives: "true",
+    includeItemsFromAllDrives: "true",
+  });
+  if (pageToken) {
+    params.set("pageToken", pageToken);
+  }
+
+  const url = `https://www.googleapis.com/drive/v3/files?${params.toString()}`;
+
+  try {
+    return await apiGetGW<DriveFilesListResponse>(fetchFn, url, token);
+  } catch (err) {
+    if (err instanceof EnrichmentAdapterError) {
+      // apiGetGW maps unexpected statuses to data_error with the status code in the message
+      if (err.code === "data_error" && err.message.includes("404")) {
+        throw new EnrichmentAdapterError(
+          "data_error",
+          `folder not found: check the folder ID and Drive permissions`,
+        );
+      }
+      if (err.code === "data_error" && err.message.includes("400")) {
+        throw new EnrichmentAdapterError(
+          "data_error",
+          `Drive query error (400): ${err.message}`,
+        );
+      }
+    }
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Enumerate docs in a single folder (one level only)
+// ---------------------------------------------------------------------------
+
+async function enumerateDocsInFolder(
+  fetchFn: GWFetchFn,
+  token: string,
+  folderId: string,
+  since: string | null,
+): Promise<DriveFileItem[]> {
+  let q =
+    `mimeType='application/vnd.google-apps.document'` +
+    ` and '${folderId}' in parents` +
+    ` and trashed=false`;
+
+  if (since) {
+    q += ` and modifiedTime > '${since}'`;
+  }
+
+  const docs: DriveFileItem[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const resp = await driveListPage(
+      fetchFn,
+      token,
+      q,
+      pageToken,
+      "files(id,modifiedTime),nextPageToken",
+    );
+    for (const f of resp.files ?? []) {
+      if (f.id) docs.push(f);
+    }
+    pageToken = resp.nextPageToken;
+  } while (pageToken);
+
+  return docs;
+}
+
+// ---------------------------------------------------------------------------
+// Enumerate subfolders inside a folder (BFS, cycle-guarded)
+// ---------------------------------------------------------------------------
+
+async function enumerateSubfolders(
+  fetchFn: GWFetchFn,
+  token: string,
+  folderId: string,
+): Promise<string[]> {
+  const q =
+    `mimeType='application/vnd.google-apps.folder'` +
+    ` and '${folderId}' in parents` +
+    ` and trashed=false`;
+
+  const ids: string[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const resp = await driveListPage(
+      fetchFn,
+      token,
+      q,
+      pageToken,
+      "files(id),nextPageToken",
+    );
+    for (const f of resp.files ?? []) {
+      if (f.id) ids.push(f.id);
+    }
+    pageToken = resp.nextPageToken;
+  } while (pageToken);
+
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Public: enumerateFolderDocs
+// ---------------------------------------------------------------------------
+
+/**
+ * Enumerate all Google Docs inside `folderId`, optionally recursing into
+ * subfolders (BFS with cycle guard).
+ *
+ * @param fetchFn  - Injected fetch implementation (real or test stub).
+ * @param token    - Bearer token for Drive API.
+ * @param folderId - Drive folder ID to enumerate.
+ * @param recursive - Whether to recurse into subfolders.
+ * @param since    - ISO8601 cursor. If provided, only docs modified after
+ *                   this timestamp are returned.
+ * @returns Array of `{ id, modifiedTime }` tuples for matched docs.
+ */
+export async function enumerateFolderDocs(
+  fetchFn: GWFetchFn,
+  token: string,
+  folderId: string,
+  recursive: boolean,
+  since: string | null,
+): Promise<DriveFileItem[]> {
+  const allDocs: DriveFileItem[] = [];
+  const visitedFolders = new Set<string>();
+
+  // BFS queue — starts with the root folder
+  const queue: string[] = [folderId];
+
+  while (queue.length > 0) {
+    const currentId = queue.shift() as string;
+
+    if (visitedFolders.has(currentId)) {
+      // Cycle guard: skip already-visited folders (handles Drive shortcuts)
+      continue;
+    }
+    visitedFolders.add(currentId);
+
+    const docs = await enumerateDocsInFolder(fetchFn, token, currentId, since);
+    allDocs.push(...docs);
+
+    if (recursive) {
+      const subfolders = await enumerateSubfolders(fetchFn, token, currentId);
+      for (const subfolderId of subfolders) {
+        if (!visitedFolders.has(subfolderId)) {
+          queue.push(subfolderId);
+        }
+      }
+    }
+  }
+
+  return allDocs;
+}
+
+// ---------------------------------------------------------------------------
+// Public: enumerateQueryDocs
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a Drive search query, always AND-injecting `mimeType` and `trashed`
+ * constraints so users cannot accidentally retrieve non-Doc files.
+ *
+ * @param fetchFn   - Injected fetch implementation.
+ * @param token     - Bearer token for Drive API.
+ * @param userQuery - User-supplied Drive query fragment (e.g. `name contains 'spec'`).
+ * @param since     - ISO8601 cursor. If provided, also injects `modifiedTime > '<since>'`.
+ * @returns Array of `{ id, modifiedTime }` tuples for matched docs.
+ */
+export async function enumerateQueryDocs(
+  fetchFn: GWFetchFn,
+  token: string,
+  userQuery: string,
+  since: string | null,
+): Promise<DriveFileItem[]> {
+  if (!userQuery.trim()) {
+    throw new EnrichmentAdapterError(
+      "data_error",
+      "query scope must include a non-empty Drive query: query:<q>",
+    );
+  }
+
+  // AND-inject mimeType + trashed constraints, then wrap user query in parens
+  let q =
+    `mimeType='application/vnd.google-apps.document'` +
+    ` and trashed=false` +
+    ` and (${userQuery})`;
+
+  if (since) {
+    q += ` and modifiedTime > '${since}'`;
+  }
+
+  const docs: DriveFileItem[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const resp = await driveListPage(
+      fetchFn,
+      token,
+      q,
+      pageToken,
+      "files(id,modifiedTime),nextPageToken",
+    );
+    for (const f of resp.files ?? []) {
+      if (f.id) docs.push(f);
+    }
+    pageToken = resp.nextPageToken;
+  } while (pageToken);
+
+  return docs;
+}
+
+// ---------------------------------------------------------------------------
+// Cursor: compute max modifiedTime from a set of discovered docs
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a list of enumerated Drive file items, return the maximum
+ * `modifiedTime` seen as an ISO8601 string — to be stored as the run cursor.
+ * Returns `null` if the list is empty or no item has a `modifiedTime`.
+ */
+export function computeDiscoveryCursor(items: DriveFileItem[]): string | null {
+  let max: string | null = null;
+  for (const item of items) {
+    if (item.modifiedTime) {
+      if (max === null || item.modifiedTime > max) {
+        max = item.modifiedTime;
+      }
+    }
+  }
+  return max;
+}

--- a/packages/engram-core/src/ingest/adapters/google-workspace-discovery.ts
+++ b/packages/engram-core/src/ingest/adapters/google-workspace-discovery.ts
@@ -57,12 +57,22 @@ export function parseFolderScope(scope: string): ParsedFolderScope {
     if (!folderId) {
       throw new Error("folder scope must include a folder ID: folder:<id>");
     }
+    if (!/^[A-Za-z0-9_-]+$/.test(folderId)) {
+      throw new Error(
+        `invalid folder ID: expected alphanumeric/underscore/dash characters only`,
+      );
+    }
     return { folderId, recursive: false };
   }
 
   const folderId = rest.slice(0, qIdx).trim();
   if (!folderId) {
     throw new Error("folder scope must include a folder ID: folder:<id>");
+  }
+  if (!/^[A-Za-z0-9_-]+$/.test(folderId)) {
+    throw new Error(
+      `invalid folder ID: expected alphanumeric/underscore/dash characters only`,
+    );
   }
 
   const queryString = rest.slice(qIdx + 1);
@@ -335,13 +345,16 @@ export async function enumerateQueryDocs(
  * Returns `null` if the list is empty or no item has a `modifiedTime`.
  */
 export function computeDiscoveryCursor(items: DriveFileItem[]): string | null {
-  let max: string | null = null;
+  let maxSeen: string | null = null;
   for (const item of items) {
     if (item.modifiedTime) {
-      if (max === null || item.modifiedTime > max) {
-        max = item.modifiedTime;
+      if (
+        !maxSeen ||
+        new Date(item.modifiedTime).getTime() > new Date(maxSeen).getTime()
+      ) {
+        maxSeen = item.modifiedTime;
       }
     }
   }
-  return max;
+  return maxSeen;
 }

--- a/packages/engram-core/src/ingest/adapters/google-workspace-helpers.ts
+++ b/packages/engram-core/src/ingest/adapters/google-workspace-helpers.ts
@@ -92,8 +92,14 @@ export interface DrivePermission {
  * Parses a Google Workspace scope string into a list of document IDs.
  *
  * Accepted formats:
- * - `doc:<id>`          — single document
- * - `docs:<id>,<id>`   — comma-separated list of document IDs
+ * - `doc:<id>`                     — single document
+ * - `docs:<id>,<id>`              — comma-separated list of document IDs
+ * - `folder:<id>`                  — all docs in a Drive folder (flat)
+ * - `folder:<id>?recursive=true`  — all docs in a folder tree (BFS)
+ * - `query:<drive-q>`             — arbitrary Drive search query
+ *
+ * For `folder:` and `query:` scopes this function returns an empty array —
+ * the adapter discovers doc IDs at enrich time via Drive API enumeration.
  */
 export function parseScope(scope: string): string[] {
   if (scope.startsWith("doc:")) {
@@ -113,9 +119,103 @@ export function parseScope(scope: string): string[] {
       );
     return ids;
   }
+  if (scope.startsWith("folder:")) {
+    // Validated elsewhere (parseFolderScope) — return empty so adapter takes
+    // the discovery path
+    return [];
+  }
+  if (scope.startsWith("query:")) {
+    // Validated elsewhere — return empty so adapter takes the discovery path
+    return [];
+  }
   throw new Error(
-    `Unsupported scope format: ${JSON.stringify(scope)}. Use 'doc:<id>' or 'docs:<id>,<id>,...'`,
+    `Unsupported scope format: ${JSON.stringify(scope)}. ` +
+      `Use 'doc:<id>', 'docs:<id>,<id>,...', 'folder:<id>', or 'query:<q>'`,
   );
+}
+
+/**
+ * Validate a Google Workspace scope string.
+ * Throws with a descriptive message on invalid input.
+ *
+ * Accepted formats:
+ * - `doc:<id>`                     — single document
+ * - `docs:<id>,<id>`              — comma-separated list of document IDs
+ * - `folder:<id>`                  — all docs in a Drive folder (flat)
+ * - `folder:<id>?recursive=true`  — all docs in a folder tree (BFS)
+ * - `folder:<id>?recursive=false` — explicitly flat (same as no param)
+ * - `query:<drive-q>`             — arbitrary Drive search query (non-empty)
+ */
+export function validateScope(scope: string): void {
+  if (scope.startsWith("doc:")) {
+    const id = scope.slice(4).trim();
+    if (!id) throw new Error("doc scope must include a document ID: doc:<id>");
+    return;
+  }
+  if (scope.startsWith("docs:")) {
+    const raw = scope.slice(5);
+    const ids = raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (ids.length === 0)
+      throw new Error(
+        "docs scope must include at least one document ID: docs:<id>,<id>,...",
+      );
+    return;
+  }
+  if (scope.startsWith("folder:")) {
+    validateFolderScope(scope);
+    return;
+  }
+  if (scope.startsWith("query:")) {
+    const q = scope.slice("query:".length).trim();
+    if (!q) {
+      throw new Error(
+        "query scope must include a non-empty Drive query: query:<q>",
+      );
+    }
+    return;
+  }
+  throw new Error(
+    `Unsupported scope format: ${JSON.stringify(scope)}. ` +
+      `Use 'doc:<id>', 'docs:<id>,<id>,...', 'folder:<id>', or 'query:<q>'`,
+  );
+}
+
+/**
+ * Validate a folder:<id> scope string inline (no import needed).
+ */
+function validateFolderScope(scope: string): void {
+  const rest = scope.slice("folder:".length);
+  const qIdx = rest.indexOf("?");
+  const folderId = qIdx === -1 ? rest.trim() : rest.slice(0, qIdx).trim();
+
+  if (!folderId) {
+    throw new Error("folder scope must include a folder ID: folder:<id>");
+  }
+
+  if (qIdx !== -1) {
+    const queryString = rest.slice(qIdx + 1);
+    const params = new URLSearchParams(queryString);
+    for (const key of params.keys()) {
+      if (key !== "recursive") {
+        throw new Error(
+          `Unknown query parameter in folder scope: '${key}'. Valid keys: recursive`,
+        );
+      }
+    }
+    const recursiveVal = params.get("recursive");
+    if (
+      recursiveVal !== null &&
+      recursiveVal !== "true" &&
+      recursiveVal !== "false"
+    ) {
+      throw new Error(
+        `Invalid value for recursive in folder scope: '${recursiveVal}'. Use true or false`,
+      );
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/engram-core/src/ingest/adapters/google-workspace.ts
+++ b/packages/engram-core/src/ingest/adapters/google-workspace.ts
@@ -42,14 +42,21 @@ import {
   assertAuthKind,
   EnrichmentAdapterError,
 } from "../adapter.js";
-import { writeCursor } from "../cursor.js";
+import { readIsoCursor, writeCursor } from "../cursor.js";
 import type { IngestResult } from "../git.js";
+import {
+  computeDiscoveryCursor,
+  enumerateFolderDocs,
+  enumerateQueryDocs,
+  parseFolderScope,
+} from "./google-workspace-discovery.js";
 import type { GWFetchFn } from "./google-workspace-helpers.js";
 import {
   extractDocText,
   fetchDoc,
   fetchDriveMeta,
   parseScope,
+  validateScope,
 } from "./google-workspace-helpers.js";
 
 // ---------------------------------------------------------------------------
@@ -58,14 +65,22 @@ import {
 
 /**
  * ScopeSchema for the Google Workspace adapter.
- * Accepts 'doc:<id>' or 'docs:<id>,<id>,...'.
+ *
+ * Accepted formats:
+ *   doc:<id>                     — single document
+ *   docs:<id>,<id>,...          — comma-separated list
+ *   folder:<id>                  — all docs in a Drive folder (flat)
+ *   folder:<id>?recursive=true  — all docs in a folder tree (BFS)
+ *   query:<drive-q>             — arbitrary Drive search query
  */
 export const googleWorkspaceScopeSchema: ScopeSchema = {
   description:
-    "Google Workspace scope. Use 'doc:<docId>' for a single document or 'docs:<id>,<id>,...' for multiple.",
+    "Google Workspace scope. " +
+    "Use 'doc:<id>' for a single document, 'docs:<id>,<id>,...' for multiple, " +
+    "'folder:<id>' (or 'folder:<id>?recursive=true') for folder enumeration, " +
+    "or 'query:<drive-q>' for a Drive search.",
   validate(scope: string): void {
-    // Delegate to the helper — it throws on invalid input
-    parseScope(scope);
+    validateScope(scope);
   },
 };
 
@@ -175,8 +190,6 @@ export class GoogleWorkspaceAdapter implements EnrichmentAdapter {
 
     googleWorkspaceScopeSchema.validate(scope);
 
-    const docIds = parseScope(scope);
-
     // Resolve token from auth credential
     const auth = opts.auth;
     let token: string | undefined;
@@ -210,23 +223,38 @@ export class GoogleWorkspaceAdapter implements EnrichmentAdapter {
     };
 
     try {
-      for (const docId of docIds) {
-        await this.ingestDoc(
+      // Discovery scopes (folder:, query:) need Drive enumeration first
+      if (scope.startsWith("folder:") || scope.startsWith("query:")) {
+        await this.enrichDiscovery(
           graph,
-          docId,
+          scope,
           token,
           refreshFn,
+          runId,
           counts,
           opts.dryRun,
         );
-      }
+      } else {
+        // Explicit doc / docs scopes
+        const docIds = parseScope(scope);
+        for (const docId of docIds) {
+          await this.ingestDoc(
+            graph,
+            docId,
+            token,
+            refreshFn,
+            counts,
+            opts.dryRun,
+          );
+        }
 
-      if (!opts.dryRun && run) {
-        completeIngestionRun(graph, runId, null, {
-          episodes: counts.episodesCreated,
-          entities: counts.entitiesCreated,
-          edges: counts.edgesCreated,
-        });
+        if (!opts.dryRun && run) {
+          completeIngestionRun(graph, runId, null, {
+            episodes: counts.episodesCreated,
+            entities: counts.entitiesCreated,
+            edges: counts.edgesCreated,
+          });
+        }
       }
 
       return { ...counts, runId };
@@ -236,6 +264,101 @@ export class GoogleWorkspaceAdapter implements EnrichmentAdapter {
         failIngestionRun(graph, runId, msg);
       }
       throw err;
+    }
+  }
+
+  /**
+   * Handle folder:<id> and query:<q> discovery scopes.
+   * Enumerates docs via Drive API, fans out to ingestDoc, and stores cursor.
+   */
+  private async enrichDiscovery(
+    graph: EngramGraph,
+    scope: string,
+    token: string,
+    refreshFn: (() => Promise<string>) | undefined,
+    runId: string,
+    counts: {
+      episodesCreated: number;
+      episodesSkipped: number;
+      entitiesCreated: number;
+      entitiesResolved: number;
+      edgesCreated: number;
+      edgesSuperseded: number;
+      episodeIds: string[];
+    },
+    dryRun?: boolean,
+  ): Promise<void> {
+    // Read cursor from last successful run for this scope
+    const since = readIsoCursor(graph, INGESTION_SOURCE, scope);
+
+    // Enumerate docs from Drive
+    let discoveredDocs: import("./google-workspace-discovery.js").DriveFileItem[];
+
+    if (scope.startsWith("folder:")) {
+      const { folderId, recursive } = parseFolderScope(scope);
+      discoveredDocs = await enumerateFolderDocs(
+        this.fetchFn,
+        token,
+        folderId,
+        recursive,
+        since,
+      );
+    } else {
+      // query: scope
+      const userQuery = scope.slice("query:".length).trim();
+      discoveredDocs = await enumerateQueryDocs(
+        this.fetchFn,
+        token,
+        userQuery,
+        since,
+      );
+    }
+
+    if (dryRun) {
+      const docIds = discoveredDocs.map((d) => d.id);
+      process.stderr.write(
+        `[dry-run] google-workspace: scope '${scope}' would ingest ${docIds.length} doc(s): ${docIds.slice(0, 5).join(", ")}${docIds.length > 5 ? ` ... and ${docIds.length - 5} more` : ""}\n`,
+      );
+      counts.episodesSkipped += docIds.length;
+      return;
+    }
+
+    // Fan out: ingest each discovered doc
+    for (const driveItem of discoveredDocs) {
+      try {
+        await this.ingestDoc(
+          graph,
+          driveItem.id,
+          token,
+          refreshFn,
+          counts,
+          false,
+        );
+      } catch (err) {
+        if (
+          err instanceof EnrichmentAdapterError &&
+          err.code === "data_error"
+        ) {
+          // Individual doc 404 or similar: log and continue
+          process.stderr.write(
+            `google-workspace: skipping doc ${driveItem.id}: ${err.message}\n`,
+          );
+          counts.episodesSkipped++;
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    // Compute and store cursor (max modifiedTime seen in this batch)
+    const newCursor = computeDiscoveryCursor(discoveredDocs);
+
+    if (runId) {
+      completeIngestionRun(graph, runId, newCursor, {
+        episodes: counts.episodesCreated,
+        entities: counts.entitiesCreated,
+        edges: counts.edgesCreated,
+      });
     }
   }
 

--- a/packages/engram-core/src/ingest/adapters/google-workspace.ts
+++ b/packages/engram-core/src/ingest/adapters/google-workspace.ts
@@ -168,7 +168,7 @@ export class GoogleWorkspaceAdapter implements EnrichmentAdapter {
 
   scopeSchema: ScopeSchema = googleWorkspaceScopeSchema;
 
-  supportsCursor = false;
+  supportsCursor = true;
 
   private fetchFn: GWFetchFn;
 
@@ -288,8 +288,9 @@ export class GoogleWorkspaceAdapter implements EnrichmentAdapter {
     },
     dryRun?: boolean,
   ): Promise<void> {
-    // Read cursor from last successful run for this scope
-    const since = readIsoCursor(graph, INGESTION_SOURCE, scope);
+    // Read cursor from last successful run for this scope.
+    // In dry-run mode skip cursor so the count reflects all in-scope docs.
+    const since = dryRun ? null : readIsoCursor(graph, INGESTION_SOURCE, scope);
 
     // Enumerate docs from Drive
     let discoveredDocs: import("./google-workspace-discovery.js").DriveFileItem[];

--- a/packages/engram-core/test/ingest/google-workspace-discovery.test.ts
+++ b/packages/engram-core/test/ingest/google-workspace-discovery.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../../src/ingest/adapters/google-workspace-discovery.js";
 import type { DocsDocument } from "../../src/ingest/adapters/google-workspace-helpers.js";
 import { validateScope } from "../../src/ingest/adapters/google-workspace-helpers.js";
+import { readIsoCursor } from "../../src/ingest/cursor.js";
+import { INGESTION_SOURCE_TYPES } from "../../src/vocab/index.js";
 
 // ---------------------------------------------------------------------------
 // Test fixtures & helpers
@@ -217,6 +219,18 @@ describe("parseFolderScope", () => {
   test("throws on invalid recursive value", () => {
     expect(() => parseFolderScope("folder:abc?recursive=yes")).toThrow(
       "Invalid value for recursive",
+    );
+  });
+
+  test("throws on folder ID containing single quote (injection guard)", () => {
+    expect(() => parseFolderScope("folder:abc'def")).toThrow(
+      "invalid folder ID",
+    );
+  });
+
+  test("throws on folder ID with query string containing single quote", () => {
+    expect(() => parseFolderScope("folder:abc'def?recursive=true")).toThrow(
+      "invalid folder ID",
     );
   });
 });
@@ -667,6 +681,14 @@ describe("GoogleWorkspaceAdapter.enrich — folder scope integration", () => {
     });
 
     expect(result1.episodesCreated).toBe(2);
+
+    // Assert cursor was stored after the first run
+    const storedCursor = readIsoCursor(
+      graph,
+      INGESTION_SOURCE_TYPES.GOOGLE_WORKSPACE,
+      `folder:${FOLDER}`,
+    );
+    expect(storedCursor).toBe("2024-06-01T00:00:00Z");
 
     // Second run: only DOC_NEW has a newer modifiedTime beyond the cursor
     // The cursor after run 1 is 2024-06-01T00:00:00Z

--- a/packages/engram-core/test/ingest/google-workspace-discovery.test.ts
+++ b/packages/engram-core/test/ingest/google-workspace-discovery.test.ts
@@ -1,0 +1,831 @@
+/**
+ * google-workspace-discovery.test.ts — Tests for Drive discovery helpers.
+ *
+ * All tests use injected fetch functions — no real Google API calls.
+ * Integration tests use in-memory SQLite and call verifyGraph().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { EngramGraph } from "../../src/index.js";
+import { closeGraph, createGraph, verifyGraph } from "../../src/index.js";
+import { GoogleWorkspaceAdapter } from "../../src/ingest/adapters/google-workspace.js";
+import {
+  computeDiscoveryCursor,
+  enumerateFolderDocs,
+  enumerateQueryDocs,
+  parseFolderScope,
+} from "../../src/ingest/adapters/google-workspace-discovery.js";
+import type { DocsDocument } from "../../src/ingest/adapters/google-workspace-helpers.js";
+import { validateScope } from "../../src/ingest/adapters/google-workspace-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures & helpers
+// ---------------------------------------------------------------------------
+
+let graph: EngramGraph;
+
+beforeEach(() => {
+  graph = createGraph(":memory:");
+});
+
+afterEach(() => {
+  closeGraph(graph);
+});
+
+const TOKEN = "test-token";
+
+/**
+ * Build a minimal mock fetch that handles Drive files.list and Docs API calls.
+ *
+ * `driveFiles` maps folderId → list of { id, modifiedTime } objects for docs.
+ * `driveFolders` maps folderId → list of subfolder IDs.
+ * `docs` maps docId → DocsDocument stub.
+ * `driveFileMeta` maps docId → drive metadata stub.
+ */
+interface DiscoveryFetchConfig {
+  driveFiles?: Record<string, Array<{ id: string; modifiedTime?: string }>>;
+  driveQueryResults?: Array<{ id: string; modifiedTime?: string }>;
+  driveFolders?: Record<string, string[]>;
+  docs?: Record<string, DocsDocument>;
+  driveFileMeta?: Record<string, object>;
+  statusOverrides?: Record<string, number>;
+}
+
+function makeDiscoveryFetch(config: DiscoveryFetchConfig): typeof fetch {
+  return async (input: RequestInfo | URL, _init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    // Drive files.list endpoint
+    if (url.includes("www.googleapis.com/drive/v3/files")) {
+      const parsed = new URL(url);
+      const q = parsed.searchParams.get("q") ?? "";
+      const fields = parsed.searchParams.get("fields") ?? "";
+
+      // Is this looking for subfolders?
+      if (q.includes("mimeType='application/vnd.google-apps.folder'")) {
+        // Extract the parent folder ID from the query
+        const match = q.match(/'([^']+)' in parents/);
+        const parentId = match?.[1] ?? "";
+        const subfolderIds = config.driveFolders?.[parentId] ?? [];
+        const files = subfolderIds.map((id) => ({ id }));
+        return new Response(JSON.stringify({ files }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      // Is this looking for docs?
+      if (q.includes("mimeType='application/vnd.google-apps.document'")) {
+        let files: Array<{ id: string; modifiedTime?: string }> = [];
+
+        if (q.includes("in parents")) {
+          // folder-based query
+          const match = q.match(/'([^']+)' in parents/);
+          const parentId = match?.[1] ?? "";
+          files = config.driveFiles?.[parentId] ?? [];
+        } else {
+          // query-based (no "in parents")
+          files = config.driveQueryResults ?? [];
+        }
+
+        // Only return id if fields don't include modifiedTime
+        const responseFiles = fields.includes("modifiedTime")
+          ? files
+          : files.map((f) => ({ id: f.id }));
+
+        return new Response(JSON.stringify({ files: responseFiles }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      // Drive metadata for a specific file (fetchDriveMeta)
+      const fileMatch = url.match(/\/drive\/v3\/files\/([^?]+)/);
+      if (fileMatch && !url.includes("drive/v3/files?")) {
+        const docId = fileMatch[1];
+        const meta = config.driveFileMeta?.[docId];
+        if (meta) {
+          return new Response(JSON.stringify(meta), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
+    // Drive metadata for specific doc — must be before docs API to avoid match collision
+    if (url.includes("www.googleapis.com/drive/v3/files/")) {
+      const fileMatch = url.match(/\/files\/([^?]+)/);
+      const docId = fileMatch?.[1] ?? "";
+      const meta = config.driveFileMeta?.[docId];
+      if (meta) {
+        return new Response(JSON.stringify(meta), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Docs API
+    if (url.includes("docs.googleapis.com")) {
+      const match = url.match(/\/documents\/([^?]+)/);
+      const docId = match?.[1] ?? "";
+      const doc = config.docs?.[docId];
+      if (doc) {
+        const status = config.statusOverrides?.[docId] ?? 200;
+        return new Response(JSON.stringify(doc), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ error: "unexpected url" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+function makeDoc(
+  docId: string,
+  revisionId = "rev1",
+  title = "Test",
+): DocsDocument {
+  return { documentId: docId, title, revisionId, body: { content: [] } };
+}
+
+function makeDriveMeta(ownerEmail = "owner@example.com") {
+  return {
+    modifiedTime: "2024-06-01T12:00:00Z",
+    owners: [{ emailAddress: ownerEmail, displayName: "Owner" }],
+    lastModifyingUser: { emailAddress: ownerEmail, displayName: "Owner" },
+    permissions: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseFolderScope — unit tests
+// ---------------------------------------------------------------------------
+
+describe("parseFolderScope", () => {
+  test("parses plain folder:<id>", () => {
+    expect(parseFolderScope("folder:abc123")).toEqual({
+      folderId: "abc123",
+      recursive: false,
+    });
+  });
+
+  test("parses folder:<id>?recursive=true", () => {
+    expect(parseFolderScope("folder:abc123?recursive=true")).toEqual({
+      folderId: "abc123",
+      recursive: true,
+    });
+  });
+
+  test("parses folder:<id>?recursive=false as non-recursive", () => {
+    expect(parseFolderScope("folder:abc123?recursive=false")).toEqual({
+      folderId: "abc123",
+      recursive: false,
+    });
+  });
+
+  test("throws on empty folder ID", () => {
+    expect(() => parseFolderScope("folder:")).toThrow(
+      "folder scope must include a folder ID",
+    );
+  });
+
+  test("throws on unknown query param", () => {
+    expect(() => parseFolderScope("folder:abc?foo=bar")).toThrow(
+      "Unknown query parameter in folder scope: 'foo'",
+    );
+  });
+
+  test("throws on invalid recursive value", () => {
+    expect(() => parseFolderScope("folder:abc?recursive=yes")).toThrow(
+      "Invalid value for recursive",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateScope — unit tests (all patterns)
+// ---------------------------------------------------------------------------
+
+describe("validateScope", () => {
+  test("accepts doc:<id>", () => {
+    expect(() => validateScope("doc:abc123")).not.toThrow();
+  });
+
+  test("accepts docs:<id>,<id>", () => {
+    expect(() => validateScope("docs:id1,id2")).not.toThrow();
+  });
+
+  test("accepts folder:<id>", () => {
+    expect(() => validateScope("folder:folderXYZ")).not.toThrow();
+  });
+
+  test("accepts folder:<id>?recursive=true", () => {
+    expect(() =>
+      validateScope("folder:folderXYZ?recursive=true"),
+    ).not.toThrow();
+  });
+
+  test("accepts folder:<id>?recursive=false", () => {
+    expect(() =>
+      validateScope("folder:folderXYZ?recursive=false"),
+    ).not.toThrow();
+  });
+
+  test("accepts query:<non-empty>", () => {
+    expect(() => validateScope("query:name contains 'spec'")).not.toThrow();
+  });
+
+  test("rejects doc: (empty id)", () => {
+    expect(() => validateScope("doc:")).toThrow();
+  });
+
+  test("rejects docs: (empty list)", () => {
+    expect(() => validateScope("docs:")).toThrow();
+  });
+
+  test("rejects folder: (empty id)", () => {
+    expect(() => validateScope("folder:")).toThrow();
+  });
+
+  test("rejects folder:<id>?foo=bar (unknown param)", () => {
+    expect(() => validateScope("folder:abc?foo=bar")).toThrow(
+      "Unknown query parameter",
+    );
+  });
+
+  test("rejects query: (empty query)", () => {
+    expect(() => validateScope("query:")).toThrow();
+  });
+
+  test("rejects unknown prefix", () => {
+    expect(() => validateScope("drive:abc")).toThrow(
+      "Unsupported scope format",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enumerateFolderDocs — unit tests
+// ---------------------------------------------------------------------------
+
+describe("enumerateFolderDocs", () => {
+  test("returns docs from a flat folder", async () => {
+    const fetchFn = makeDiscoveryFetch({
+      driveFiles: {
+        folder1: [
+          { id: "doc1", modifiedTime: "2024-01-01T00:00:00Z" },
+          { id: "doc2", modifiedTime: "2024-02-01T00:00:00Z" },
+        ],
+      },
+    });
+
+    const docs = await enumerateFolderDocs(
+      fetchFn,
+      TOKEN,
+      "folder1",
+      false,
+      null,
+    );
+    expect(docs.map((d) => d.id)).toEqual(["doc1", "doc2"]);
+  });
+
+  test("returns empty array for empty folder", async () => {
+    const fetchFn = makeDiscoveryFetch({
+      driveFiles: { folder1: [] },
+    });
+
+    const docs = await enumerateFolderDocs(
+      fetchFn,
+      TOKEN,
+      "folder1",
+      false,
+      null,
+    );
+    expect(docs).toHaveLength(0);
+  });
+
+  test("recursive mode traverses subfolders via BFS", async () => {
+    const fetchFn = makeDiscoveryFetch({
+      driveFiles: {
+        root: [{ id: "rootDoc", modifiedTime: "2024-01-01T00:00:00Z" }],
+        child1: [{ id: "childDoc1", modifiedTime: "2024-01-02T00:00:00Z" }],
+        child2: [{ id: "childDoc2", modifiedTime: "2024-01-03T00:00:00Z" }],
+      },
+      driveFolders: {
+        root: ["child1", "child2"],
+        child1: [],
+        child2: [],
+      },
+    });
+
+    const docs = await enumerateFolderDocs(fetchFn, TOKEN, "root", true, null);
+    const ids = docs.map((d) => d.id).sort();
+    expect(ids).toEqual(["childDoc1", "childDoc2", "rootDoc"]);
+  });
+
+  test("cycle guard prevents infinite loop on shared-drive shortcut loop", async () => {
+    // child1 → child2 → child1 (cycle)
+    const fetchFn = makeDiscoveryFetch({
+      driveFiles: {
+        root: [],
+        child1: [{ id: "doc1", modifiedTime: "2024-01-01T00:00:00Z" }],
+        child2: [],
+      },
+      driveFolders: {
+        root: ["child1"],
+        child1: ["child2"],
+        child2: ["child1"], // creates a cycle
+      },
+    });
+
+    // Should complete without hanging
+    const docs = await enumerateFolderDocs(fetchFn, TOKEN, "root", true, null);
+    expect(docs.map((d) => d.id)).toContain("doc1");
+  });
+
+  test("since cursor is included in query URL", async () => {
+    const capturedUrls: string[] = [];
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      capturedUrls.push(url);
+      return new Response(JSON.stringify({ files: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    await enumerateFolderDocs(
+      fetchFn as typeof fetch,
+      TOKEN,
+      "folder1",
+      false,
+      "2024-06-01T00:00:00Z",
+    );
+
+    const driveUrl = capturedUrls.find((u) => u.includes("drive/v3/files"));
+    expect(driveUrl).toBeDefined();
+    // The 'q' param should contain modifiedTime filter
+    const parsed = new URL(driveUrl as string);
+    expect(parsed.searchParams.get("q")).toContain(
+      "modifiedTime > '2024-06-01T00:00:00Z'",
+    );
+  });
+
+  test("non-recursive mode does not enumerate subfolders", async () => {
+    const capturedUrls: string[] = [];
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      capturedUrls.push(url);
+      return new Response(JSON.stringify({ files: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    await enumerateFolderDocs(
+      fetchFn as typeof fetch,
+      TOKEN,
+      "folder1",
+      false,
+      null,
+    );
+
+    // Should only have one Drive API call (for docs), not two (docs + subfolders)
+    const driveCalls = capturedUrls.filter((u) => u.includes("drive/v3/files"));
+    expect(driveCalls).toHaveLength(1);
+    const q = new URL(driveCalls[0]).searchParams.get("q") ?? "";
+    // The query should be for docs (not for subfolders)
+    expect(q).toContain("mimeType='application/vnd.google-apps.document'");
+    expect(q).not.toContain("application/vnd.google-apps.folder");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enumerateQueryDocs — unit tests
+// ---------------------------------------------------------------------------
+
+describe("enumerateQueryDocs", () => {
+  test("returns docs matching the query", async () => {
+    const fetchFn = makeDiscoveryFetch({
+      driveQueryResults: [
+        { id: "qDoc1", modifiedTime: "2024-03-01T00:00:00Z" },
+        { id: "qDoc2", modifiedTime: "2024-03-02T00:00:00Z" },
+      ],
+    });
+
+    const docs = await enumerateQueryDocs(
+      fetchFn,
+      TOKEN,
+      "name contains 'spec'",
+      null,
+    );
+    expect(docs.map((d) => d.id)).toEqual(["qDoc1", "qDoc2"]);
+  });
+
+  test("AND-injects mimeType constraint into query", async () => {
+    const capturedUrls: string[] = [];
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      capturedUrls.push(url);
+      return new Response(JSON.stringify({ files: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    await enumerateQueryDocs(
+      fetchFn as typeof fetch,
+      TOKEN,
+      "name contains 'spec'",
+      null,
+    );
+
+    const driveUrl = capturedUrls.find((u) => u.includes("drive/v3/files"));
+    expect(driveUrl).toBeDefined();
+    const q = new URL(driveUrl as string).searchParams.get("q") ?? "";
+    // Must include mimeType AND-injection
+    expect(q).toContain("mimeType='application/vnd.google-apps.document'");
+    // Must include trashed=false
+    expect(q).toContain("trashed=false");
+    // Must include user query wrapped in parens
+    expect(q).toContain("(name contains 'spec')");
+  });
+
+  test("since cursor appends modifiedTime filter", async () => {
+    const capturedUrls: string[] = [];
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      capturedUrls.push(url);
+      return new Response(JSON.stringify({ files: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    await enumerateQueryDocs(
+      fetchFn as typeof fetch,
+      TOKEN,
+      "name contains 'spec'",
+      "2024-05-01T00:00:00Z",
+    );
+
+    const driveUrl = capturedUrls.find((u) => u.includes("drive/v3/files"));
+    const q = new URL(driveUrl as string).searchParams.get("q") ?? "";
+    expect(q).toContain("modifiedTime > '2024-05-01T00:00:00Z'");
+  });
+
+  test("empty query throws data_error", async () => {
+    const fetchFn = async () =>
+      new Response(JSON.stringify({ files: [] }), { status: 200 });
+
+    await expect(
+      enumerateQueryDocs(fetchFn as typeof fetch, TOKEN, "", null),
+    ).rejects.toMatchObject({ code: "data_error" });
+  });
+
+  test("400 response from Drive throws data_error", async () => {
+    const fetchFn = async () =>
+      new Response(
+        JSON.stringify({ error: { code: 400, message: "Bad query" } }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+
+    await expect(
+      enumerateQueryDocs(
+        fetchFn as typeof fetch,
+        TOKEN,
+        "bad query syntax !!!",
+        null,
+      ),
+    ).rejects.toMatchObject({ code: "data_error" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeDiscoveryCursor — unit tests
+// ---------------------------------------------------------------------------
+
+describe("computeDiscoveryCursor", () => {
+  test("returns null for empty list", () => {
+    expect(computeDiscoveryCursor([])).toBeNull();
+  });
+
+  test("returns the single item's modifiedTime", () => {
+    expect(
+      computeDiscoveryCursor([
+        { id: "x", modifiedTime: "2024-01-01T00:00:00Z" },
+      ]),
+    ).toBe("2024-01-01T00:00:00Z");
+  });
+
+  test("returns the maximum modifiedTime", () => {
+    expect(
+      computeDiscoveryCursor([
+        { id: "a", modifiedTime: "2024-01-01T00:00:00Z" },
+        { id: "b", modifiedTime: "2024-06-01T00:00:00Z" },
+        { id: "c", modifiedTime: "2024-03-01T00:00:00Z" },
+      ]),
+    ).toBe("2024-06-01T00:00:00Z");
+  });
+
+  test("ignores items without modifiedTime", () => {
+    expect(
+      computeDiscoveryCursor([
+        { id: "a" },
+        { id: "b", modifiedTime: "2024-04-01T00:00:00Z" },
+      ]),
+    ).toBe("2024-04-01T00:00:00Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: folder scope → adapter.enrich
+// ---------------------------------------------------------------------------
+
+describe("GoogleWorkspaceAdapter.enrich — folder scope integration", () => {
+  test("folder: scope ingests all docs and verifyGraph passes", async () => {
+    const DOC_A = "folderDocA";
+    const DOC_B = "folderDocB";
+    const FOLDER = "folderXYZ";
+
+    const fetchFn = makeDiscoveryFetch({
+      driveFiles: {
+        [FOLDER]: [
+          { id: DOC_A, modifiedTime: "2024-01-10T00:00:00Z" },
+          { id: DOC_B, modifiedTime: "2024-01-11T00:00:00Z" },
+        ],
+      },
+      docs: {
+        [DOC_A]: makeDoc(DOC_A, "rev1", "Doc A"),
+        [DOC_B]: makeDoc(DOC_B, "rev1", "Doc B"),
+      },
+      driveFileMeta: {
+        [DOC_A]: makeDriveMeta("alice@example.com"),
+        [DOC_B]: makeDriveMeta("bob@example.com"),
+      },
+    });
+
+    const adapter = new GoogleWorkspaceAdapter(fetchFn);
+    const result = await adapter.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: `folder:${FOLDER}`,
+    });
+
+    expect(result.episodesCreated).toBe(2);
+    expect(result.entitiesCreated).toBeGreaterThanOrEqual(2);
+
+    const verify = verifyGraph(graph);
+    expect(verify.violations).toHaveLength(0);
+  });
+
+  test("folder: scope with recursive=true traverses subfolders", async () => {
+    const DOC_ROOT = "docRoot";
+    const DOC_CHILD = "docChild";
+    const FOLDER = "rootFolder";
+    const SUBFOLDER = "subFolder1";
+
+    const fetchFn = makeDiscoveryFetch({
+      driveFiles: {
+        [FOLDER]: [{ id: DOC_ROOT, modifiedTime: "2024-01-10T00:00:00Z" }],
+        [SUBFOLDER]: [{ id: DOC_CHILD, modifiedTime: "2024-01-11T00:00:00Z" }],
+      },
+      driveFolders: {
+        [FOLDER]: [SUBFOLDER],
+        [SUBFOLDER]: [],
+      },
+      docs: {
+        [DOC_ROOT]: makeDoc(DOC_ROOT, "rev1", "Root Doc"),
+        [DOC_CHILD]: makeDoc(DOC_CHILD, "rev1", "Child Doc"),
+      },
+      driveFileMeta: {
+        [DOC_ROOT]: makeDriveMeta("alice@example.com"),
+        [DOC_CHILD]: makeDriveMeta("alice@example.com"),
+      },
+    });
+
+    const adapter = new GoogleWorkspaceAdapter(fetchFn);
+    const result = await adapter.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: `folder:${FOLDER}?recursive=true`,
+    });
+
+    expect(result.episodesCreated).toBe(2);
+
+    const verify = verifyGraph(graph);
+    expect(verify.violations).toHaveLength(0);
+  });
+
+  test("second run uses cursor — only fetches docs modified after cursor", async () => {
+    const DOC_OLD = "docOld";
+    const DOC_NEW = "docNew";
+    const FOLDER = "folderCursor";
+
+    // First run: return both docs
+    const fetchFn1 = makeDiscoveryFetch({
+      driveFiles: {
+        [FOLDER]: [
+          { id: DOC_OLD, modifiedTime: "2024-01-01T00:00:00Z" },
+          { id: DOC_NEW, modifiedTime: "2024-06-01T00:00:00Z" },
+        ],
+      },
+      docs: {
+        [DOC_OLD]: makeDoc(DOC_OLD, "rev1", "Old Doc"),
+        [DOC_NEW]: makeDoc(DOC_NEW, "rev1", "New Doc"),
+      },
+      driveFileMeta: {
+        [DOC_OLD]: makeDriveMeta(),
+        [DOC_NEW]: makeDriveMeta(),
+      },
+    });
+
+    const adapter1 = new GoogleWorkspaceAdapter(fetchFn1);
+    const result1 = await adapter1.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: `folder:${FOLDER}`,
+    });
+
+    expect(result1.episodesCreated).toBe(2);
+
+    // Second run: only DOC_NEW has a newer modifiedTime beyond the cursor
+    // The cursor after run 1 is 2024-06-01T00:00:00Z
+    // We simulate only the new-doc being returned (cursor filtered by Drive)
+    const capturedQueries: string[] = [];
+    const fetchFn2 = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("drive/v3/files") && url.includes("q=")) {
+        const q = new URL(url).searchParams.get("q") ?? "";
+        capturedQueries.push(q);
+        // Return empty (no docs changed since cursor)
+        return new Response(JSON.stringify({ files: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const adapter2 = new GoogleWorkspaceAdapter(fetchFn2 as typeof fetch);
+    await adapter2.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: `folder:${FOLDER}`,
+    });
+
+    // The cursor should have been included in the query
+    expect(capturedQueries.some((q) => q.includes("modifiedTime >"))).toBe(
+      true,
+    );
+    expect(
+      capturedQueries.some((q) => q.includes("2024-06-01T00:00:00Z")),
+    ).toBe(true);
+  });
+
+  test("dry-run for folder scope skips content fetch and returns 0 episodes created", async () => {
+    const DOC = "dryRunDoc";
+    const FOLDER = "dryRunFolder";
+
+    const contentFetchCalled: string[] = [];
+    const fetchFn = async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("docs.googleapis.com")) {
+        contentFetchCalled.push(url);
+      }
+      if (url.includes("drive/v3/files") && url.includes("q=")) {
+        return new Response(
+          JSON.stringify({
+            files: [{ id: DOC, modifiedTime: "2024-01-01T00:00:00Z" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const adapter = new GoogleWorkspaceAdapter(fetchFn as typeof fetch);
+    const result = await adapter.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: `folder:${FOLDER}`,
+      dryRun: true,
+    });
+
+    expect(result.episodesCreated).toBe(0);
+    expect(contentFetchCalled).toHaveLength(0); // no Docs API calls in dry-run
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: query scope → adapter.enrich
+// ---------------------------------------------------------------------------
+
+describe("GoogleWorkspaceAdapter.enrich — query scope integration", () => {
+  test("query: scope ingests matching docs and verifyGraph passes", async () => {
+    const DOC = "queryDoc1";
+
+    const fetchFn = makeDiscoveryFetch({
+      driveQueryResults: [{ id: DOC, modifiedTime: "2024-04-01T00:00:00Z" }],
+      docs: { [DOC]: makeDoc(DOC, "rev1", "Query Doc") },
+      driveFileMeta: { [DOC]: makeDriveMeta() },
+    });
+
+    const adapter = new GoogleWorkspaceAdapter(fetchFn);
+    const result = await adapter.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: "query:name contains 'spec'",
+    });
+
+    expect(result.episodesCreated).toBe(1);
+
+    const verify = verifyGraph(graph);
+    expect(verify.violations).toHaveLength(0);
+  });
+
+  test("incremental second run: advanced modifiedTime triggers supersession, unchanged skips", async () => {
+    const DOC = "incrDoc";
+
+    // First run: ingest rev1
+    const fetchFn1 = makeDiscoveryFetch({
+      driveQueryResults: [{ id: DOC, modifiedTime: "2024-04-01T00:00:00Z" }],
+      docs: { [DOC]: makeDoc(DOC, "rev1", "Incremental Doc") },
+      driveFileMeta: {
+        [DOC]: {
+          modifiedTime: "2024-04-01T00:00:00Z",
+          owners: [{ emailAddress: "owner@example.com", displayName: "Owner" }],
+          lastModifyingUser: {
+            emailAddress: "owner@example.com",
+            displayName: "Owner",
+          },
+          permissions: [],
+        },
+      },
+    });
+
+    const adapter1 = new GoogleWorkspaceAdapter(fetchFn1);
+    const result1 = await adapter1.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: "query:name contains 'incrDoc'",
+    });
+
+    expect(result1.episodesCreated).toBe(1);
+
+    // Second run: same query, doc at rev2 (content changed)
+    const fetchFn2 = makeDiscoveryFetch({
+      driveQueryResults: [{ id: DOC, modifiedTime: "2024-05-01T00:00:00Z" }],
+      docs: { [DOC]: makeDoc(DOC, "rev2", "Incremental Doc Updated") },
+      driveFileMeta: {
+        [DOC]: {
+          modifiedTime: "2024-05-01T00:00:00Z",
+          owners: [{ emailAddress: "owner@example.com", displayName: "Owner" }],
+          lastModifyingUser: {
+            emailAddress: "owner@example.com",
+            displayName: "Owner",
+          },
+          permissions: [],
+        },
+      },
+    });
+
+    const adapter2 = new GoogleWorkspaceAdapter(fetchFn2);
+    const result2 = await adapter2.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: "query:name contains 'incrDoc'",
+    });
+
+    expect(result2.episodesCreated).toBe(1); // superseded
+    expect(result2.edgesSuperseded).toBe(1);
+
+    // Third run: same revision — skip
+    const adapter3 = new GoogleWorkspaceAdapter(fetchFn2);
+    const result3 = await adapter3.enrich(graph, {
+      auth: { kind: "bearer", token: TOKEN },
+      scope: "query:name contains 'incrDoc'",
+    });
+
+    // Drive returns doc (since modifiedTime cursor may or may not filter)
+    // but revision hasn't changed → skip
+    expect(result3.episodesCreated).toBe(0);
+
+    const verify = verifyGraph(graph);
+    expect(verify.violations).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Extends `GoogleWorkspaceAdapter` with Drive-based doc discovery: `folder:<id>`, `folder:<id>?recursive=true`, and `query:<drive-q>` scopes
- Adds `google-workspace-discovery.ts` with `enumerateFolderDocs()` (flat + BFS recursive with cycle guard), `enumerateQueryDocs()` (mimeType AND-injection), `parseFolderScope()`, and `computeDiscoveryCursor()`
- Cursor semantics: stores `max(modifiedTime)` after each run; subsequent runs augment the Drive query with `modifiedTime > '<cursor>'` for incremental ingest
- Dry-run for discovery scopes runs Drive list calls but skips Docs content fetch, returning `episodesCreated: 0`

## Acceptance Criteria

- [x] `folder:<id>` enumerates all Docs in a flat folder via Drive files.list
- [x] `folder:<id>?recursive=true` traverses subfolders via BFS with cycle guard
- [x] `folder:<id>?foo=bar` rejected (unknown query param, error lists valid keys)
- [x] `query:<drive-q>` AND-injects `mimeType` and `trashed=false` constraints
- [x] `query:` (empty) rejected with `data_error`
- [x] 400 from Drive (malformed query) → `EnrichmentAdapterError { code: 'data_error' }`
- [x] Individual doc 404 in fan-out → logged, skipped, continues
- [x] Cursor stored as `max(modifiedTime)` across enumerated docs; next run augments query
- [x] Dry-run enumerates docs but skips Docs API calls
- [x] `verifyGraph()` passes after folder and query ingest
- [x] Existing `doc:` and `docs:` scopes unchanged
- [x] 39 unit + integration tests (injected fetch, real SQLite `:memory:`)
- [x] Build passes, lint clean, all tests pass

## Test plan

- Run `bun test packages/engram-core/test/ingest/google-workspace-discovery.test.ts` — 39 tests pass
- Run `bun test packages/engram-core/test/ingest/google-workspace.test.ts` — 32 existing tests pass
- Run `bun run build && bun run lint` — clean

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)