### PR TITLE
refactor(ingest): move google-workspace adapter to packages/plugins/

### DIFF
--- a/packages/engram-cli/package.json
+++ b/packages/engram-cli/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@clack/prompts": "^0.9.0",
     "@engram/engram-web": "workspace:*",
+    "@engram/plugin-google-workspace": "workspace:*",
     "commander": "^13.0.0",
     "engram-core": "workspace:*",
     "google-auth-library": "^9.0.0",

--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -11,7 +11,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { intro, log, outro, spinner } from "@clack/prompts";
-
+import { GoogleWorkspaceAdapter } from "@engram/plugin-google-workspace";
 // git and markdown ingest use execFileSync / synchronous SQLite — the event
 // loop is blocked for the duration, so spinner intervals cannot fire.
 // For those commands we log a "starting" line and print results when done.
@@ -26,7 +26,6 @@ import {
   closeGraph,
   EnrichmentAdapterError,
   GitHubAdapter,
-  GoogleWorkspaceAdapter,
   ingestGitRepo,
   ingestMarkdown,
   ingestSource,

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -156,10 +156,6 @@ export {
   GitHubAuthError,
   githubScopeSchema,
 } from "./ingest/adapters/github.js";
-export {
-  GoogleWorkspaceAdapter,
-  googleWorkspaceScopeSchema,
-} from "./ingest/adapters/google-workspace.js";
 export type {
   PluginReferencePattern,
   ReferencePattern,

--- a/packages/plugins/google-workspace/manifest.json
+++ b/packages/plugins/google-workspace/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "google-workspace",
+  "version": "0.1.0",
+  "contract_version": 1,
+  "transport": "js-module",
+  "entry": "src/index.ts",
+  "capabilities": {
+    "supported_auth": ["oauth2", "bearer"],
+    "supports_cursor": true,
+    "scope_schema": {
+      "description": "doc:<id> | docs:<id>,<id>,... | folder:<id>[?recursive=true] | query:<drive-q>",
+      "pattern": "^(doc:|docs:|folder:|query:).+"
+    }
+  }
+}

--- a/packages/plugins/google-workspace/package.json
+++ b/packages/plugins/google-workspace/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@engram/plugin-google-workspace",
+  "version": "0.1.0",
+  "description": "Google Workspace enrichment adapter for engram (in-repo plugin)",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "echo 'plugin: no build step required'",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "engram-core": "workspace:*",
+    "google-auth-library": "^9.0.0",
+    "ulid": "^2.3.0"
+  }
+}

--- a/packages/plugins/google-workspace/src/discovery.ts
+++ b/packages/plugins/google-workspace/src/discovery.ts
@@ -1,5 +1,8 @@
 /**
- * google-workspace-discovery.ts — Drive discovery helpers for folder and query scopes.
+ * discovery.ts — Drive discovery helpers for folder and query scopes.
+ *
+ * Ported from packages/engram-core/src/ingest/adapters/google-workspace-discovery.ts
+ * into the in-repo plugin package.
  *
  * Provides:
  * - `enumerateFolderDocs()` — list all Google Docs in a Drive folder (flat or recursive BFS)
@@ -16,9 +19,9 @@
  *   new cursor.
  */
 
-import { EnrichmentAdapterError } from "../adapter.js";
-import type { GWFetchFn } from "./google-workspace-helpers.js";
-import { apiGetGW } from "./google-workspace-helpers.js";
+import { EnrichmentAdapterError } from "engram-core";
+import type { GWFetchFn } from "./helpers.js";
+import { apiGetGW } from "./helpers.js";
 
 // ---------------------------------------------------------------------------
 // Drive API types (only fields we use)

--- a/packages/plugins/google-workspace/src/helpers.ts
+++ b/packages/plugins/google-workspace/src/helpers.ts
@@ -1,5 +1,8 @@
 /**
- * google-workspace-helpers.ts — Internal helpers for the Google Workspace adapter.
+ * helpers.ts — Internal helpers for the Google Workspace adapter.
+ *
+ * Ported from packages/engram-core/src/ingest/adapters/google-workspace-helpers.ts
+ * into the in-repo plugin package.
  *
  * Provides:
  * - Scope parsing (doc:<id>, docs:<id>,<id>,...)
@@ -8,7 +11,7 @@
  * - Error-classified HTTP fetch helpers
  */
 
-import { EnrichmentAdapterError } from "../adapter.js";
+import { EnrichmentAdapterError } from "engram-core";
 
 // ---------------------------------------------------------------------------
 // Google Docs API types (only fields we use)

--- a/packages/plugins/google-workspace/src/index.ts
+++ b/packages/plugins/google-workspace/src/index.ts
@@ -1,5 +1,8 @@
 /**
- * google-workspace.ts — Google Workspace enrichment adapter (MVP: Google Docs).
+ * index.ts — Google Workspace enrichment adapter (in-repo plugin).
+ *
+ * Ported from packages/engram-core/src/ingest/adapters/google-workspace.ts
+ * into the in-repo plugin package.
  *
  * Ingests explicitly-specified Google Docs as revision-aware episodes.
  * Supports oauth2 (ADC-minted at CLI layer) and bearer token auth.
@@ -7,57 +10,62 @@
  * Scope formats:
  *   doc:<docId>          — single document
  *   docs:<id>,<id>,...   — comma-separated list
+ *   folder:<id>          — all docs in a Drive folder (flat)
+ *   folder:<id>?recursive=true — all docs in a folder tree (BFS)
+ *   query:<drive-q>      — arbitrary Drive search query
  *
  * Revision-aware supersession:
  *   - First ingest: addEpisode()
  *   - Re-ingest, same revisionId: skip
  *   - Re-ingest, new revisionId: supersedeEpisode()
+ *
+ * Default export: GoogleWorkspaceAdapter instance (required by js-module plugin contract).
  */
 
-import { ulid } from "ulid";
-import type { EngramGraph } from "../../format/index.js";
-import { ENGINE_VERSION } from "../../format/version.js";
-import { addEntityAlias, resolveEntity } from "../../graph/aliases.js";
-import { addEdge, findEdges } from "../../graph/edges.js";
-import { addEntity } from "../../graph/entities.js";
-import {
-  addEpisode,
-  getCurrentEpisode,
-  supersedeEpisode,
-} from "../../graph/episodes.js";
-import {
-  ENTITY_TYPES,
-  EPISODE_SOURCE_TYPES,
-  INGESTION_SOURCE_TYPES,
-  RELATION_TYPES,
-} from "../../vocab/index.js";
 import type {
   AuthCredential,
+  EngramGraph,
   EnrichmentAdapter,
   EnrichOpts,
+  IngestResult,
   ScopeSchema,
-} from "../adapter.js";
+} from "engram-core";
 import {
+  addEdge,
+  addEntity,
+  addEntityAlias,
+  addEpisode,
   applyCompatShim,
   assertAuthKind,
+  ENGINE_VERSION,
+  ENTITY_TYPES,
   EnrichmentAdapterError,
-} from "../adapter.js";
-import { readIsoCursor, writeCursor } from "../cursor.js";
-import type { IngestResult } from "../git.js";
+  EPISODE_SOURCE_TYPES,
+  findEdges,
+  getCurrentEpisode,
+  INGESTION_SOURCE_TYPES,
+  RELATION_TYPES,
+  readIsoCursor,
+  resolveEntity,
+  supersedeEpisode,
+  writeCursor,
+} from "engram-core";
+import { ulid } from "ulid";
+import type { DriveFileItem } from "./discovery.js";
 import {
   computeDiscoveryCursor,
   enumerateFolderDocs,
   enumerateQueryDocs,
   parseFolderScope,
-} from "./google-workspace-discovery.js";
-import type { GWFetchFn } from "./google-workspace-helpers.js";
+} from "./discovery.js";
+import type { GWFetchFn } from "./helpers.js";
 import {
   extractDocText,
   fetchDoc,
   fetchDriveMeta,
   parseScope,
   validateScope,
-} from "./google-workspace-helpers.js";
+} from "./helpers.js";
 
 // ---------------------------------------------------------------------------
 // Scope schema
@@ -293,7 +301,7 @@ export class GoogleWorkspaceAdapter implements EnrichmentAdapter {
     const since = dryRun ? null : readIsoCursor(graph, INGESTION_SOURCE, scope);
 
     // Enumerate docs from Drive
-    let discoveredDocs: import("./google-workspace-discovery.js").DriveFileItem[];
+    let discoveredDocs: DriveFileItem[];
 
     if (scope.startsWith("folder:")) {
       const { folderId, recursive } = parseFolderScope(scope);
@@ -639,3 +647,6 @@ function ensurePersonEntity(
   counts.entitiesCreated++;
   return entity.id;
 }
+
+// Default export required by the js-module plugin transport contract.
+export default new GoogleWorkspaceAdapter();

--- a/packages/plugins/google-workspace/test/google-workspace-discovery.test.ts
+++ b/packages/plugins/google-workspace/test/google-workspace-discovery.test.ts
@@ -6,19 +6,23 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { EngramGraph } from "../../src/index.js";
-import { closeGraph, createGraph, verifyGraph } from "../../src/index.js";
-import { GoogleWorkspaceAdapter } from "../../src/ingest/adapters/google-workspace.js";
+import type { EngramGraph } from "engram-core";
+import {
+  closeGraph,
+  createGraph,
+  INGESTION_SOURCE_TYPES,
+  readIsoCursor,
+  verifyGraph,
+} from "engram-core";
 import {
   computeDiscoveryCursor,
   enumerateFolderDocs,
   enumerateQueryDocs,
   parseFolderScope,
-} from "../../src/ingest/adapters/google-workspace-discovery.js";
-import type { DocsDocument } from "../../src/ingest/adapters/google-workspace-helpers.js";
-import { validateScope } from "../../src/ingest/adapters/google-workspace-helpers.js";
-import { readIsoCursor } from "../../src/ingest/cursor.js";
-import { INGESTION_SOURCE_TYPES } from "../../src/vocab/index.js";
+} from "../src/discovery.js";
+import type { DocsDocument } from "../src/helpers.js";
+import { validateScope } from "../src/helpers.js";
+import { GoogleWorkspaceAdapter } from "../src/index.js";
 
 // ---------------------------------------------------------------------------
 // Test fixtures & helpers

--- a/packages/plugins/google-workspace/test/google-workspace.test.ts
+++ b/packages/plugins/google-workspace/test/google-workspace.test.ts
@@ -6,19 +6,17 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { getCurrentEpisode } from "../../src/graph/episodes.js";
-import type { EngramGraph } from "../../src/index.js";
-import { closeGraph, createGraph, verifyGraph } from "../../src/index.js";
-import { GoogleWorkspaceAdapter } from "../../src/ingest/adapters/google-workspace.js";
-import type {
-  DocsDocument,
-  DocsStructuralElement,
-} from "../../src/ingest/adapters/google-workspace-helpers.js";
+import type { EngramGraph } from "engram-core";
 import {
-  extractDocText,
-  parseScope,
-} from "../../src/ingest/adapters/google-workspace-helpers.js";
-import { EPISODE_SOURCE_TYPES } from "../../src/vocab/index.js";
+  closeGraph,
+  createGraph,
+  EPISODE_SOURCE_TYPES,
+  getCurrentEpisode,
+  verifyGraph,
+} from "engram-core";
+import type { DocsDocument, DocsStructuralElement } from "../src/helpers.js";
+import { extractDocText, parseScope } from "../src/helpers.js";
+import { GoogleWorkspaceAdapter } from "../src/index.js";
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

- Moves `GoogleWorkspaceAdapter` from `engram-core/src/ingest/adapters/` to
  `packages/plugins/google-workspace/`, following the in-repo plugin model
  established by the gerrit port
- Adds `@engram/plugin-google-workspace` workspace package with `package.json`,
  `manifest.json`, and migrated source (`index.ts`, `helpers.ts`, `discovery.ts`)
- Removes `GoogleWorkspaceAdapter` and `googleWorkspaceScopeSchema` exports from
  `engram-core/src/index.ts`
- Updates `engram-cli` to import `GoogleWorkspaceAdapter` from
  `@engram/plugin-google-workspace` instead of `engram-core`
- Moves all Google Workspace tests to `packages/plugins/google-workspace/test/`
  with imports updated to use `engram-core` and relative plugin paths

Addresses ADR-006 decision in DECISIONS.md.

All 1379 tests pass, build succeeds, lint clean.

## Test plan

- [x] `bun run build` — all packages build cleanly
- [x] `bun test` — 1379 tests pass (0 failures), including the migrated
  Google Workspace adapter and discovery tests in the new plugin package
- [x] `bun run lint` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)