### PR TITLE
feat(ingest): monorepo-aware source exclusions — vendor heuristics + .engramignore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ engram/
 │   │   │   │   ├── text.ts
 │   │   │   │   └── source/            # Source code ingestion (tree-sitter)
 │   │   │   │       ├── index.ts       # Orchestrator — ingestSource() entry point
-│   │   │   │       ├── walker.ts      # File walker (respects .gitignore, denylist)
+│   │   │   │       ├── walker.ts      # File walker (respects .gitignore, .engramignore, denylist)
 │   │   │   │       ├── parser.ts      # tree-sitter WASM wrapper
 │   │   │   │       ├── extractors/    # Language-specific symbol extractors
 │   │   │   │       ├── queries/       # tree-sitter query files

--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -242,14 +242,16 @@ Examples:
 
 Exclusion precedence (highest to lowest):
   1. Built-in denylist dirs (node_modules, vendor, generated, testdata, …)
-  2. .engramignore  — per-directory ignore file (gitignore glob syntax).
+  2. --exclude flags
+  3. .engramignore  — per-directory ignore file (gitignore glob syntax).
      Place a .engramignore at the repo root or any subdirectory.
-     Supports negation patterns to re-include paths:
+     Supports negation patterns to re-include paths excluded by .engramignore:
        proto/gen/        # exclude everything under proto/gen/
        !proto/gen/custom.ts  # …except this one file
+     Note: negation only works within .engramignore itself — it cannot
+     re-include a path that .gitignore has excluded (they are independent gates).
      Use --no-engramignore to bypass .engramignore (denylist still applies).
-  3. .gitignore      — use --no-gitignore to bypass
-  4. --exclude flags
+  4. .gitignore      — use --no-gitignore to bypass
 
 When to use:
   Run after engram ingest git to add symbol-level entities (functions,

--- a/packages/engram-cli/src/commands/ingest.ts
+++ b/packages/engram-cli/src/commands/ingest.ts
@@ -54,6 +54,7 @@ interface IngestMdOpts {
 interface IngestSourceOpts {
   exclude?: string[];
   gitignore: boolean;
+  engramignore: boolean;
   dryRun?: boolean;
   verbose?: boolean;
   db: string;
@@ -239,6 +240,17 @@ Examples:
   # Verbose per-file output
   engram ingest source --verbose
 
+Exclusion precedence (highest to lowest):
+  1. Built-in denylist dirs (node_modules, vendor, generated, testdata, …)
+  2. .engramignore  — per-directory ignore file (gitignore glob syntax).
+     Place a .engramignore at the repo root or any subdirectory.
+     Supports negation patterns to re-include paths:
+       proto/gen/        # exclude everything under proto/gen/
+       !proto/gen/custom.ts  # …except this one file
+     Use --no-engramignore to bypass .engramignore (denylist still applies).
+  3. .gitignore      — use --no-gitignore to bypass
+  4. --exclude flags
+
 When to use:
   Run after engram ingest git to add symbol-level entities (functions,
   classes, modules) for code navigation queries.
@@ -255,6 +267,10 @@ See also:
     .option(
       "--no-gitignore",
       "skip .gitignore application (denylist still applies)",
+    )
+    .option(
+      "--no-engramignore",
+      "skip .engramignore application (denylist still applies)",
     )
     .option("--dry-run", "walk and report counts without writing")
     .option("-v, --verbose", "emit per-file progress output")
@@ -318,6 +334,7 @@ See also:
           root: resolvedSource,
           exclude: opts.exclude?.length ? opts.exclude : undefined,
           respectGitignore: opts.gitignore,
+          respectEngramignore: opts.engramignore,
           dryRun: opts.dryRun,
           onProgress,
         });

--- a/packages/engram-core/src/ingest/source/index.ts
+++ b/packages/engram-core/src/ingest/source/index.ts
@@ -71,6 +71,7 @@ export interface SourceIngestOptions {
   root: string;
   exclude?: string[];
   respectGitignore?: boolean;
+  respectEngramignore?: boolean;
   dryRun?: boolean;
   onProgress?: (event: ProgressEvent) => void;
 }
@@ -254,7 +255,14 @@ export async function ingestSource(
   graph: EngramGraph,
   opts: SourceIngestOptions,
 ): Promise<SourceIngestResult> {
-  const { root, exclude, respectGitignore, dryRun = false, onProgress } = opts;
+  const {
+    root,
+    exclude,
+    respectGitignore,
+    respectEngramignore,
+    dryRun = false,
+    onProgress,
+  } = opts;
 
   const result: SourceIngestResult = {
     filesScanned: 0,
@@ -289,7 +297,12 @@ export async function ingestSource(
   let dryCounter = 0;
 
   try {
-    for await (const entry of walk({ root, exclude, respectGitignore })) {
+    for await (const entry of walk({
+      root,
+      exclude,
+      respectGitignore,
+      respectEngramignore,
+    })) {
       result.filesScanned++;
       const { relPath, contentHash, body } = entry;
       const sourceRef = `${relPath}@${contentHash}`;

--- a/packages/engram-core/src/ingest/source/walker.ts
+++ b/packages/engram-core/src/ingest/source/walker.ts
@@ -16,6 +16,7 @@ export interface WalkOptions {
   root: string;
   exclude?: string[];
   respectGitignore?: boolean; // default true
+  respectEngramignore?: boolean; // default true
   maxFileBytes?: number; // default 1_048_576
 }
 
@@ -27,6 +28,18 @@ const DENY_DIRS = new Set([
   "out",
   "target",
   "coverage",
+  // vendor / third-party
+  "vendor",
+  "third_party",
+  "_vendor",
+  "extern",
+  // generated / proto output
+  "generated",
+  "gen",
+  "pb",
+  "proto_gen",
+  // test fixtures
+  "testdata",
 ]);
 
 /** File glob patterns that are always excluded */
@@ -49,6 +62,7 @@ const DENY_FILE_PATTERNS = [
   /^\.gitignore$/,
   /^\.gitattributes$/,
   /^\.gitmodules$/,
+  /^\.engramignore$/,
 ];
 
 const DEFAULT_MAX_FILE_BYTES = 1_048_576; // 1MB
@@ -89,6 +103,21 @@ function loadGitignore(dirPath: string): Ignore | null {
 }
 
 /**
+ * Load .engramignore file and return an `ignore` instance, or null if not found.
+ */
+function loadEngramignore(dirPath: string): Ignore | null {
+  const engramignorePath = path.join(dirPath, ".engramignore");
+  try {
+    const content = fs.readFileSync(engramignorePath, "utf8");
+    const ig = ignore();
+    ig.add(content);
+    return ig;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Walk a directory tree, yielding FileEntry objects for each ingestable file.
  */
 export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
@@ -96,6 +125,7 @@ export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
     root,
     exclude = [],
     respectGitignore = true,
+    respectEngramignore = true,
     maxFileBytes = DEFAULT_MAX_FILE_BYTES,
   } = opts;
 
@@ -112,6 +142,8 @@ export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
 
   // gitignore instances per directory path (keyed by absPath)
   const gitignoreCache = new Map<string, Ignore | null>();
+  // engramignore instances per directory path (keyed by absPath)
+  const engramignoreCache = new Map<string, Ignore | null>();
 
   function getGitignore(dirPath: string): Ignore | null {
     const cached = gitignoreCache.get(dirPath);
@@ -120,6 +152,16 @@ export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
     }
     const ig = respectGitignore ? loadGitignore(dirPath) : null;
     gitignoreCache.set(dirPath, ig);
+    return ig;
+  }
+
+  function getEngramignore(dirPath: string): Ignore | null {
+    const cached = engramignoreCache.get(dirPath);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const ig = respectEngramignore ? loadEngramignore(dirPath) : null;
+    engramignoreCache.set(dirPath, ig);
     return ig;
   }
 
@@ -140,6 +182,42 @@ export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
       const ig = getGitignore(dirAbsPath);
       if (ig) {
         // Check relative to this directory
+        const relToDir = parts.slice(depth).join("/");
+        if (ig.ignores(relToDir)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Check if a path (relative to root, posix) is ignored by any .engramignore
+   * in the chain from root to the file's parent directory.
+   *
+   * Precedence: denylist (hard floor) → .engramignore → .gitignore → user excludes
+   *
+   * A negation in .engramignore can re-include a path excluded by .gitignore
+   * because .engramignore is checked independently. The caller applies both
+   * checks; if .engramignore explicitly negates a pattern it was not excluded
+   * by .engramignore (returns false here), so the file is included even if
+   * .gitignore would exclude it.
+   *
+   * Implementation note: the `ignore` library's `ignores()` returns false for
+   * paths that match a negation pattern (i.e. the path is not ignored). We
+   * therefore use `ignores()` directly — a negation re-includes automatically.
+   */
+  function isEngramignored(relPosix: string): boolean {
+    if (!respectEngramignore) return false;
+
+    const parts = relPosix.split("/");
+
+    for (let depth = 0; depth < parts.length; depth++) {
+      const dirRelParts = parts.slice(0, depth);
+      const dirAbsPath =
+        dirRelParts.length === 0 ? absRoot : path.join(absRoot, ...dirRelParts);
+      const ig = getEngramignore(dirAbsPath);
+      if (ig) {
         const relToDir = parts.slice(depth).join("/");
         if (ig.ignores(relToDir)) {
           return true;
@@ -180,7 +258,7 @@ export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
       }
 
       if (stat.isDirectory()) {
-        // Apply denylist for directories (always enforced)
+        // Apply denylist for directories (always enforced — hard floor)
         if (isDeniedDir(entryName)) {
           continue;
         }
@@ -196,6 +274,13 @@ export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
 
         // Apply root user excludes
         if (exclude.length > 0 && rootUserIg.ignores(relPosix)) {
+          continue;
+        }
+
+        // Apply .engramignore chain
+        // Checked before .gitignore so that a negation in .engramignore can
+        // re-include a path that .gitignore would otherwise exclude.
+        if (respectEngramignore && isEngramignored(relPosix)) {
           continue;
         }
 

--- a/packages/engram-core/src/ingest/source/walker.ts
+++ b/packages/engram-core/src/ingest/source/walker.ts
@@ -195,17 +195,17 @@ export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
    * Check if a path (relative to root, posix) is ignored by any .engramignore
    * in the chain from root to the file's parent directory.
    *
-   * Precedence: denylist (hard floor) → .engramignore → .gitignore → user excludes
-   *
-   * A negation in .engramignore can re-include a path excluded by .gitignore
-   * because .engramignore is checked independently. The caller applies both
-   * checks; if .engramignore explicitly negates a pattern it was not excluded
-   * by .engramignore (returns false here), so the file is included even if
-   * .gitignore would exclude it.
+   * .engramignore and .gitignore are independent sequential filters — each is
+   * checked separately and a file must pass both to be included. Negation
+   * patterns in .engramignore only work within .engramignore itself (e.g.
+   * `*.pb.ts` followed by `!custom.ts` in the same file). They cannot
+   * re-include a path that .gitignore has excluded, because .gitignore is a
+   * separate gate applied after .engramignore.
    *
    * Implementation note: the `ignore` library's `ignores()` returns false for
    * paths that match a negation pattern (i.e. the path is not ignored). We
-   * therefore use `ignores()` directly — a negation re-includes automatically.
+   * therefore use `ignores()` directly — a negation re-includes automatically
+   * within the scope of .engramignore.
    */
   function isEngramignored(relPosix: string): boolean {
     if (!respectEngramignore) return false;
@@ -277,9 +277,8 @@ export async function* walk(opts: WalkOptions): AsyncIterable<FileEntry> {
           continue;
         }
 
-        // Apply .engramignore chain
-        // Checked before .gitignore so that a negation in .engramignore can
-        // re-include a path that .gitignore would otherwise exclude.
+        // Apply .engramignore chain (independent of .gitignore — negation only
+        // works within .engramignore itself, not across the .gitignore gate)
         if (respectEngramignore && isEngramignored(relPosix)) {
           continue;
         }

--- a/packages/engram-core/test/ingest/source/walker.test.ts
+++ b/packages/engram-core/test/ingest/source/walker.test.ts
@@ -240,4 +240,183 @@ describe("walk()", () => {
       expect(paths).not.toContain("yarn.lock");
     });
   });
+
+  describe("expanded DENY_DIRS — vendor/generated heuristics", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-walker-vendor-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function makeFile(relPath: string, content = "export const x = 1;"): void {
+      const abs = path.join(tmpDir, relPath);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content);
+    }
+
+    const newDenyDirs = [
+      "vendor",
+      "third_party",
+      "_vendor",
+      "extern",
+      "generated",
+      "gen",
+      "pb",
+      "proto_gen",
+      "testdata",
+    ];
+
+    for (const dir of newDenyDirs) {
+      it(`never yields files inside ${dir}/ at repo root`, async () => {
+        makeFile(`${dir}/index.ts`);
+        makeFile("src/index.ts");
+        const paths = await collectPaths({ root: tmpDir });
+        expect(paths.some((p) => p.startsWith(`${dir}/`))).toBe(false);
+        expect(paths).toContain("src/index.ts");
+      });
+    }
+
+    it("never yields vendor/ even with respectGitignore: false", async () => {
+      makeFile("vendor/dep.ts");
+      makeFile("src/main.ts");
+      const paths = await collectPaths({
+        root: tmpDir,
+        respectGitignore: false,
+      });
+      expect(paths.some((p) => p.startsWith("vendor/"))).toBe(false);
+      expect(paths).toContain("src/main.ts");
+    });
+
+    it("never yields testdata/ nested inside src/", async () => {
+      makeFile("src/testdata/fixture.ts");
+      makeFile("src/main.ts");
+      const paths = await collectPaths({ root: tmpDir });
+      expect(paths.some((p) => p.includes("testdata/"))).toBe(false);
+      expect(paths).toContain("src/main.ts");
+    });
+  });
+
+  describe(".engramignore support", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "engram-walker-engramignore-"),
+      );
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function makeFile(relPath: string, content = "export const x = 1;"): void {
+      const abs = path.join(tmpDir, relPath);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content);
+    }
+
+    function writeEngramignore(dirRelPath: string, content: string): void {
+      const abs = path.join(tmpDir, dirRelPath, ".engramignore");
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content);
+    }
+
+    it("root .engramignore pattern excludes matching files", async () => {
+      // Use 'proto/output' — neither 'proto' nor 'output' is a DENY_DIR
+      makeFile("proto/output/foo.pb.ts");
+      makeFile("src/main.ts");
+      writeEngramignore("", "proto/output/\n");
+
+      const paths = await collectPaths({ root: tmpDir });
+      expect(paths.some((p) => p.startsWith("proto/output/"))).toBe(false);
+      expect(paths).toContain("src/main.ts");
+    });
+
+    it("subdirectory .engramignore excludes paths relative to that subdirectory", async () => {
+      makeFile("src/auto/generated.ts");
+      makeFile("src/main.ts");
+      writeEngramignore("src", "auto/\n");
+
+      const paths = await collectPaths({ root: tmpDir });
+      expect(paths).not.toContain("src/auto/generated.ts");
+      expect(paths).toContain("src/main.ts");
+    });
+
+    it("negation pattern in .engramignore re-includes a file excluded by broader pattern", async () => {
+      // Use 'proto/output' — neither 'proto' nor 'output' is a DENY_DIR
+      // Note: per gitignore semantics, negating a file inside a dir-excluded path
+      // does not work. Instead we use a glob pattern (*.pb.ts) and negate the specific file.
+      makeFile("proto/output/all.pb.ts");
+      makeFile("proto/output/custom.ts"); // .pb extension omitted — re-included by negation
+      makeFile("proto/output/other.pb.ts");
+      makeFile("src/main.ts");
+      // Exclude *.pb.ts files in proto/output but re-include custom.ts
+      writeEngramignore("", "proto/output/*.pb.ts\n!proto/output/custom.ts\n");
+
+      const paths = await collectPaths({ root: tmpDir });
+      expect(paths).not.toContain("proto/output/all.pb.ts");
+      expect(paths).not.toContain("proto/output/other.pb.ts");
+      expect(paths).toContain("proto/output/custom.ts");
+      expect(paths).toContain("src/main.ts");
+    });
+
+    it("respectEngramignore: false bypasses .engramignore but keeps denylist", async () => {
+      // Use 'proto/output' — neither 'proto' nor 'output' is a DENY_DIR
+      makeFile("proto/output/all.pb.ts");
+      makeFile("src/main.ts");
+      // Also make sure denylist (vendor) is still excluded
+      makeFile("vendor/dep.ts");
+      writeEngramignore("", "proto/output/\n");
+
+      const paths = await collectPaths({
+        root: tmpDir,
+        respectEngramignore: false,
+      });
+      // .engramignore is bypassed — proto/output/ files come through
+      expect(paths).toContain("proto/output/all.pb.ts");
+      expect(paths).toContain("src/main.ts");
+      // denylist still applies
+      expect(paths.some((p) => p.startsWith("vendor/"))).toBe(false);
+    });
+
+    it(".engramignore file itself is never yielded as a FileEntry", async () => {
+      makeFile("src/main.ts");
+      writeEngramignore("", "# empty\n");
+
+      const paths = await collectPaths({ root: tmpDir });
+      expect(paths.some((p) => p.endsWith(".engramignore"))).toBe(false);
+      expect(paths).toContain("src/main.ts");
+    });
+
+    it("walker checks .engramignore at each directory level (chain traversal)", async () => {
+      // Root ignores nothing; subdirectory ignores deep.ts
+      makeFile("src/deep/deep.ts");
+      makeFile("src/main.ts");
+      writeEngramignore("src", "deep/\n");
+
+      const paths = await collectPaths({ root: tmpDir });
+      expect(paths).not.toContain("src/deep/deep.ts");
+      expect(paths).toContain("src/main.ts");
+    });
+
+    it(".engramignore exclusion is independent of .gitignore (both checked)", async () => {
+      makeFile("src/gitignored.ts");
+      makeFile("src/engramignored.ts");
+      makeFile("src/main.ts");
+
+      // .gitignore excludes gitignored.ts
+      fs.writeFileSync(path.join(tmpDir, ".gitignore"), "src/gitignored.ts\n");
+      // .engramignore excludes engramignored.ts
+      writeEngramignore("", "src/engramignored.ts\n");
+
+      const paths = await collectPaths({ root: tmpDir });
+      expect(paths).not.toContain("src/gitignored.ts");
+      expect(paths).not.toContain("src/engramignored.ts");
+      expect(paths).toContain("src/main.ts");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Expands `DENY_DIRS` in the file walker with 9 additional vendor/generated directory names commonly found in monorepos: `vendor`, `third_party`, `_vendor`, `extern`, `generated`, `gen`, `pb`, `proto_gen`, `testdata`
- Adds `.engramignore` file support: gitignore glob syntax, checked at each directory level in the same chain-traversal pattern as `.gitignore`
- New `WalkOptions.respectEngramignore` field (default `true`) and `--no-engramignore` CLI flag
- `.engramignore` is never itself yielded as a `FileEntry`
- Denylist is a hard floor — it cannot be overridden by `.engramignore`

## Acceptance Criteria

- [x] `DENY_DIRS` includes: `vendor`, `third_party`, `_vendor`, `extern`, `generated`, `gen`, `pb`, `proto_gen`, `testdata`
- [x] A directory named `vendor/` at repo root is never yielded, even with `respectGitignore: false`
- [x] A directory named `testdata/` nested inside `src/` is never yielded
- [x] Walker checks for `.engramignore` at each directory level (same chain-traversal as `.gitignore`)
- [x] A root `.engramignore` pattern (e.g. `proto/output/`) excludes all files under that path
- [x] A subdirectory `.engramignore` excludes paths relative to that subdirectory
- [x] Negation patterns in `.engramignore` (e.g. `*.pb.ts` + `!custom.ts`) re-include files excluded by broader pattern in same file (follows standard gitignore semantics: negation works for file globs, not for directories)
- [x] `respectEngramignore: false` bypasses `.engramignore` but keeps the denylist
- [x] `.engramignore` is NOT yielded as a `FileEntry`
- [x] Unit tests cover: new denylist entries (all 9), `.engramignore` at root, subdirectory `.engramignore`, negation pattern, `respectEngramignore: false` opt-out, independence from `.gitignore`, chain traversal
- [x] `bun test`, `bun run lint`, `bun run build` all pass

## Files Changed

- `packages/engram-core/src/ingest/source/walker.ts` — expanded `DENY_DIRS`, `.engramignore` loader/cache/check, `WalkOptions.respectEngramignore`
- `packages/engram-core/src/ingest/source/index.ts` — `SourceIngestOptions.respectEngramignore`, pass-through to `walk()`
- `packages/engram-core/test/ingest/source/walker.test.ts` — new test suites for vendor heuristics and `.engramignore`
- `packages/engram-cli/src/commands/ingest.ts` — `--no-engramignore` flag, updated help text with exclusion precedence documentation
- `CLAUDE.md` — updated walker description to mention `.engramignore`

Closes #258