### PR TITLE
feat(plugins): plugin docs contract — manifest description/docs fields and plugin info command

### DIFF
--- a/docs/internal/specs/plugin-docs.md
+++ b/docs/internal/specs/plugin-docs.md
@@ -1,0 +1,115 @@
+# Plugin Documentation Contract
+
+> Spec for optional `description` and `docs` fields in plugin manifests.
+> Companion to `plugin-loading.md`.
+
+---
+
+## 1. Manifest fields
+
+Two optional top-level fields extend `PluginManifest`:
+
+### `description` (string, optional)
+
+A single-line description of the plugin shown in `plugin list` output. Max
+recommended length: 80 characters.
+
+```json
+{
+  "description": "Ingest Gerrit code-review changes as episodes"
+}
+```
+
+### `docs` (object, optional)
+
+Extended documentation surfaced by `plugin info` and at install time.
+
+```typescript
+interface PluginDocs {
+  /** 2–4 sentence overview shown by `engram plugin info`. */
+  summary?: string;
+  /** What the user must do before first use (auth setup, credentials, etc.). */
+  auth_setup?: string;
+  /** 3–6 representative scope examples. */
+  scope_examples?: Array<{ scope: string; description: string }>;
+}
+```
+
+All sub-fields are optional. The manifest loader passes `docs` through as-is
+without further validation — only the outer type check (`object`, not array,
+not null) is enforced.
+
+---
+
+## 2. `README.md` well-known filename contract
+
+Each plugin directory **should** contain a `README.md`. The CLI surfaces its
+path in `plugin info` output when present.
+
+### Required sections
+
+| Section | Purpose |
+|---------|---------|
+| Overview / intro paragraph | 1–3 sentence description of what the plugin ingests |
+| Prerequisites | What must be set up before first use (auth, credentials, tools) |
+| Scope syntax | Table of supported scope forms with descriptions |
+| Examples | 2–5 concrete CLI invocations |
+
+### Optional sections
+
+| Section | Purpose |
+|---------|---------|
+| Limitations | Known constraints (quota, pagination, missing features) |
+| Configuration | Additional flags or environment variables |
+
+---
+
+## 3. CLI surfaces
+
+### `plugin list`
+
+Shows `description` as a trailing column in the plugin table. The column is
+omitted from the header calculation only if all rows have an empty description
+(no manifest updates needed — the column always renders but may be blank).
+
+```
+NAME              VERSION  TRANSPORT  SCOPE    SOURCE  STATUS  DESCRIPTION
+gerrit            0.1.0    js-module  user     user    OK      Ingest Gerrit code-review changes as episodes
+google-workspace  0.1.0    js-module  user     user    OK      Ingest Google Docs as revision-aware episodes
+```
+
+### `plugin info <name>`
+
+Renders a formatted info card with:
+1. Header line: name, version
+2. Capabilities block: auth kinds, cursor support, scope pattern
+3. Overview section (from `docs.summary`) — skipped if absent
+4. Auth setup section (from `docs.auth_setup`) — skipped if absent
+5. Examples section (from `docs.scope_examples`) — skipped if absent
+6. README path — shown if `README.md` exists in the plugin directory
+
+### `plugin install <name>`
+
+After the success message, if `docs.auth_setup` is present in the manifest,
+prints a "Before first use" hint block (word-wrapped at 80 chars).
+
+---
+
+## 4. Docsite aggregation
+
+The docsite build globs `packages/plugins/*/README.md` to collect plugin docs.
+Each file receives frontmatter injection during the build step:
+
+```yaml
+---
+title: "<plugin name> plugin"
+sidebar_position: <auto-assigned>
+---
+```
+
+This allows the docsite to render plugin-specific pages without manual
+registration. The `description` field from `manifest.json` is used as the
+page subtitle in the auto-generated index.
+
+No docsite tooling is implemented yet — this section describes the intended
+contract for future build tooling.

--- a/docs/internal/specs/plugin-docs.md
+++ b/docs/internal/specs/plugin-docs.md
@@ -35,9 +35,9 @@ interface PluginDocs {
 }
 ```
 
-All sub-fields are optional. The manifest loader passes `docs` through as-is
-without further validation — only the outer type check (`object`, not array,
-not null) is enforced.
+All sub-fields are optional. The manifest loader validates the outer type
+(`object`, not array, not null) and additionally asserts that `scope_examples`,
+if present, is an array (throws `ManifestValidationError` otherwise).
 
 ---
 
@@ -91,7 +91,7 @@ Renders a formatted info card with:
 ### `plugin install <name>`
 
 After the success message, if `docs.auth_setup` is present in the manifest,
-prints a "Before first use" hint block (word-wrapped at 80 chars).
+prints a "Before first use" hint block (word-wrapped at 78 chars).
 
 ---
 

--- a/packages/engram-cli/src/commands/plugin.ts
+++ b/packages/engram-cli/src/commands/plugin.ts
@@ -67,6 +67,28 @@ function copyDir(src: string, dest: string): void {
   }
 }
 
+/**
+ * Word-wrap a string to a given column width. Returns an array of lines.
+ */
+function wrapText(text: string, width: number): string[] {
+  const words = text.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (!word) continue;
+    if (!current) {
+      current = word;
+    } else if (current.length + 1 + word.length <= width) {
+      current += ` ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
 // ---------------------------------------------------------------------------
 // plugin list
 // ---------------------------------------------------------------------------
@@ -134,6 +156,7 @@ function registerList(plugin: Command): void {
         scope: string;
         source: string;
         status: string;
+        description: string;
       }> = [];
 
       for (const pd of discovered) {
@@ -146,6 +169,7 @@ function registerList(plugin: Command): void {
             scope: pd.scope,
             source: pd.source,
             status: "OK",
+            description: manifest.description ?? "",
           });
         } catch (err) {
           rows.push({
@@ -158,6 +182,7 @@ function registerList(plugin: Command): void {
               err instanceof ManifestValidationError
                 ? `FAILED: ${err.message}`
                 : `FAILED: ${err instanceof Error ? err.message : String(err)}`,
+            description: "",
           });
         }
       }
@@ -170,6 +195,7 @@ function registerList(plugin: Command): void {
         "SCOPE",
         "SOURCE",
         "STATUS",
+        "DESCRIPTION",
       ];
       const colWidths = headers.map((h, i) => {
         const key = [
@@ -179,6 +205,7 @@ function registerList(plugin: Command): void {
           "scope",
           "source",
           "status",
+          "description",
         ][i] as keyof (typeof rows)[0];
         return Math.max(h.length, ...rows.map((r) => r[key].length));
       });
@@ -200,6 +227,7 @@ function registerList(plugin: Command): void {
             r.scope,
             r.source,
             r.status,
+            r.description,
           ]),
         ),
       ];
@@ -286,6 +314,19 @@ function registerInstall(plugin: Command): void {
       log.success(
         `Installed plugin '${name}' → ${dest} (${method === "symlink" ? "symlinked" : "copied"})`,
       );
+
+      // Show auth_setup hint if present in the manifest
+      try {
+        const manifest = loadManifest(src);
+        if (manifest.docs?.auth_setup) {
+          const wrapped = wrapText(manifest.docs.auth_setup, 78);
+          log.info(
+            `Before first use:\n${wrapped.map((l) => `    ${l}`).join("\n")}`,
+          );
+        }
+      } catch {
+        // Non-fatal: manifest already validated above, ignore re-read errors
+      }
     });
 }
 
@@ -386,6 +427,100 @@ function registerUninstall(plugin: Command): void {
 }
 
 // ---------------------------------------------------------------------------
+// plugin info
+// ---------------------------------------------------------------------------
+
+interface PluginInfoOpts {
+  project?: string;
+  bundledRoot?: string;
+}
+
+function registerInfo(plugin: Command): void {
+  plugin
+    .command("info <name>")
+    .description("Show detailed information about a discovered plugin")
+    .option("--project <path>", "check project-local plugins too")
+    .option("--bundled-root <path>", "override bundled plugins root (testing)")
+    .action(async (name: string, opts: PluginInfoOpts) => {
+      const projectRoot = path.resolve(opts.project ?? ".");
+      const root = opts.bundledRoot ?? bundledPluginsRoot();
+
+      const discovered = discoverPlugins(projectRoot, root ?? undefined);
+      const pd = discovered.find((p) => p.name === name);
+
+      if (!pd) {
+        process.stderr.write(
+          `error: plugin '${name}' not found in any plugin directory\n` +
+            `  Run \`engram plugin list\` to see available plugins.\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      let manifest: ReturnType<typeof loadManifest>;
+      try {
+        manifest = loadManifest(pd.dir);
+      } catch (err) {
+        process.stderr.write(
+          `error: failed to load manifest for '${name}': ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const caps = manifest.capabilities;
+      const authList = caps.supported_auth.join(", ");
+      const cursor = caps.supports_cursor ? "yes" : "no";
+      const scopePattern = caps.scope_schema.description;
+
+      // Header
+      process.stdout.write(`Plugin: ${manifest.name}  v${manifest.version}\n`);
+      process.stdout.write(`Auth:   ${authList}\n`);
+      process.stdout.write(`Cursor: ${cursor}\n`);
+      process.stdout.write(`Scope:  ${scopePattern}\n`);
+
+      // Overview (docs.summary)
+      if (manifest.docs?.summary) {
+        process.stdout.write(`\nOverview\n`);
+        const lines = wrapText(manifest.docs.summary, 78);
+        for (const line of lines) {
+          process.stdout.write(`  ${line}\n`);
+        }
+      }
+
+      // Auth setup
+      if (manifest.docs?.auth_setup) {
+        process.stdout.write(`\nAuth setup\n`);
+        const lines = wrapText(manifest.docs.auth_setup, 78);
+        for (const line of lines) {
+          process.stdout.write(`  ${line}\n`);
+        }
+      }
+
+      // Scope examples
+      if (
+        manifest.docs?.scope_examples &&
+        manifest.docs.scope_examples.length > 0
+      ) {
+        process.stdout.write(`\nExamples\n`);
+        const maxScope = Math.max(
+          ...manifest.docs.scope_examples.map((e) => e.scope.length),
+        );
+        for (const ex of manifest.docs.scope_examples) {
+          const padded = ex.scope.padEnd(maxScope);
+          process.stdout.write(`  ${padded}   ${ex.description}\n`);
+        }
+      }
+
+      // README path
+      const readmePath = path.join(pd.dir, "README.md");
+      if (fs.existsSync(readmePath)) {
+        process.stdout.write(`\nREADME: ${readmePath}\n`);
+      }
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
 
@@ -395,4 +530,5 @@ export function registerPlugin(program: Command): void {
   registerList(plugin);
   registerInstall(plugin);
   registerUninstall(plugin);
+  registerInfo(plugin);
 }

--- a/packages/engram-cli/src/commands/plugin.ts
+++ b/packages/engram-cli/src/commands/plugin.ts
@@ -69,6 +69,9 @@ function copyDir(src: string, dest: string): void {
 
 /**
  * Word-wrap a string to a given column width. Returns an array of lines.
+ *
+ * Long tokens (e.g. URLs) that exceed `width` are placed on their own line.
+ * We do not split tokens — hyphenation is not implemented.
  */
 function wrapText(text: string, width: number): string[] {
   const words = text.split(/\s+/);
@@ -446,12 +449,25 @@ function registerInfo(plugin: Command): void {
       const root = opts.bundledRoot ?? bundledPluginsRoot();
 
       const discovered = discoverPlugins(projectRoot, root ?? undefined);
-      const pd = discovered.find((p) => p.name === name);
+      let pd = discovered.find((p) => p.name === name);
+
+      // Fall back to bundled plugins (search order: project > user > bundled)
+      if (!pd && root) {
+        const bundled = listBundledPlugins(root);
+        if (bundled.includes(name)) {
+          pd = {
+            name,
+            dir: path.join(root, name),
+            scope: "user",
+            source: "bundled",
+          };
+        }
+      }
 
       if (!pd) {
         process.stderr.write(
           `error: plugin '${name}' not found in any plugin directory\n` +
-            `  Run \`engram plugin list\` to see available plugins.\n`,
+            `  Run \`engram plugin list --available\` to see bundled plugins.\n`,
         );
         process.exitCode = 1;
         return;

--- a/packages/engram-core/src/plugins/manifest.ts
+++ b/packages/engram-core/src/plugins/manifest.ts
@@ -198,11 +198,24 @@ export function loadManifest(pluginDir: string): PluginManifest {
         : undefined,
     description:
       typeof obj.description === "string" ? obj.description : undefined,
-    docs:
-      typeof obj.docs === "object" &&
-      obj.docs !== null &&
-      !Array.isArray(obj.docs)
-        ? (obj.docs as PluginDocs)
-        : undefined,
+    docs: (() => {
+      if (
+        typeof obj.docs !== "object" ||
+        obj.docs === null ||
+        Array.isArray(obj.docs)
+      ) {
+        return undefined;
+      }
+      const docsObj = obj.docs as Record<string, unknown>;
+      if (
+        "scope_examples" in docsObj &&
+        !Array.isArray(docsObj.scope_examples)
+      ) {
+        throw new ManifestValidationError(
+          `manifest.json in '${pluginDir}': 'docs.scope_examples' must be an array`,
+        );
+      }
+      return docsObj as PluginDocs;
+    })(),
   };
 }

--- a/packages/engram-core/src/plugins/manifest.ts
+++ b/packages/engram-core/src/plugins/manifest.ts
@@ -22,6 +22,15 @@ export interface PluginVocabExtensions {
   relation_types?: string[];
 }
 
+export interface PluginDocs {
+  /** 2–4 sentence overview shown by `engram plugin info`. */
+  summary?: string;
+  /** What the user must do before first use (auth setup, credentials, etc.). */
+  auth_setup?: string;
+  /** 3–6 representative scope examples. */
+  scope_examples?: Array<{ scope: string; description: string }>;
+}
+
 export interface PluginManifest {
   name: string;
   version: string;
@@ -30,6 +39,10 @@ export interface PluginManifest {
   entry: string;
   capabilities: PluginCapabilities;
   vocab_extensions?: PluginVocabExtensions;
+  /** One-line description shown in `plugin list` output. */
+  description?: string;
+  /** Extended documentation surfaced by `plugin info` and at install time. */
+  docs?: PluginDocs;
 }
 
 export class ManifestValidationError extends Error {
@@ -182,6 +195,14 @@ export function loadManifest(pluginDir: string): PluginManifest {
     vocab_extensions:
       "vocab_extensions" in obj
         ? (obj.vocab_extensions as PluginVocabExtensions)
+        : undefined,
+    description:
+      typeof obj.description === "string" ? obj.description : undefined,
+    docs:
+      typeof obj.docs === "object" &&
+      obj.docs !== null &&
+      !Array.isArray(obj.docs)
+        ? (obj.docs as PluginDocs)
         : undefined,
   };
 }

--- a/packages/plugins/gerrit/README.md
+++ b/packages/plugins/gerrit/README.md
@@ -1,0 +1,41 @@
+# engram plugin — gerrit
+
+Ingest Gerrit code-review changes as episodes in your engram knowledge graph.
+Each change becomes an episode; owners and reviewers become person entities with
+`reviewed` / `authored` edges.
+
+## Prerequisites
+
+No credentials needed for public Gerrit instances. For authenticated instances,
+create an HTTP password in your Gerrit profile and pass it as:
+
+    engram ingest enrich gerrit --auth basic --token "user:password"
+
+## Scope syntax
+
+The scope is a Gerrit project name (no leading or trailing slashes).
+
+| Scope | Description |
+|-------|-------------|
+| `my-project` | All changes in project `my-project` |
+| `org/sub-project` | Nested project path |
+
+## Examples
+
+    # Ingest all changes from a public Gerrit project
+    engram ingest enrich gerrit --scope chromium/src \
+      --endpoint https://chromium-review.googlesource.com
+
+    # Authenticated ingest
+    engram ingest enrich gerrit --scope my-project \
+      --endpoint https://gerrit.example.com \
+      --auth basic --token "alice:mypassword"
+
+    # Dry run (count changes without writing)
+    engram ingest enrich gerrit --scope my-project --dry-run
+
+## Limitations
+
+- Fetches changes in batches of 100; large projects may take several minutes.
+- Incremental re-ingest via cursor resumes from the last processed offset.
+- Gerrit's XSSI prefix (`)]}'`) is stripped automatically.

--- a/packages/plugins/gerrit/manifest.json
+++ b/packages/plugins/gerrit/manifest.json
@@ -11,5 +11,17 @@
       "description": "Gerrit project name (e.g. 'my-project' or 'org/sub-project')",
       "pattern": "^[^/][^/]*(/[^/]+)*[^/]$|^[^/]$"
     }
+  },
+  "description": "Ingest Gerrit code-review changes as episodes",
+  "docs": {
+    "summary": "Fetches Gerrit changes and ingests them as episodes. Change owners and reviewers become person entities with authored/reviewed edges. Supports cursor-based incremental re-ingest.",
+    "auth_setup": "For authenticated instances, create an HTTP password in your Gerrit profile (Settings → HTTP Credentials) and pass it with --auth basic --token \"user:password\".",
+    "scope_examples": [
+      {
+        "scope": "my-project",
+        "description": "All changes in project my-project"
+      },
+      { "scope": "org/sub-project", "description": "Nested Gerrit project" }
+    ]
   }
 }

--- a/packages/plugins/google-workspace/README.md
+++ b/packages/plugins/google-workspace/README.md
@@ -1,0 +1,57 @@
+# engram plugin — google-workspace
+
+Ingest Google Docs as revision-aware episodes in your engram knowledge graph.
+Each document becomes a `document` entity; revision changes are detected via the
+Drive API `modifiedTime` and supersede prior episodes atomically. Document owners
+and last-modifiers become `person` entities with `authored` / `edited` edges.
+
+## Prerequisites
+
+**Application Default Credentials (default)**
+
+    gcloud auth application-default login \
+      --scopes https://www.googleapis.com/auth/documents.readonly,\
+               https://www.googleapis.com/auth/drive.readonly
+
+**Bearer token (CI / non-gcloud environments)**
+
+    engram ingest enrich google-workspace --scope doc:<id> \
+      --auth bearer --token $OAUTH2_TOKEN
+
+## Scope syntax
+
+| Scope | Description |
+|-------|-------------|
+| `doc:<id>` | Single document by ID |
+| `docs:<id>,<id>,...` | Explicit list of document IDs |
+| `folder:<id>` | All Docs in a Drive folder |
+| `folder:<id>?recursive=true` | Recursive folder traversal (cycle-safe) |
+| `query:<drive-q>` | Arbitrary Drive search query |
+
+The `query:` scope AND-injects `mimeType='application/vnd.google-apps.document'`
+automatically — only Docs are enumerated regardless of the user query.
+
+## Examples
+
+    # Single document
+    engram ingest enrich google-workspace \
+      --scope doc:1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms
+
+    # All docs in a folder, recursively
+    engram ingest enrich google-workspace \
+      --scope "folder:1A2B3C4D5E6F7G8H?recursive=true"
+
+    # All docs owned by the authenticated user
+    engram ingest enrich google-workspace \
+      --scope "query:'me' in owners"
+
+    # Dry run — enumerate and count without writing
+    engram ingest enrich google-workspace \
+      --scope "folder:1A2B3C4D5E6F7G8H" --dry-run
+
+## Limitations
+
+- Docs API quota: ~300 req/min/user. Large folders may trigger 429 backoff.
+- Folder/query scopes use Drive list cursor; individual doc re-ingest uses
+  `modifiedTime` for change detection.
+- Cross-provider person deduplication is not yet implemented.

--- a/packages/plugins/google-workspace/manifest.json
+++ b/packages/plugins/google-workspace/manifest.json
@@ -11,5 +11,21 @@
       "description": "doc:<id> | docs:<id>,<id>,... | folder:<id>[?recursive=true] | query:<drive-q>",
       "pattern": "^(doc:|docs:|folder:|query:).+"
     }
+  },
+  "description": "Ingest Google Docs as revision-aware episodes",
+  "docs": {
+    "summary": "Ingests Google Docs as revision-aware episodes using the Drive and Docs APIs. Supports ADC and bearer token auth. Folder and query scopes enumerate docs automatically.",
+    "auth_setup": "Run `gcloud auth application-default login --scopes https://www.googleapis.com/auth/documents.readonly,https://www.googleapis.com/auth/drive.readonly` to configure Application Default Credentials.",
+    "scope_examples": [
+      { "scope": "doc:<id>", "description": "Single document by ID" },
+      {
+        "scope": "folder:<id>?recursive=true",
+        "description": "Recursive folder traversal"
+      },
+      {
+        "scope": "query:'me' in owners",
+        "description": "All docs owned by the authenticated user"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds optional `description` and `docs` (summary, auth_setup, scope_examples) fields to `PluginManifest` type and `loadManifest()` in `engram-core`
- Surfaces `description` as a new column in `plugin list` output
- Adds `engram plugin info <name>` subcommand that renders a formatted capabilities + docs card
- Prints `docs.auth_setup` hint after successful `plugin install`
- Adds `README.md` to gerrit and google-workspace bundled plugins
- Documents the contract in `docs/internal/specs/plugin-docs.md`

## Test plan

- [ ] `bun run build` passes (all packages)
- [ ] `bun test` passes (1379 tests, 0 failures)
- [ ] `bun run lint` passes (no errors)
- [ ] `engram plugin list` shows DESCRIPTION column when plugins have `description` in their manifest
- [ ] `engram plugin info gerrit` renders capabilities block + overview + auth setup + examples
- [ ] `engram plugin info google-workspace` renders correctly with all docs sections
- [ ] `engram plugin install <name>` shows auth_setup hint after success for plugins with docs.auth_setup
- [ ] `engram plugin info <nonexistent>` exits with error and helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)