### PR TITLE
feat(cli): engram sync — config-driven multi-source orchestration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,11 @@ engram/
 │   │   │   │   ├── markdown.ts
 │   │   │   │   ├── text.ts
 │   │   │   │   └── source/            # Source code ingestion (tree-sitter)
+│   │   │   ├── sync/         # Config-driven sync orchestrator
+│   │   │   │   ├── types.ts         # SyncConfig, SyncSource, SyncResult, SyncAuthConfig
+│   │   │   │   ├── errors.ts        # SyncConfigValidationError, SyncSourceError
+│   │   │   │   ├── run.ts           # runSync() orchestrator + validateSyncConfig()
+│   │   │   │   └── index.ts         # barrel export
 │   │   │   │       ├── index.ts       # Orchestrator — ingestSource() entry point
 │   │   │   │       ├── walker.ts      # File walker (respects .gitignore, denylist)
 │   │   │   │       ├── parser.ts      # tree-sitter WASM wrapper
@@ -146,6 +151,8 @@ This distinction is critical for trust. Never present inferred edges as observed
 Two layers:
 1. **VCS layer (universal)**: git commits, blame, co-change analysis. No API tokens needed. Produces the structural graph.
 2. **Enrichment adapters (pluggable)**: GitHub PRs/issues, Gerrit, future Jira/etc. Each implements `EnrichmentAdapter` interface (v2). New adapters must import `entity_type`, `source_type`, and `relation_type` values from `packages/engram-core/src/vocab/`.
+
+**Preferred entry point**: For routine multi-source ingestion, use `engram sync` with a `.engram.config.json` rather than composing individual `engram ingest` commands. See `docs/internal/specs/sync-orchestration.md`.
 
 **Adapter contract v2 — key conventions:**
 - **Auth**: Use `AuthCredential` union (`bearer`, `basic`, `service_account`, `oauth2`, `none`) via `opts.auth`. Declare accepted kinds in `supportedAuth: AuthCredential['kind'][]`. Use `assertAuthKind()` helper before processing.
@@ -279,6 +286,9 @@ When creating a PR that implements a GitHub issue:
 | `packages/engram-core/src/ai/` | AI provider layer (NullProvider, OllamaProvider, GeminiProvider) |
 | `packages/engram-core/src/ai/kinds/` | Built-in projection kind catalog files (YAML). User overrides via `$XDG_CONFIG_HOME/engram/kinds/` (fallback `~/.config/engram/kinds/`). |
 | `packages/engram-core/src/ai/kinds.ts` | Kind catalog loader — `loadKindCatalog()`, `KindEntry`, `KindCatalog` |
+| `packages/engram-core/src/sync/run.ts` | `runSync()` orchestrator + `validateSyncConfig()` — preferred multi-source entry point |
+| `docs/internal/specs/sync-orchestration.md` | Config schema, discovery, adapter resolution, failure semantics, exit codes |
+| `docs/examples/.engram.config.json` | Example sync config file |
 | `packages/engram-core/src/ingest/git.ts` | Git VCS ingestion (the "money command" engine) |
 | `packages/engram-core/src/ingest/adapter.ts` | EnrichmentAdapter interface (v2) — AuthCredential, ScopeSchema, applyCompatShim, assertAuthKind |
 | `packages/engram-core/src/ingest/cursor.ts` | Cursor helpers — readIsoCursor, readNumericCursor, writeCursor |

--- a/docs/examples/.engram.config.json
+++ b/docs/examples/.engram.config.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "sources": [
+    {
+      "name": "repo-git",
+      "type": "git",
+      "path": "."
+    },
+    {
+      "name": "repo-src",
+      "type": "source",
+      "root": "packages/"
+    },
+    {
+      "name": "engram-gh",
+      "type": "github",
+      "scope": "org/repo",
+      "auth": {
+        "kind": "bearer",
+        "tokenEnv": "GITHUB_TOKEN"
+      }
+    },
+    {
+      "name": "workspace-docs",
+      "type": "google_workspace",
+      "scope": "folder:root",
+      "auth": {
+        "kind": "service_account",
+        "keyJsonEnv": "GOOGLE_SERVICE_ACCOUNT_JSON"
+      }
+    }
+  ]
+}

--- a/docs/internal/specs/sync-orchestration.md
+++ b/docs/internal/specs/sync-orchestration.md
@@ -1,0 +1,164 @@
+# Sync Orchestration — Design Specification
+
+`engram sync` is a config-driven command that runs all configured ingesters in
+declaration order, then runs the cross-ref resolver. It replaces hand-crafted
+shell sequences like `ingest git && ingest source && ingest enrich github && ...`.
+
+## Config File
+
+The config lives in `.engram.config.json`. The format is JSON, versioned at the
+top level.
+
+### Schema
+
+```json
+{
+  "version": 1,
+  "sources": [
+    { "name": "repo-git",  "type": "git",    "path": "." },
+    { "name": "repo-src",  "type": "source", "root": "packages/" },
+    { "name": "engram-gh", "type": "github", "scope": "org/repo",
+      "auth": { "kind": "bearer", "tokenEnv": "GITHUB_TOKEN" } }
+  ]
+}
+```
+
+### Top-level fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | `1` | yes | Schema version. Only `1` is accepted; mismatch fails with upgrade-path message. |
+| `sources` | array | yes | Ordered list of source definitions. |
+
+### Source fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Unique identifier. Used with `--only <name>`. |
+| `type` | string | yes | Adapter type (see Built-in types below). |
+| `scope` | string | no | Adapter-specific scope (e.g. `owner/repo` for GitHub). |
+| `path` | string | no | Filesystem path — repo path for `git`, root for `source`. |
+| `root` | string | no | Alias for `path` specifically for `source` adapter. Takes precedence over `path`. |
+| `auth` | object | no | Auth config (see Auth below). May be omitted for `git` and `source`. |
+
+Unknown fields at any level cause validation failure (fail-closed design).
+
+### Auth config
+
+Auth config uses env var references (`tokenEnv`) rather than literal secrets.
+
+| Kind | Fields | Description |
+|------|--------|-------------|
+| `none` | — | No auth required. |
+| `bearer` | `tokenEnv` | Env var holding the Bearer/PAT token. |
+| `basic` | `usernameEnv`, `secretEnv` | Env vars for HTTP Basic auth. |
+| `service_account` | `keyJsonEnv` | Env var holding the full JSON key content. |
+| `oauth2` | `tokenEnv`, `scopesEnv?` | OAuth2 access token + optional scopes. |
+
+## Config Discovery
+
+`engram sync` finds its config using this resolution order (first match wins):
+
+1. `--config <path>` — explicit path
+2. `$ENGRAM_CONFIG` — environment variable
+3. `<cwd>/.engram.config.json` — auto-discovered
+4. `<db-dir>/.engram.config.json` — adjacent to the `.engram` database file
+
+If no config is found, the command exits with code `3` and prints the resolution
+order with the paths that were checked, plus a pointer to the example config at
+`docs/examples/.engram.config.json`.
+
+## Built-in Types
+
+| Type | Adapter | Notes |
+|------|---------|-------|
+| `git` | `ingestGitRepo()` | Uses `path` (default: `.`). |
+| `source` | `ingestSource()` | Uses `root` or `path` (default: `.`). |
+| `github` | `GitHubAdapter` | Requires `scope: owner/repo` and `auth`. |
+| `google_workspace` | `GoogleWorkspaceAdapter` | Requires `@engram/plugin-google-workspace`. |
+| _anything else_ | Plugin | Resolved via `discoverPlugins()`. Unknown type → exit 2. |
+
+## Adapter Resolution
+
+1. Check built-in type map first.
+2. If not found, call `discoverPlugins(cwd, bundledPluginsRoot)`.
+3. Look for a plugin with a matching `name`.
+4. Load via the plugin's declared transport (`js-module` or `executable`).
+5. If no plugin found, exit `2` and list all available built-in types plus discovered plugins.
+
+## Failure Semantics
+
+### Fail-fast (default)
+
+Sources run in declaration order. On first failure:
+- Remaining sources are marked `skipped`.
+- Cross-ref resolver is **not** run.
+- Exit code `1`.
+
+### `--continue-on-error`
+
+All sources run regardless of failures. After all sources:
+- Cross-ref resolver runs over episodes from **all** sources (including failed ones that
+  wrote partial data before failing).
+- Exit code `1` if any source failed, `0` if all succeeded.
+
+### Pre-flight auth check
+
+Before any source runs, all `auth.tokenEnv` references are checked for presence
+in the environment. Any missing env vars cause immediate exit `2` with a list of
+all missing vars — no partial execution.
+
+## Cross-ref Resolver
+
+After all sources complete (or after the successful subset with `--continue-on-error`),
+`resolveReferences()` is called once over all non-redacted episodes. This:
+- Scans episode content for cross-source references (e.g. GitHub PR mentions in commit msgs).
+- Emits `references` edges (edge_kind: `observed`).
+- Records unresolved references in `unresolved_refs` for future drain.
+
+Skip with `--no-cross-refs`. The resolver does not run if fail-fast aborted.
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All sources succeeded. |
+| `1` | At least one source failed. |
+| `2` | Config validation error, unknown `--only` name, or missing auth env var. |
+| `3` | No discoverable config file. |
+
+## CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--config <path>` | Override config discovery. |
+| `--db <path>` | Target `.engram` file (default: `.engram`). |
+| `--only <name>[,<name>...]` | Run named subset in declaration order. |
+| `--continue-on-error` | Run all sources, even after a failure. |
+| `--no-cross-refs` | Skip the cross-ref resolver step. |
+| `--format json` | Emit `SyncResult` JSON. Default: human-readable table. |
+| `--dry-run` | Validate config + print plan; no execution. Exits `0`. |
+
+## `SyncResult` shape (JSON output)
+
+```ts
+interface SyncResult {
+  sources: Array<{
+    name: string;
+    type: string;
+    status: "success" | "failed" | "skipped";
+    error?: string;
+    episodesCreated?: number;
+    entitiesCreated?: number;
+    edgesCreated?: number;
+    elapsedMs: number;
+  }>;
+  crossRefs: {
+    edgesCreated: number;
+    unresolved: number;
+    elapsedMs: number;
+  } | null;
+  status: "success" | "failed";
+  elapsedMs: number;
+}
+```

--- a/packages/engram-cli/src/cli.ts
+++ b/packages/engram-cli/src/cli.ts
@@ -21,6 +21,7 @@ import { registerSearch } from "./commands/search.js";
 import { registerShow } from "./commands/show.js";
 import { registerStats } from "./commands/stats.js";
 import { registerStatus } from "./commands/status.js";
+import { registerSync } from "./commands/sync.js";
 import { registerVerify } from "./commands/verify.js";
 import { registerVisualize } from "./commands/visualize.js";
 
@@ -65,5 +66,6 @@ registerMaintenance(program);
 registerReconcile(program);
 registerVisualize(program);
 registerPlugin(program);
+registerSync(program);
 
 program.parse();

--- a/packages/engram-cli/src/commands/sync.ts
+++ b/packages/engram-cli/src/commands/sync.ts
@@ -1,0 +1,419 @@
+/**
+ * sync.ts — `engram sync` command.
+ *
+ * Reads a config file and runs all configured ingesters in declaration order,
+ * then runs the cross-ref resolver. Replaces hand-crafted shell sequences of
+ * individual `engram ingest` commands.
+ *
+ * Config discovery (first match wins):
+ *   1. --config <path>
+ *   2. $ENGRAM_CONFIG env var
+ *   3. <cwd>/.engram.config.json
+ *   4. <db-dir>/.engram.config.json  (adjacent to the .engram file)
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { log } from "@clack/prompts";
+import type { Command } from "commander";
+import {
+  closeGraph,
+  openGraph,
+  resolveDbPath,
+  runSync,
+  type SourceResult,
+  SyncConfigValidationError,
+  type SyncResult,
+  validateSyncConfig,
+} from "engram-core";
+
+// ---------------------------------------------------------------------------
+// Config discovery
+// ---------------------------------------------------------------------------
+
+const CONFIG_FILENAME = ".engram.config.json";
+const EXAMPLE_CONFIG_PATH = "docs/examples/.engram.config.json";
+
+/**
+ * Discover the config file path using the documented resolution order.
+ * Returns null if no config can be found.
+ */
+function discoverConfigPath(
+  explicitPath: string | undefined,
+  dbPath: string,
+): string | null {
+  // 1. --config flag
+  if (explicitPath) {
+    return path.resolve(explicitPath);
+  }
+
+  // 2. $ENGRAM_CONFIG env var
+  const envPath = process.env.ENGRAM_CONFIG;
+  if (envPath) {
+    return path.resolve(envPath);
+  }
+
+  // 3. <cwd>/.engram.config.json
+  const cwdConfig = path.join(process.cwd(), CONFIG_FILENAME);
+  if (fs.existsSync(cwdConfig)) {
+    return cwdConfig;
+  }
+
+  // 4. db-adjacent (.engram file's directory)
+  const dbDir = path.dirname(path.resolve(dbPath));
+  const dbAdjacentConfig = path.join(dbDir, CONFIG_FILENAME);
+  if (dbAdjacentConfig !== cwdConfig && fs.existsSync(dbAdjacentConfig)) {
+    return dbAdjacentConfig;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatStatus(status: string): string {
+  switch (status) {
+    case "success":
+      return "ok     ";
+    case "failed":
+      return "FAILED ";
+    case "skipped":
+      return "skipped";
+    default:
+      return status;
+  }
+}
+
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function printTable(results: SourceResult[]): void {
+  const colWidths = {
+    name: Math.max(4, ...results.map((r) => r.name.length)),
+    type: Math.max(4, ...results.map((r) => r.type.length)),
+    status: 7,
+    episodes: 8,
+    entities: 8,
+    edges: 5,
+    elapsed: 7,
+  };
+
+  const header = [
+    "name".padEnd(colWidths.name),
+    "type".padEnd(colWidths.type),
+    "status ",
+    "episodes".padStart(colWidths.episodes),
+    "entities".padStart(colWidths.entities),
+    "edges".padStart(colWidths.edges),
+    "elapsed",
+  ].join("  ");
+
+  const divider = "-".repeat(header.length);
+
+  process.stdout.write(`${header}\n${divider}\n`);
+
+  for (const r of results) {
+    const row = [
+      r.name.padEnd(colWidths.name),
+      r.type.padEnd(colWidths.type),
+      formatStatus(r.status),
+      (r.episodesCreated ?? "-").toString().padStart(colWidths.episodes),
+      (r.entitiesCreated ?? "-").toString().padStart(colWidths.entities),
+      (r.edgesCreated ?? "-").toString().padStart(colWidths.edges),
+      formatMs(r.elapsedMs).padStart(colWidths.elapsed),
+    ].join("  ");
+    process.stdout.write(`${row}\n`);
+  }
+
+  process.stdout.write(`${divider}\n`);
+}
+
+function printSyncResult(result: SyncResult): void {
+  printTable(result.sources);
+
+  const totalEpisodes = result.sources.reduce(
+    (s, r) => s + (r.episodesCreated ?? 0),
+    0,
+  );
+  const totalEntities = result.sources.reduce(
+    (s, r) => s + (r.entitiesCreated ?? 0),
+    0,
+  );
+  const totalEdges = result.sources.reduce(
+    (s, r) => s + (r.edgesCreated ?? 0),
+    0,
+  );
+  const failed = result.sources.filter((r) => r.status === "failed").length;
+
+  process.stdout.write(
+    `\nTotal: ${result.sources.length} sources, ${failed} failed — ` +
+      `${totalEpisodes} episodes, ${totalEntities} entities, ${totalEdges} edges, ` +
+      `${formatMs(result.elapsedMs)} total\n`,
+  );
+
+  if (result.crossRefs) {
+    process.stdout.write(
+      `Cross-refs: ${result.crossRefs.edgesCreated} edges created, ` +
+        `${result.crossRefs.unresolved} unresolved, ` +
+        `${formatMs(result.crossRefs.elapsedMs)}\n`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command registration
+// ---------------------------------------------------------------------------
+
+interface SyncOpts {
+  config?: string;
+  db: string;
+  only?: string;
+  continueOnError?: boolean;
+  noCrossRefs?: boolean;
+  format?: string;
+  dryRun?: boolean;
+}
+
+export function registerSync(program: Command): void {
+  program
+    .command("sync")
+    .description(
+      "Run all configured ingesters from .engram.config.json, then resolve cross-refs",
+    )
+    .addHelpText(
+      "after",
+      `
+Config discovery (first match wins):
+  --config <path>              Explicit config file path
+  $ENGRAM_CONFIG               Environment variable
+  <cwd>/.engram.config.json    Auto-discovered in working directory
+  <db-dir>/.engram.config.json Adjacent to the .engram database file
+
+Config format (.engram.config.json):
+  {
+    "version": 1,
+    "sources": [
+      { "name": "repo-git",  "type": "git",    "path": "." },
+      { "name": "repo-src",  "type": "source", "root": "packages/" },
+      { "name": "engram-gh", "type": "github", "scope": "org/repo",
+        "auth": { "kind": "bearer", "tokenEnv": "GITHUB_TOKEN" } }
+    ]
+  }
+
+Examples:
+  # Run all configured sources
+  engram sync --db myproject.engram
+
+  # Dry-run to see what would run
+  engram sync --dry-run
+
+  # Run only the git source
+  engram sync --only repo-git
+
+  # Continue even if one source fails
+  engram sync --continue-on-error
+
+  # JSON output for scripting
+  engram sync --format json | jq .status
+
+Exit codes:
+  0 — all sources succeeded
+  1 — at least one source failed
+  2 — config validation error, unknown --only name, or missing auth env var
+  3 — no discoverable config file`,
+    )
+    .option("--config <path>", "path to sync config file")
+    .option("--db <path>", "path to .engram file", ".engram")
+    .option(
+      "--only <names>",
+      "comma-separated list of source names to run (subset)",
+    )
+    .option(
+      "--continue-on-error",
+      "run remaining sources after a failure (default: fail-fast)",
+    )
+    .option("--no-cross-refs", "skip the cross-ref resolver step")
+    .option(
+      "--format <format>",
+      "output format: 'human' (default) or 'json'",
+      "human",
+    )
+    .option(
+      "--dry-run",
+      "validate config and print plan without executing any ingestion",
+    )
+    .action(async (opts: SyncOpts) => {
+      const isTTY = process.stdout.isTTY;
+      const isJson = opts.format === "json";
+
+      // Resolve db path
+      const dbPath = resolveDbPath(path.resolve(opts.db));
+
+      // Discover config
+      const configPath = discoverConfigPath(opts.config, dbPath);
+      if (!configPath) {
+        const msg =
+          `No sync config found. Create ${CONFIG_FILENAME} in your project directory.\n` +
+          `See ${EXAMPLE_CONFIG_PATH} for an example, or use --config <path> to specify a file.\n` +
+          `\nResolution order checked:\n` +
+          `  1. --config flag\n` +
+          `  2. $ENGRAM_CONFIG env var\n` +
+          `  3. ${path.join(process.cwd(), CONFIG_FILENAME)}\n` +
+          `  4. ${path.join(path.dirname(path.resolve(dbPath)), CONFIG_FILENAME)}`;
+        process.stderr.write(`${msg}\n`);
+        process.exit(3);
+      }
+
+      // Load and parse config
+      let rawConfig: unknown;
+      try {
+        const content = fs.readFileSync(configPath, "utf8");
+        rawConfig = JSON.parse(content);
+      } catch (err) {
+        process.stderr.write(
+          `Cannot read config file '${configPath}': ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exit(2);
+      }
+
+      // Validate config
+      let config: ReturnType<typeof validateSyncConfig>;
+      try {
+        config = validateSyncConfig(rawConfig);
+      } catch (err) {
+        if (err instanceof SyncConfigValidationError) {
+          process.stderr.write(`${err.message}\n`);
+        } else {
+          process.stderr.write(
+            `Config validation error: ${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
+        process.exit(2);
+      }
+
+      // Validate --only names
+      const onlyNames = opts.only
+        ? opts.only
+            .split(",")
+            .map((n) => n.trim())
+            .filter(Boolean)
+        : undefined;
+
+      if (onlyNames && onlyNames.length > 0) {
+        const knownNames = new Set(config.sources.map((s) => s.name));
+        const unknown = onlyNames.filter((n) => !knownNames.has(n));
+        if (unknown.length > 0) {
+          process.stderr.write(
+            `Unknown source name(s) in --only: ${unknown.map((n) => `'${n}'`).join(", ")}\n` +
+              `Known sources: ${Array.from(knownNames).join(", ")}\n`,
+          );
+          process.exit(2);
+        }
+      }
+
+      // Dry-run: print plan and exit
+      if (opts.dryRun) {
+        const sourcesToRun = onlyNames
+          ? config.sources.filter((s) => onlyNames.includes(s.name))
+          : config.sources;
+
+        if (!isJson) {
+          process.stdout.write(
+            `Dry-run: would run ${sourcesToRun.length} source(s) from ${configPath}\n\n`,
+          );
+          for (const src of sourcesToRun) {
+            const authDesc = src.auth ? ` [auth: ${src.auth.kind}]` : "";
+            const scopeDesc = src.scope ? ` scope=${src.scope}` : "";
+            const pathDesc =
+              (src.root ?? src.path) ? ` path=${src.root ?? src.path}` : "";
+            process.stdout.write(
+              `  ${src.name.padEnd(20)} type=${src.type}${scopeDesc}${pathDesc}${authDesc}\n`,
+            );
+          }
+          if (!opts.noCrossRefs) {
+            process.stdout.write("\n  [cross-ref resolver would run after]\n");
+          }
+        } else {
+          const plan = {
+            dryRun: true,
+            configPath,
+            sources: sourcesToRun.map((s) => ({
+              name: s.name,
+              type: s.type,
+              scope: s.scope,
+              path: s.root ?? s.path,
+              authKind: s.auth?.kind ?? "none",
+            })),
+            crossRefs: !opts.noCrossRefs,
+          };
+          process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+        }
+        process.exit(0);
+      }
+
+      // Open graph
+      let graph: ReturnType<typeof openGraph>;
+      try {
+        graph = openGraph(dbPath);
+      } catch (err) {
+        process.stderr.write(
+          `Cannot open graph '${dbPath}': ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exit(1);
+      }
+
+      // Run sync
+      let result: SyncResult;
+      try {
+        result = await runSync(
+          graph,
+          config,
+          {
+            only: onlyNames,
+            continueOnError: opts.continueOnError,
+            noCrossRefs: opts.noCrossRefs,
+            dryRun: false,
+            onSourceStart: (name, type) => {
+              if (isTTY && !isJson) {
+                log.info(`Running source '${name}' (${type})...`);
+              }
+            },
+            onSourceEnd: (sourceResult) => {
+              if (isTTY && !isJson) {
+                if (sourceResult.status === "failed") {
+                  log.error(
+                    `Source '${sourceResult.name}' failed: ${sourceResult.error}`,
+                  );
+                }
+              }
+            },
+          },
+          process.cwd(),
+        );
+      } catch (err) {
+        // SyncSourceError from pre-flight auth check
+        process.stderr.write(
+          `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        closeGraph(graph);
+        process.exit(2);
+      }
+
+      closeGraph(graph);
+
+      // Output results
+      if (isJson) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      } else {
+        printSyncResult(result);
+      }
+
+      // Exit code
+      const exitCode = result.status === "failed" ? 1 : 0;
+      process.exit(exitCode);
+    });
+}

--- a/packages/engram-core/src/index.ts
+++ b/packages/engram-core/src/index.ts
@@ -211,6 +211,22 @@ export {
   graphSearch,
   search,
 } from "./retrieval/index.js";
+export type { ValidationFailure } from "./sync/errors.js";
+export {
+  SyncConfigValidationError,
+  SyncSourceError,
+} from "./sync/errors.js";
+export { runSync, validateSyncConfig } from "./sync/run.js";
+export type {
+  RunSyncOpts,
+  SourceResult,
+  SourceStatus,
+  SyncAuthConfig,
+  SyncConfig,
+  SyncResult,
+  SyncSource,
+} from "./sync/types.js";
+export { resolveSyncAuth } from "./sync/types.js";
 export type { ResolvedAsOf, TemporalSnapshot } from "./temporal/index.js";
 export {
   checkActiveEdgeConflict,

--- a/packages/engram-core/src/sync/errors.ts
+++ b/packages/engram-core/src/sync/errors.ts
@@ -1,0 +1,52 @@
+/**
+ * sync/errors.ts — error types for the sync orchestrator.
+ */
+
+// ---------------------------------------------------------------------------
+// Validation error
+// ---------------------------------------------------------------------------
+
+export interface ValidationFailure {
+  /** JSON path to the failing field, e.g. 'sources[1].auth.tokenEnv'. */
+  field: string;
+  /** Human-readable reason. */
+  reason: string;
+}
+
+/**
+ * Thrown when `.engram.config.json` fails validation.
+ * Reports ALL failures at once so the user can fix everything in one edit.
+ */
+export class SyncConfigValidationError extends Error {
+  readonly failures: ValidationFailure[];
+
+  constructor(failures: ValidationFailure[]) {
+    const lines = failures.map((f) => `  ${f.field}: ${f.reason}`).join("\n");
+    super(`Sync config validation failed:\n${lines}`);
+    this.name = "SyncConfigValidationError";
+    this.failures = failures;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source execution error
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown (or caught and converted to SourceResult) when a single source fails.
+ * Wraps the underlying cause with source name and type context.
+ */
+export class SyncSourceError extends Error {
+  readonly sourceName: string;
+  readonly sourceType: string;
+  readonly cause: unknown;
+
+  constructor(sourceName: string, sourceType: string, cause: unknown) {
+    const msg = cause instanceof Error ? cause.message : String(cause);
+    super(`source '${sourceName}' (${sourceType}) failed: ${msg}`);
+    this.name = "SyncSourceError";
+    this.sourceName = sourceName;
+    this.sourceType = sourceType;
+    this.cause = cause;
+  }
+}

--- a/packages/engram-core/src/sync/index.ts
+++ b/packages/engram-core/src/sync/index.ts
@@ -18,3 +18,4 @@ export type {
   SyncSource,
 } from "./types.js";
 export { resolveSyncAuth } from "./types.js";
+export { validateAuthConfig } from "./validate.js";

--- a/packages/engram-core/src/sync/index.ts
+++ b/packages/engram-core/src/sync/index.ts
@@ -1,0 +1,20 @@
+/**
+ * sync/index.ts — barrel export for the sync orchestrator module.
+ */
+
+export type { ValidationFailure } from "./errors.js";
+export {
+  SyncConfigValidationError,
+  SyncSourceError,
+} from "./errors.js";
+export { runSync, validateSyncConfig } from "./run.js";
+export type {
+  RunSyncOpts,
+  SourceResult,
+  SourceStatus,
+  SyncAuthConfig,
+  SyncConfig,
+  SyncResult,
+  SyncSource,
+} from "./types.js";
+export { resolveSyncAuth } from "./types.js";

--- a/packages/engram-core/src/sync/run.ts
+++ b/packages/engram-core/src/sync/run.ts
@@ -1,0 +1,570 @@
+/**
+ * sync/run.ts — config-driven multi-source ingestion orchestrator.
+ *
+ * Runs all configured sources in declaration order, then runs the cross-ref
+ * resolver. Replaces hand-crafted shell sequences of individual ingest commands.
+ */
+
+import * as path from "node:path";
+import type { EngramGraph } from "../format/index.js";
+import type { AuthCredential, EnrichmentAdapter } from "../ingest/adapter.js";
+import { resolveReferences } from "../ingest/cross-ref/index.js";
+import { ingestGitRepo } from "../ingest/git.js";
+import { ingestSource } from "../ingest/source/index.js";
+import {
+  bundledPluginsRoot,
+  discoverPlugins,
+  loadExecutablePlugin,
+  loadJsModulePlugin,
+} from "../plugins/index.js";
+import { SyncConfigValidationError, SyncSourceError } from "./errors.js";
+import type {
+  RunSyncOpts,
+  SourceResult,
+  SyncAuthConfig,
+  SyncConfig,
+  SyncResult,
+  SyncSource,
+} from "./types.js";
+import { resolveSyncAuth } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Built-in adapter types
+// ---------------------------------------------------------------------------
+
+const BUILT_IN_TYPES = ["git", "source", "github", "google_workspace"] as const;
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+const ALLOWED_AUTH_KINDS = [
+  "none",
+  "bearer",
+  "basic",
+  "service_account",
+  "oauth2",
+] as const;
+
+const ALLOWED_SOURCE_FIELDS = new Set([
+  "name",
+  "type",
+  "scope",
+  "path",
+  "root",
+  "auth",
+]);
+
+const ALLOWED_AUTH_FIELDS: Record<string, Set<string>> = {
+  none: new Set(["kind"]),
+  bearer: new Set(["kind", "tokenEnv"]),
+  basic: new Set(["kind", "usernameEnv", "secretEnv"]),
+  service_account: new Set(["kind", "keyJsonEnv"]),
+  oauth2: new Set(["kind", "tokenEnv", "scopesEnv"]),
+};
+
+/**
+ * Validate a raw JSON object against the SyncConfig schema.
+ * Collects ALL errors before throwing, so the user can fix everything at once.
+ *
+ * Rules (fail-closed):
+ * - `version: 1` required
+ * - Every source: `name` (unique), `type` — no unknown fields
+ * - Auth uses `SyncAuthConfig` union — no unknown fields per kind
+ */
+export function validateSyncConfig(raw: unknown): SyncConfig {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new SyncConfigValidationError([
+      { field: "(root)", reason: "must be a JSON object" },
+    ]);
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const failures: Array<{ field: string; reason: string }> = [];
+
+  // Check for unknown top-level fields
+  const ALLOWED_TOP_FIELDS = new Set(["version", "sources"]);
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_TOP_FIELDS.has(key)) {
+      failures.push({
+        field: key,
+        reason: `unknown top-level field (allowed: ${Array.from(ALLOWED_TOP_FIELDS).join(", ")})`,
+      });
+    }
+  }
+
+  // Validate version
+  if (!("version" in obj)) {
+    failures.push({ field: "version", reason: "required field missing" });
+  } else if (obj.version !== 1) {
+    failures.push({
+      field: "version",
+      reason: `must be 1 (got ${JSON.stringify(obj.version)}). If you have a newer config format, upgrade engram to the matching version.`,
+    });
+  }
+
+  // Validate sources
+  if (!("sources" in obj)) {
+    failures.push({ field: "sources", reason: "required field missing" });
+  } else if (!Array.isArray(obj.sources)) {
+    failures.push({ field: "sources", reason: "must be an array" });
+  } else {
+    const seenNames = new Set<string>();
+
+    for (let i = 0; i < obj.sources.length; i++) {
+      const src = obj.sources[i];
+      const prefix = `sources[${i}]`;
+
+      if (typeof src !== "object" || src === null || Array.isArray(src)) {
+        failures.push({ field: prefix, reason: "must be an object" });
+        continue;
+      }
+
+      const srcObj = src as Record<string, unknown>;
+
+      // Check for unknown source fields
+      for (const key of Object.keys(srcObj)) {
+        if (!ALLOWED_SOURCE_FIELDS.has(key)) {
+          failures.push({
+            field: `${prefix}.${key}`,
+            reason: `unknown field (allowed: ${Array.from(ALLOWED_SOURCE_FIELDS).join(", ")})`,
+          });
+        }
+      }
+
+      // name
+      if (!("name" in srcObj)) {
+        failures.push({ field: `${prefix}.name`, reason: "required" });
+      } else if (typeof srcObj.name !== "string" || !srcObj.name) {
+        failures.push({
+          field: `${prefix}.name`,
+          reason: "must be a non-empty string",
+        });
+      } else if (seenNames.has(srcObj.name)) {
+        failures.push({
+          field: `${prefix}.name`,
+          reason: `duplicate source name '${srcObj.name}' — names must be unique`,
+        });
+      } else {
+        seenNames.add(srcObj.name as string);
+      }
+
+      // type
+      if (!("type" in srcObj)) {
+        failures.push({ field: `${prefix}.type`, reason: "required" });
+      } else if (typeof srcObj.type !== "string" || !srcObj.type) {
+        failures.push({
+          field: `${prefix}.type`,
+          reason: "must be a non-empty string",
+        });
+      }
+
+      // scope (optional string)
+      if ("scope" in srcObj && typeof srcObj.scope !== "string") {
+        failures.push({ field: `${prefix}.scope`, reason: "must be a string" });
+      }
+
+      // path (optional string)
+      if ("path" in srcObj && typeof srcObj.path !== "string") {
+        failures.push({ field: `${prefix}.path`, reason: "must be a string" });
+      }
+
+      // root (optional string)
+      if ("root" in srcObj && typeof srcObj.root !== "string") {
+        failures.push({ field: `${prefix}.root`, reason: "must be a string" });
+      }
+
+      // auth (optional)
+      if ("auth" in srcObj) {
+        const authFailures = validateAuthConfig(srcObj.auth, `${prefix}.auth`);
+        failures.push(...authFailures);
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new SyncConfigValidationError(failures);
+  }
+
+  return obj as unknown as SyncConfig;
+}
+
+function validateAuthConfig(
+  auth: unknown,
+  fieldPrefix: string,
+): Array<{ field: string; reason: string }> {
+  const failures: Array<{ field: string; reason: string }> = [];
+
+  if (typeof auth !== "object" || auth === null || Array.isArray(auth)) {
+    failures.push({ field: fieldPrefix, reason: "must be an object" });
+    return failures;
+  }
+
+  const authObj = auth as Record<string, unknown>;
+
+  if (!("kind" in authObj)) {
+    failures.push({ field: `${fieldPrefix}.kind`, reason: "required" });
+    return failures;
+  }
+
+  const kind = authObj.kind;
+  if (
+    !ALLOWED_AUTH_KINDS.includes(kind as (typeof ALLOWED_AUTH_KINDS)[number])
+  ) {
+    failures.push({
+      field: `${fieldPrefix}.kind`,
+      reason: `must be one of [${ALLOWED_AUTH_KINDS.join(", ")}], got ${JSON.stringify(kind)}`,
+    });
+    return failures;
+  }
+
+  const kindStr = kind as string;
+  const allowedFields = ALLOWED_AUTH_FIELDS[kindStr];
+  if (allowedFields) {
+    for (const key of Object.keys(authObj)) {
+      if (!allowedFields.has(key)) {
+        failures.push({
+          field: `${fieldPrefix}.${key}`,
+          reason: `unknown field for auth kind '${kindStr}' (allowed: ${Array.from(allowedFields).join(", ")})`,
+        });
+      }
+    }
+  }
+
+  // Kind-specific required fields
+  switch (kindStr) {
+    case "bearer":
+      if (typeof authObj.tokenEnv !== "string" || !authObj.tokenEnv) {
+        failures.push({
+          field: `${fieldPrefix}.tokenEnv`,
+          reason:
+            "required for bearer auth — name of the env var holding the token",
+        });
+      }
+      break;
+    case "basic":
+      if (typeof authObj.usernameEnv !== "string" || !authObj.usernameEnv) {
+        failures.push({
+          field: `${fieldPrefix}.usernameEnv`,
+          reason: "required for basic auth",
+        });
+      }
+      if (typeof authObj.secretEnv !== "string" || !authObj.secretEnv) {
+        failures.push({
+          field: `${fieldPrefix}.secretEnv`,
+          reason: "required for basic auth",
+        });
+      }
+      break;
+    case "service_account":
+      if (typeof authObj.keyJsonEnv !== "string" || !authObj.keyJsonEnv) {
+        failures.push({
+          field: `${fieldPrefix}.keyJsonEnv`,
+          reason: "required for service_account auth",
+        });
+      }
+      break;
+    case "oauth2":
+      if (typeof authObj.tokenEnv !== "string" || !authObj.tokenEnv) {
+        failures.push({
+          field: `${fieldPrefix}.tokenEnv`,
+          reason: "required for oauth2 auth",
+        });
+      }
+      break;
+  }
+
+  return failures;
+}
+
+// ---------------------------------------------------------------------------
+// Auth env var pre-flight check
+// ---------------------------------------------------------------------------
+
+/**
+ * Check that all env vars referenced in auth configs are present.
+ * Returns a list of {sourceName, envVar} pairs that are missing.
+ */
+function checkAuthEnvVars(
+  sources: SyncSource[],
+): Array<{ sourceName: string; envVar: string }> {
+  const missing: Array<{ sourceName: string; envVar: string }> = [];
+
+  for (const src of sources) {
+    if (!src.auth) continue;
+    const result = resolveSyncAuth(src.auth);
+    if ("missing" in result) {
+      missing.push({ sourceName: src.name, envVar: result.missing });
+    }
+  }
+
+  return missing;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter resolution
+// ---------------------------------------------------------------------------
+
+async function resolveAdapter(
+  src: SyncSource,
+  cwd: string,
+): Promise<EnrichmentAdapter> {
+  // Only network adapters (non-git, non-source) need a loader
+  const type = src.type;
+
+  if (type === "github") {
+    const { GitHubAdapter } = await import("../ingest/adapters/github.js");
+    return new GitHubAdapter();
+  }
+
+  if (type === "google_workspace") {
+    // Dynamic import so monorepo works without hard dependency
+    try {
+      const mod = await import("@engram/plugin-google-workspace" as string);
+      return new mod.GoogleWorkspaceAdapter();
+    } catch {
+      throw new Error(
+        `'google_workspace' adapter requires the '@engram/plugin-google-workspace' plugin. ` +
+          `Install it with: engram plugin install google-workspace`,
+      );
+    }
+  }
+
+  // Plugin type — resolve via discoverPlugins
+  const bundledRoot = bundledPluginsRoot() ?? undefined;
+  const plugins = discoverPlugins(cwd, bundledRoot);
+  const found = plugins.find((p) => p.name === type);
+  if (!found) {
+    const available = [...BUILT_IN_TYPES, ...plugins.map((p) => p.name)].join(
+      ", ",
+    );
+    throw new Error(
+      `Unknown source type '${type}'. Available types: ${available}`,
+    );
+  }
+
+  // Load the plugin
+  const { loadManifest } = await import("../plugins/manifest.js");
+  const manifest = loadManifest(found.dir);
+  if (manifest.transport === "js-module") {
+    const plugin = await loadJsModulePlugin(found.dir, manifest);
+    if (!plugin.adapter) {
+      throw new Error(`Plugin '${type}' does not export an enrichment adapter`);
+    }
+    return plugin.adapter;
+  }
+  if (manifest.transport === "executable") {
+    return loadExecutablePlugin(
+      found.dir,
+      manifest,
+    ) as unknown as EnrichmentAdapter;
+  }
+
+  throw new Error(
+    `Plugin '${type}' has unsupported transport '${manifest.transport}'`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single-source runner
+// ---------------------------------------------------------------------------
+
+async function runSource(
+  graph: EngramGraph,
+  src: SyncSource,
+  cwd: string,
+  dryRun: boolean,
+): Promise<SourceResult> {
+  const startMs = Date.now();
+  const type = src.type;
+
+  try {
+    if (type === "git") {
+      const repoPath = path.resolve(cwd, src.path ?? src.root ?? ".");
+      const result = await ingestGitRepo(graph, repoPath, {
+        dryRun,
+      } as Parameters<typeof ingestGitRepo>[2]);
+      return {
+        name: src.name,
+        type,
+        status: "success",
+        episodesCreated: result.episodesCreated,
+        entitiesCreated: result.entitiesCreated,
+        edgesCreated: result.edgesCreated,
+        elapsedMs: Date.now() - startMs,
+      };
+    }
+
+    if (type === "source") {
+      const root = path.resolve(cwd, src.root ?? src.path ?? ".");
+      const result = await ingestSource(graph, { root, dryRun });
+      return {
+        name: src.name,
+        type,
+        status: "success",
+        episodesCreated: result.episodesCreated,
+        entitiesCreated: result.entitiesCreated,
+        edgesCreated: result.edgesCreated,
+        elapsedMs: Date.now() - startMs,
+      };
+    }
+
+    // Network adapter (github, google_workspace, or plugin)
+    const adapter = await resolveAdapter(src, cwd);
+
+    // Resolve auth credential
+    let auth: AuthCredential = { kind: "none" };
+    if (src.auth) {
+      const resolved = resolveSyncAuth(src.auth as SyncAuthConfig);
+      if ("missing" in resolved) {
+        throw new Error(
+          `Missing required env var '${resolved.missing}' for source '${src.name}'`,
+        );
+      }
+      auth = resolved.credential;
+    }
+
+    // Validate scope
+    if (adapter.scopeSchema && src.scope) {
+      adapter.scopeSchema.validate(src.scope);
+    }
+
+    const result = await adapter.enrich(graph, {
+      auth,
+      scope: src.scope,
+      dryRun,
+    });
+
+    return {
+      name: src.name,
+      type,
+      status: "success",
+      episodesCreated: result.episodesCreated,
+      entitiesCreated: result.entitiesCreated,
+      edgesCreated: result.edgesCreated,
+      elapsedMs: Date.now() - startMs,
+    };
+  } catch (err) {
+    return {
+      name: src.name,
+      type,
+      status: "failed",
+      error: err instanceof Error ? err.message : String(err),
+      elapsedMs: Date.now() - startMs,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a full sync: all configured sources in declaration order,
+ * then the cross-ref resolver.
+ *
+ * @param graph - Open EngramGraph to write to
+ * @param config - Validated SyncConfig (call validateSyncConfig first)
+ * @param opts - Runtime options (--only, --continue-on-error, etc.)
+ * @param cwd - Working directory for resolving relative paths (default: process.cwd())
+ */
+export async function runSync(
+  graph: EngramGraph,
+  config: SyncConfig,
+  opts: RunSyncOpts = {},
+  cwd: string = process.cwd(),
+): Promise<SyncResult> {
+  const totalStart = Date.now();
+  const dryRun = opts.dryRun ?? false;
+
+  // Determine which sources to run
+  let sourcesToRun = config.sources;
+  if (opts.only && opts.only.length > 0) {
+    // Preserve declaration order
+    sourcesToRun = config.sources.filter(
+      (s) => opts.only?.includes(s.name) ?? false,
+    );
+  }
+
+  // Pre-flight: check all auth env vars before any execution
+  const missingEnvVars = checkAuthEnvVars(sourcesToRun);
+  if (missingEnvVars.length > 0) {
+    const lines = missingEnvVars
+      .map((m) => `  source '${m.sourceName}': missing env var '${m.envVar}'`)
+      .join("\n");
+    throw new SyncSourceError(
+      missingEnvVars[0].sourceName,
+      "",
+      new Error(
+        `Missing required environment variables:\n${lines}\n` +
+          `Set these env vars before running sync.`,
+      ),
+    );
+  }
+
+  const sourceResults: SourceResult[] = [];
+  let aborted = false;
+
+  for (const src of sourcesToRun) {
+    if (aborted) {
+      sourceResults.push({
+        name: src.name,
+        type: src.type,
+        status: "skipped",
+        elapsedMs: 0,
+      });
+      continue;
+    }
+
+    opts.onSourceStart?.(src.name, src.type);
+
+    const result = dryRun
+      ? ({
+          name: src.name,
+          type: src.type,
+          status: "success",
+          episodesCreated: 0,
+          entitiesCreated: 0,
+          edgesCreated: 0,
+          elapsedMs: 0,
+        } satisfies SourceResult)
+      : await runSource(graph, src, cwd, dryRun);
+
+    sourceResults.push(result);
+    opts.onSourceEnd?.(result);
+
+    if (result.status === "failed" && !opts.continueOnError) {
+      aborted = true;
+    }
+  }
+
+  // Run cross-ref resolver unless: --no-cross-refs, dry-run, or fail-fast abort
+  let crossRefs: SyncResult["crossRefs"] = null;
+  const hadFailure = sourceResults.some((r) => r.status === "failed");
+
+  if (!opts.noCrossRefs && !dryRun && !(aborted && hadFailure)) {
+    const crossRefStart = Date.now();
+    // Get all episode IDs from episodes table for a full scan
+    const allEpisodes = graph.db
+      .query<{ id: string }, []>(
+        "SELECT id FROM episodes WHERE status != 'redacted' ORDER BY timestamp ASC",
+      )
+      .all();
+    const allEpisodeIds = allEpisodes.map((e) => e.id);
+    const resolveResult = resolveReferences(graph, allEpisodeIds);
+    crossRefs = {
+      edgesCreated: resolveResult.edgesCreated,
+      unresolved: resolveResult.unresolved,
+      elapsedMs: Date.now() - crossRefStart,
+    };
+  }
+
+  const overallStatus = hadFailure ? "failed" : "success";
+
+  return {
+    sources: sourceResults,
+    crossRefs,
+    status: overallStatus,
+    elapsedMs: Date.now() - totalStart,
+  };
+}

--- a/packages/engram-core/src/sync/run.ts
+++ b/packages/engram-core/src/sync/run.ts
@@ -17,7 +17,7 @@ import {
   loadExecutablePlugin,
   loadJsModulePlugin,
 } from "../plugins/index.js";
-import { SyncConfigValidationError, SyncSourceError } from "./errors.js";
+import { SyncSourceError } from "./errors.js";
 import type {
   RunSyncOpts,
   SourceResult,
@@ -28,254 +28,13 @@ import type {
 } from "./types.js";
 import { resolveSyncAuth } from "./types.js";
 
+export { validateSyncConfig } from "./validate.js";
+
 // ---------------------------------------------------------------------------
 // Built-in adapter types
 // ---------------------------------------------------------------------------
 
 const BUILT_IN_TYPES = ["git", "source", "github", "google_workspace"] as const;
-
-// ---------------------------------------------------------------------------
-// Config validation
-// ---------------------------------------------------------------------------
-
-const ALLOWED_AUTH_KINDS = [
-  "none",
-  "bearer",
-  "basic",
-  "service_account",
-  "oauth2",
-] as const;
-
-const ALLOWED_SOURCE_FIELDS = new Set([
-  "name",
-  "type",
-  "scope",
-  "path",
-  "root",
-  "auth",
-]);
-
-const ALLOWED_AUTH_FIELDS: Record<string, Set<string>> = {
-  none: new Set(["kind"]),
-  bearer: new Set(["kind", "tokenEnv"]),
-  basic: new Set(["kind", "usernameEnv", "secretEnv"]),
-  service_account: new Set(["kind", "keyJsonEnv"]),
-  oauth2: new Set(["kind", "tokenEnv", "scopesEnv"]),
-};
-
-/**
- * Validate a raw JSON object against the SyncConfig schema.
- * Collects ALL errors before throwing, so the user can fix everything at once.
- *
- * Rules (fail-closed):
- * - `version: 1` required
- * - Every source: `name` (unique), `type` — no unknown fields
- * - Auth uses `SyncAuthConfig` union — no unknown fields per kind
- */
-export function validateSyncConfig(raw: unknown): SyncConfig {
-  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    throw new SyncConfigValidationError([
-      { field: "(root)", reason: "must be a JSON object" },
-    ]);
-  }
-
-  const obj = raw as Record<string, unknown>;
-  const failures: Array<{ field: string; reason: string }> = [];
-
-  // Check for unknown top-level fields
-  const ALLOWED_TOP_FIELDS = new Set(["version", "sources"]);
-  for (const key of Object.keys(obj)) {
-    if (!ALLOWED_TOP_FIELDS.has(key)) {
-      failures.push({
-        field: key,
-        reason: `unknown top-level field (allowed: ${Array.from(ALLOWED_TOP_FIELDS).join(", ")})`,
-      });
-    }
-  }
-
-  // Validate version
-  if (!("version" in obj)) {
-    failures.push({ field: "version", reason: "required field missing" });
-  } else if (obj.version !== 1) {
-    failures.push({
-      field: "version",
-      reason: `must be 1 (got ${JSON.stringify(obj.version)}). If you have a newer config format, upgrade engram to the matching version.`,
-    });
-  }
-
-  // Validate sources
-  if (!("sources" in obj)) {
-    failures.push({ field: "sources", reason: "required field missing" });
-  } else if (!Array.isArray(obj.sources)) {
-    failures.push({ field: "sources", reason: "must be an array" });
-  } else {
-    const seenNames = new Set<string>();
-
-    for (let i = 0; i < obj.sources.length; i++) {
-      const src = obj.sources[i];
-      const prefix = `sources[${i}]`;
-
-      if (typeof src !== "object" || src === null || Array.isArray(src)) {
-        failures.push({ field: prefix, reason: "must be an object" });
-        continue;
-      }
-
-      const srcObj = src as Record<string, unknown>;
-
-      // Check for unknown source fields
-      for (const key of Object.keys(srcObj)) {
-        if (!ALLOWED_SOURCE_FIELDS.has(key)) {
-          failures.push({
-            field: `${prefix}.${key}`,
-            reason: `unknown field (allowed: ${Array.from(ALLOWED_SOURCE_FIELDS).join(", ")})`,
-          });
-        }
-      }
-
-      // name
-      if (!("name" in srcObj)) {
-        failures.push({ field: `${prefix}.name`, reason: "required" });
-      } else if (typeof srcObj.name !== "string" || !srcObj.name) {
-        failures.push({
-          field: `${prefix}.name`,
-          reason: "must be a non-empty string",
-        });
-      } else if (seenNames.has(srcObj.name)) {
-        failures.push({
-          field: `${prefix}.name`,
-          reason: `duplicate source name '${srcObj.name}' — names must be unique`,
-        });
-      } else {
-        seenNames.add(srcObj.name as string);
-      }
-
-      // type
-      if (!("type" in srcObj)) {
-        failures.push({ field: `${prefix}.type`, reason: "required" });
-      } else if (typeof srcObj.type !== "string" || !srcObj.type) {
-        failures.push({
-          field: `${prefix}.type`,
-          reason: "must be a non-empty string",
-        });
-      }
-
-      // scope (optional string)
-      if ("scope" in srcObj && typeof srcObj.scope !== "string") {
-        failures.push({ field: `${prefix}.scope`, reason: "must be a string" });
-      }
-
-      // path (optional string)
-      if ("path" in srcObj && typeof srcObj.path !== "string") {
-        failures.push({ field: `${prefix}.path`, reason: "must be a string" });
-      }
-
-      // root (optional string)
-      if ("root" in srcObj && typeof srcObj.root !== "string") {
-        failures.push({ field: `${prefix}.root`, reason: "must be a string" });
-      }
-
-      // auth (optional)
-      if ("auth" in srcObj) {
-        const authFailures = validateAuthConfig(srcObj.auth, `${prefix}.auth`);
-        failures.push(...authFailures);
-      }
-    }
-  }
-
-  if (failures.length > 0) {
-    throw new SyncConfigValidationError(failures);
-  }
-
-  return obj as unknown as SyncConfig;
-}
-
-function validateAuthConfig(
-  auth: unknown,
-  fieldPrefix: string,
-): Array<{ field: string; reason: string }> {
-  const failures: Array<{ field: string; reason: string }> = [];
-
-  if (typeof auth !== "object" || auth === null || Array.isArray(auth)) {
-    failures.push({ field: fieldPrefix, reason: "must be an object" });
-    return failures;
-  }
-
-  const authObj = auth as Record<string, unknown>;
-
-  if (!("kind" in authObj)) {
-    failures.push({ field: `${fieldPrefix}.kind`, reason: "required" });
-    return failures;
-  }
-
-  const kind = authObj.kind;
-  if (
-    !ALLOWED_AUTH_KINDS.includes(kind as (typeof ALLOWED_AUTH_KINDS)[number])
-  ) {
-    failures.push({
-      field: `${fieldPrefix}.kind`,
-      reason: `must be one of [${ALLOWED_AUTH_KINDS.join(", ")}], got ${JSON.stringify(kind)}`,
-    });
-    return failures;
-  }
-
-  const kindStr = kind as string;
-  const allowedFields = ALLOWED_AUTH_FIELDS[kindStr];
-  if (allowedFields) {
-    for (const key of Object.keys(authObj)) {
-      if (!allowedFields.has(key)) {
-        failures.push({
-          field: `${fieldPrefix}.${key}`,
-          reason: `unknown field for auth kind '${kindStr}' (allowed: ${Array.from(allowedFields).join(", ")})`,
-        });
-      }
-    }
-  }
-
-  // Kind-specific required fields
-  switch (kindStr) {
-    case "bearer":
-      if (typeof authObj.tokenEnv !== "string" || !authObj.tokenEnv) {
-        failures.push({
-          field: `${fieldPrefix}.tokenEnv`,
-          reason:
-            "required for bearer auth — name of the env var holding the token",
-        });
-      }
-      break;
-    case "basic":
-      if (typeof authObj.usernameEnv !== "string" || !authObj.usernameEnv) {
-        failures.push({
-          field: `${fieldPrefix}.usernameEnv`,
-          reason: "required for basic auth",
-        });
-      }
-      if (typeof authObj.secretEnv !== "string" || !authObj.secretEnv) {
-        failures.push({
-          field: `${fieldPrefix}.secretEnv`,
-          reason: "required for basic auth",
-        });
-      }
-      break;
-    case "service_account":
-      if (typeof authObj.keyJsonEnv !== "string" || !authObj.keyJsonEnv) {
-        failures.push({
-          field: `${fieldPrefix}.keyJsonEnv`,
-          reason: "required for service_account auth",
-        });
-      }
-      break;
-    case "oauth2":
-      if (typeof authObj.tokenEnv !== "string" || !authObj.tokenEnv) {
-        failures.push({
-          field: `${fieldPrefix}.tokenEnv`,
-          reason: "required for oauth2 auth",
-        });
-      }
-      break;
-  }
-
-  return failures;
-}
 
 // ---------------------------------------------------------------------------
 // Auth env var pre-flight check
@@ -292,9 +51,9 @@ function checkAuthEnvVars(
 
   for (const src of sources) {
     if (!src.auth) continue;
-    const result = resolveSyncAuth(src.auth);
-    if ("missing" in result) {
-      missing.push({ sourceName: src.name, envVar: result.missing });
+    const missingVars = resolveSyncAuth(src.auth);
+    for (const envVar of missingVars) {
+      missing.push({ sourceName: src.name, envVar });
     }
   }
 
@@ -373,7 +132,6 @@ async function runSource(
   graph: EngramGraph,
   src: SyncSource,
   cwd: string,
-  dryRun: boolean,
 ): Promise<SourceResult> {
   const startMs = Date.now();
   const type = src.type;
@@ -381,9 +139,7 @@ async function runSource(
   try {
     if (type === "git") {
       const repoPath = path.resolve(cwd, src.path ?? src.root ?? ".");
-      const result = await ingestGitRepo(graph, repoPath, {
-        dryRun,
-      } as Parameters<typeof ingestGitRepo>[2]);
+      const result = await ingestGitRepo(graph, repoPath);
       return {
         name: src.name,
         type,
@@ -397,7 +153,7 @@ async function runSource(
 
     if (type === "source") {
       const root = path.resolve(cwd, src.root ?? src.path ?? ".");
-      const result = await ingestSource(graph, { root, dryRun });
+      const result = await ingestSource(graph, { root });
       return {
         name: src.name,
         type,
@@ -415,13 +171,15 @@ async function runSource(
     // Resolve auth credential
     let auth: AuthCredential = { kind: "none" };
     if (src.auth) {
-      const resolved = resolveSyncAuth(src.auth as SyncAuthConfig);
-      if ("missing" in resolved) {
+      const missing = resolveSyncAuth(src.auth as SyncAuthConfig);
+      if (missing.length > 0) {
         throw new Error(
-          `Missing required env var '${resolved.missing}' for source '${src.name}'`,
+          `Missing required env vars for source '${src.name}': ${missing.join(", ")}`,
         );
       }
-      auth = resolved.credential;
+      // Re-resolve to get the credential (all vars confirmed present)
+      const resolved = resolveSyncAuthCredential(src.auth as SyncAuthConfig);
+      auth = resolved;
     }
 
     // Validate scope
@@ -432,7 +190,6 @@ async function runSource(
     const result = await adapter.enrich(graph, {
       auth,
       scope: src.scope,
-      dryRun,
     });
 
     return {
@@ -492,9 +249,14 @@ export async function runSync(
     const lines = missingEnvVars
       .map((m) => `  source '${m.sourceName}': missing env var '${m.envVar}'`)
       .join("\n");
+    // B3: use the actual source type from the first failing source
+    const firstMissing = missingEnvVars[0];
+    const firstSrc = sourcesToRun.find(
+      (s) => s.name === firstMissing.sourceName,
+    );
     throw new SyncSourceError(
-      missingEnvVars[0].sourceName,
-      "",
+      firstMissing.sourceName,
+      firstSrc?.type ?? "",
       new Error(
         `Missing required environment variables:\n${lines}\n` +
           `Set these env vars before running sync.`,
@@ -518,6 +280,7 @@ export async function runSync(
 
     opts.onSourceStart?.(src.name, src.type);
 
+    // B4: dry-run is handled entirely at orchestrator level — skip adapter calls
     const result = dryRun
       ? ({
           name: src.name,
@@ -528,7 +291,7 @@ export async function runSync(
           edgesCreated: 0,
           elapsedMs: 0,
         } satisfies SourceResult)
-      : await runSource(graph, src, cwd, dryRun);
+      : await runSource(graph, src, cwd);
 
     sourceResults.push(result);
     opts.onSourceEnd?.(result);
@@ -567,4 +330,42 @@ export async function runSync(
     status: overallStatus,
     elapsedMs: Date.now() - totalStart,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: resolve credential after all vars confirmed present
+// ---------------------------------------------------------------------------
+
+function resolveSyncAuthCredential(authConfig: SyncAuthConfig): AuthCredential {
+  switch (authConfig.kind) {
+    case "none":
+      return { kind: "none" };
+    case "bearer":
+      return {
+        kind: "bearer",
+        token: process.env[authConfig.tokenEnv] ?? "",
+      };
+    case "basic":
+      return {
+        kind: "basic",
+        username: process.env[authConfig.usernameEnv] ?? "",
+        secret: process.env[authConfig.secretEnv] ?? "",
+      };
+    case "service_account":
+      return {
+        kind: "service_account",
+        keyJson: process.env[authConfig.keyJsonEnv] ?? "",
+      };
+    case "oauth2": {
+      const rawScopes = authConfig.scopesEnv
+        ? process.env[authConfig.scopesEnv]
+        : undefined;
+      const scopes = rawScopes ? rawScopes.split(",").map((s) => s.trim()) : [];
+      return {
+        kind: "oauth2",
+        token: process.env[authConfig.tokenEnv] ?? "",
+        scopes,
+      };
+    }
+  }
 }

--- a/packages/engram-core/src/sync/types.ts
+++ b/packages/engram-core/src/sync/types.ts
@@ -1,0 +1,158 @@
+/**
+ * sync/types.ts — types for the config-driven sync orchestrator.
+ */
+
+import type { AuthCredential } from "../ingest/adapter.js";
+
+// ---------------------------------------------------------------------------
+// Config schema
+// ---------------------------------------------------------------------------
+
+/**
+ * Auth config within a sync source. Uses `tokenEnv` to reference an
+ * environment variable name rather than storing a literal token.
+ *
+ * This is the config-file representation — converted to `AuthCredential`
+ * at runtime by resolving the env var.
+ */
+export type SyncAuthConfig =
+  | { kind: "none" }
+  | { kind: "bearer"; tokenEnv: string }
+  | { kind: "basic"; usernameEnv: string; secretEnv: string }
+  | { kind: "service_account"; keyJsonEnv: string }
+  | { kind: "oauth2"; tokenEnv: string; scopesEnv?: string };
+
+/** A single source entry in `.engram.config.json`. */
+export interface SyncSource {
+  /** Unique name for this source (used with --only). */
+  name: string;
+  /** Adapter type: 'git', 'source', 'github', 'google_workspace', or a plugin type. */
+  type: string;
+  /**
+   * Adapter-specific scope (e.g. 'owner/repo' for github, 'domain' for google_workspace).
+   * Not required for 'git' and 'source' built-ins.
+   */
+  scope?: string;
+  /**
+   * Filesystem path — used as repo path for 'git', root dir for 'source'.
+   * Not used for network adapters.
+   */
+  path?: string;
+  /**
+   * Filesystem root — alias for 'path' specifically for 'source' adapter.
+   * If both are provided, 'root' takes precedence.
+   */
+  root?: string;
+  /** Auth configuration. May be omitted for 'git' and 'source'. */
+  auth?: SyncAuthConfig;
+}
+
+/** Root `.engram.config.json` schema. */
+export interface SyncConfig {
+  version: 1;
+  sources: SyncSource[];
+}
+
+// ---------------------------------------------------------------------------
+// Runtime result types
+// ---------------------------------------------------------------------------
+
+export type SourceStatus = "success" | "failed" | "skipped";
+
+/** Per-source result from a sync run. */
+export interface SourceResult {
+  name: string;
+  type: string;
+  status: SourceStatus;
+  /** Human-readable error message if status === 'failed'. */
+  error?: string;
+  /** Episodes created during this source run. */
+  episodesCreated?: number;
+  /** Entities created during this source run. */
+  entitiesCreated?: number;
+  /** Edges created during this source run. */
+  edgesCreated?: number;
+  /** Elapsed time in milliseconds. */
+  elapsedMs: number;
+}
+
+/** Result of a full sync run. */
+export interface SyncResult {
+  sources: SourceResult[];
+  /** Cross-ref resolver result (null if skipped). */
+  crossRefs: {
+    edgesCreated: number;
+    unresolved: number;
+    elapsedMs: number;
+  } | null;
+  /** Overall status: success if all sources succeeded, failed otherwise. */
+  status: "success" | "failed";
+  /** Total elapsed time in milliseconds. */
+  elapsedMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime options
+// ---------------------------------------------------------------------------
+
+export interface RunSyncOpts {
+  /** Run only these named sources (declaration order preserved). */
+  only?: string[];
+  /** Continue running remaining sources after a failure (default: fail-fast). */
+  continueOnError?: boolean;
+  /** Skip the cross-ref resolver step. */
+  noCrossRefs?: boolean;
+  /** Dry run: validate config + print plan, no execution. */
+  dryRun?: boolean;
+  /** Optional progress callback called before each source starts. */
+  onSourceStart?: (name: string, type: string) => void;
+  /** Optional progress callback called after each source completes. */
+  onSourceEnd?: (result: SourceResult) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Auth resolution helper (config → runtime credential)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a SyncAuthConfig to a runtime AuthCredential by reading env vars.
+ * Returns null if a required env var is missing (caller reports the error).
+ */
+export function resolveSyncAuth(
+  authConfig: SyncAuthConfig,
+): { credential: AuthCredential } | { missing: string } {
+  switch (authConfig.kind) {
+    case "none":
+      return { credential: { kind: "none" } };
+
+    case "bearer": {
+      const token = process.env[authConfig.tokenEnv];
+      if (!token) return { missing: authConfig.tokenEnv };
+      return { credential: { kind: "bearer", token } };
+    }
+
+    case "basic": {
+      const username = process.env[authConfig.usernameEnv];
+      const secret = process.env[authConfig.secretEnv];
+      if (!username) return { missing: authConfig.usernameEnv };
+      if (!secret) return { missing: authConfig.secretEnv };
+      return { credential: { kind: "basic", username, secret } };
+    }
+
+    case "service_account": {
+      const keyJson = process.env[authConfig.keyJsonEnv];
+      if (!keyJson) return { missing: authConfig.keyJsonEnv };
+      return { credential: { kind: "service_account", keyJson } };
+    }
+
+    case "oauth2": {
+      const token = process.env[authConfig.tokenEnv];
+      if (!token) return { missing: authConfig.tokenEnv };
+      const rawScopes = authConfig.scopesEnv
+        ? process.env[authConfig.scopesEnv]
+        : undefined;
+      const scopes = rawScopes ? rawScopes.split(",").map((s) => s.trim()) : [];
+      return { credential: { kind: "oauth2", token, scopes } };
+    }
+  }
+}

--- a/packages/engram-core/src/sync/types.ts
+++ b/packages/engram-core/src/sync/types.ts
@@ -2,8 +2,6 @@
  * sync/types.ts — types for the config-driven sync orchestrator.
  */
 
-import type { AuthCredential } from "../ingest/adapter.js";
-
 // ---------------------------------------------------------------------------
 // Config schema
 // ---------------------------------------------------------------------------
@@ -115,44 +113,39 @@ export interface RunSyncOpts {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a SyncAuthConfig to a runtime AuthCredential by reading env vars.
- * Returns null if a required env var is missing (caller reports the error).
+ * Check a SyncAuthConfig for missing env vars.
+ *
+ * Returns an array of all missing env var names (empty array = all present).
+ * Callers should report all missing vars together rather than stopping at the
+ * first, giving users a complete picture of what they need to set.
  */
-export function resolveSyncAuth(
-  authConfig: SyncAuthConfig,
-): { credential: AuthCredential } | { missing: string } {
+export function resolveSyncAuth(authConfig: SyncAuthConfig): string[] {
+  const missing: string[] = [];
+
   switch (authConfig.kind) {
     case "none":
-      return { credential: { kind: "none" } };
+      break;
 
-    case "bearer": {
-      const token = process.env[authConfig.tokenEnv];
-      if (!token) return { missing: authConfig.tokenEnv };
-      return { credential: { kind: "bearer", token } };
-    }
+    case "bearer":
+      if (!process.env[authConfig.tokenEnv]) missing.push(authConfig.tokenEnv);
+      break;
 
-    case "basic": {
-      const username = process.env[authConfig.usernameEnv];
-      const secret = process.env[authConfig.secretEnv];
-      if (!username) return { missing: authConfig.usernameEnv };
-      if (!secret) return { missing: authConfig.secretEnv };
-      return { credential: { kind: "basic", username, secret } };
-    }
+    case "basic":
+      if (!process.env[authConfig.usernameEnv])
+        missing.push(authConfig.usernameEnv);
+      if (!process.env[authConfig.secretEnv])
+        missing.push(authConfig.secretEnv);
+      break;
 
-    case "service_account": {
-      const keyJson = process.env[authConfig.keyJsonEnv];
-      if (!keyJson) return { missing: authConfig.keyJsonEnv };
-      return { credential: { kind: "service_account", keyJson } };
-    }
+    case "service_account":
+      if (!process.env[authConfig.keyJsonEnv])
+        missing.push(authConfig.keyJsonEnv);
+      break;
 
-    case "oauth2": {
-      const token = process.env[authConfig.tokenEnv];
-      if (!token) return { missing: authConfig.tokenEnv };
-      const rawScopes = authConfig.scopesEnv
-        ? process.env[authConfig.scopesEnv]
-        : undefined;
-      const scopes = rawScopes ? rawScopes.split(",").map((s) => s.trim()) : [];
-      return { credential: { kind: "oauth2", token, scopes } };
-    }
+    case "oauth2":
+      if (!process.env[authConfig.tokenEnv]) missing.push(authConfig.tokenEnv);
+      break;
   }
+
+  return missing;
 }

--- a/packages/engram-core/src/sync/validate.ts
+++ b/packages/engram-core/src/sync/validate.ts
@@ -1,0 +1,289 @@
+/**
+ * sync/validate.ts — config validation for the sync orchestrator.
+ *
+ * Validates a raw JSON object against the SyncConfig schema.
+ * Collects ALL errors before throwing, so the user can fix everything at once.
+ */
+
+import { SyncConfigValidationError } from "./errors.js";
+import type { SyncConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const ALLOWED_AUTH_KINDS = [
+  "none",
+  "bearer",
+  "basic",
+  "service_account",
+  "oauth2",
+] as const;
+
+export const ALLOWED_SOURCE_FIELDS = new Set([
+  "name",
+  "type",
+  "scope",
+  "path",
+  "root",
+  "auth",
+]);
+
+export const ALLOWED_AUTH_FIELDS: Record<string, Set<string>> = {
+  none: new Set(["kind"]),
+  bearer: new Set(["kind", "tokenEnv"]),
+  basic: new Set(["kind", "usernameEnv", "secretEnv"]),
+  service_account: new Set(["kind", "keyJsonEnv"]),
+  oauth2: new Set(["kind", "tokenEnv", "scopesEnv"]),
+};
+
+/**
+ * Adapter types that require a non-empty `scope` field.
+ * Validation will emit an error if scope is missing for these.
+ */
+const SCOPE_REQUIRED_ADAPTERS = new Set([
+  "github",
+  "google_workspace",
+  "gerrit",
+]);
+
+// ---------------------------------------------------------------------------
+// Auth validation helper
+// ---------------------------------------------------------------------------
+
+export function validateAuthConfig(
+  auth: unknown,
+  fieldPrefix: string,
+): Array<{ field: string; reason: string }> {
+  const failures: Array<{ field: string; reason: string }> = [];
+
+  if (typeof auth !== "object" || auth === null || Array.isArray(auth)) {
+    failures.push({ field: fieldPrefix, reason: "must be an object" });
+    return failures;
+  }
+
+  const authObj = auth as Record<string, unknown>;
+
+  if (!("kind" in authObj)) {
+    failures.push({ field: `${fieldPrefix}.kind`, reason: "required" });
+    return failures;
+  }
+
+  const kind = authObj.kind;
+  if (
+    !ALLOWED_AUTH_KINDS.includes(kind as (typeof ALLOWED_AUTH_KINDS)[number])
+  ) {
+    failures.push({
+      field: `${fieldPrefix}.kind`,
+      reason: `must be one of [${ALLOWED_AUTH_KINDS.join(", ")}], got ${JSON.stringify(kind)}`,
+    });
+    return failures;
+  }
+
+  const kindStr = kind as string;
+  const allowedFields = ALLOWED_AUTH_FIELDS[kindStr];
+  if (allowedFields) {
+    for (const key of Object.keys(authObj)) {
+      if (!allowedFields.has(key)) {
+        failures.push({
+          field: `${fieldPrefix}.${key}`,
+          reason: `unknown field for auth kind '${kindStr}' (allowed: ${Array.from(allowedFields).join(", ")})`,
+        });
+      }
+    }
+  }
+
+  // Kind-specific required fields
+  switch (kindStr) {
+    case "bearer":
+      if (typeof authObj.tokenEnv !== "string" || !authObj.tokenEnv) {
+        failures.push({
+          field: `${fieldPrefix}.tokenEnv`,
+          reason:
+            "required for bearer auth — name of the env var holding the token",
+        });
+      }
+      break;
+    case "basic":
+      if (typeof authObj.usernameEnv !== "string" || !authObj.usernameEnv) {
+        failures.push({
+          field: `${fieldPrefix}.usernameEnv`,
+          reason: "required for basic auth",
+        });
+      }
+      if (typeof authObj.secretEnv !== "string" || !authObj.secretEnv) {
+        failures.push({
+          field: `${fieldPrefix}.secretEnv`,
+          reason: "required for basic auth",
+        });
+      }
+      break;
+    case "service_account":
+      if (typeof authObj.keyJsonEnv !== "string" || !authObj.keyJsonEnv) {
+        failures.push({
+          field: `${fieldPrefix}.keyJsonEnv`,
+          reason: "required for service_account auth",
+        });
+      }
+      break;
+    case "oauth2":
+      if (typeof authObj.tokenEnv !== "string" || !authObj.tokenEnv) {
+        failures.push({
+          field: `${fieldPrefix}.tokenEnv`,
+          reason: "required for oauth2 auth",
+        });
+      }
+      break;
+  }
+
+  return failures;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level config validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a raw JSON object against the SyncConfig schema.
+ * Collects ALL errors before throwing, so the user can fix everything at once.
+ *
+ * Rules (fail-closed):
+ * - `version: 1` required
+ * - Every source: `name` (unique), `type` — no unknown fields
+ * - Auth uses `SyncAuthConfig` union — no unknown fields per kind
+ * - Known adapters that require scope (github, google_workspace, gerrit) must
+ *   have a non-empty `scope` field
+ */
+export function validateSyncConfig(raw: unknown): SyncConfig {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new SyncConfigValidationError([
+      { field: "(root)", reason: "must be a JSON object" },
+    ]);
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const failures: Array<{ field: string; reason: string }> = [];
+
+  // Check for unknown top-level fields
+  const ALLOWED_TOP_FIELDS = new Set(["version", "sources"]);
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_TOP_FIELDS.has(key)) {
+      failures.push({
+        field: key,
+        reason: `unknown top-level field (allowed: ${Array.from(ALLOWED_TOP_FIELDS).join(", ")})`,
+      });
+    }
+  }
+
+  // Validate version
+  if (!("version" in obj)) {
+    failures.push({ field: "version", reason: "required field missing" });
+  } else if (obj.version !== 1) {
+    failures.push({
+      field: "version",
+      reason: `must be 1 (got ${JSON.stringify(obj.version)}). If you have a newer config format, upgrade engram to the matching version.`,
+    });
+  }
+
+  // Validate sources
+  if (!("sources" in obj)) {
+    failures.push({ field: "sources", reason: "required field missing" });
+  } else if (!Array.isArray(obj.sources)) {
+    failures.push({ field: "sources", reason: "must be an array" });
+  } else {
+    const seenNames = new Set<string>();
+
+    for (let i = 0; i < obj.sources.length; i++) {
+      const src = obj.sources[i];
+      const prefix = `sources[${i}]`;
+
+      if (typeof src !== "object" || src === null || Array.isArray(src)) {
+        failures.push({ field: prefix, reason: "must be an object" });
+        continue;
+      }
+
+      const srcObj = src as Record<string, unknown>;
+
+      // Check for unknown source fields
+      for (const key of Object.keys(srcObj)) {
+        if (!ALLOWED_SOURCE_FIELDS.has(key)) {
+          failures.push({
+            field: `${prefix}.${key}`,
+            reason: `unknown field (allowed: ${Array.from(ALLOWED_SOURCE_FIELDS).join(", ")})`,
+          });
+        }
+      }
+
+      // name
+      if (!("name" in srcObj)) {
+        failures.push({ field: `${prefix}.name`, reason: "required" });
+      } else if (typeof srcObj.name !== "string" || !srcObj.name) {
+        failures.push({
+          field: `${prefix}.name`,
+          reason: "must be a non-empty string",
+        });
+      } else if (seenNames.has(srcObj.name)) {
+        failures.push({
+          field: `${prefix}.name`,
+          reason: `duplicate source name '${srcObj.name}' — names must be unique`,
+        });
+      } else {
+        seenNames.add(srcObj.name as string);
+      }
+
+      // type
+      let srcType: string | undefined;
+      if (!("type" in srcObj)) {
+        failures.push({ field: `${prefix}.type`, reason: "required" });
+      } else if (typeof srcObj.type !== "string" || !srcObj.type) {
+        failures.push({
+          field: `${prefix}.type`,
+          reason: "must be a non-empty string",
+        });
+      } else {
+        srcType = srcObj.type;
+      }
+
+      // scope (optional string)
+      if ("scope" in srcObj && typeof srcObj.scope !== "string") {
+        failures.push({ field: `${prefix}.scope`, reason: "must be a string" });
+      }
+
+      // N2: scope required for known adapters that need it
+      if (
+        srcType !== undefined &&
+        SCOPE_REQUIRED_ADAPTERS.has(srcType) &&
+        (!("scope" in srcObj) ||
+          !srcObj.scope ||
+          typeof srcObj.scope !== "string")
+      ) {
+        failures.push({
+          field: `${prefix}.scope`,
+          reason: `required for '${srcType}' adapter (e.g. 'owner/repo' for github, 'domain.com' for google_workspace)`,
+        });
+      }
+
+      // path (optional string)
+      if ("path" in srcObj && typeof srcObj.path !== "string") {
+        failures.push({ field: `${prefix}.path`, reason: "must be a string" });
+      }
+
+      // root (optional string)
+      if ("root" in srcObj && typeof srcObj.root !== "string") {
+        failures.push({ field: `${prefix}.root`, reason: "must be a string" });
+      }
+
+      // auth (optional)
+      if ("auth" in srcObj) {
+        const authFailures = validateAuthConfig(srcObj.auth, `${prefix}.auth`);
+        failures.push(...authFailures);
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new SyncConfigValidationError(failures);
+  }
+
+  return obj as unknown as SyncConfig;
+}

--- a/packages/engram-core/test/sync/run.test.ts
+++ b/packages/engram-core/test/sync/run.test.ts
@@ -1,0 +1,451 @@
+/**
+ * test/sync/run.test.ts — unit tests for runSync and validateSyncConfig.
+ *
+ * Uses real SQLite (:memory:) and stub implementations. No mocks.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createGraph } from "../../src/format/index.js";
+import { SyncConfigValidationError } from "../../src/sync/errors.js";
+import { runSync, validateSyncConfig } from "../../src/sync/run.js";
+import type { SyncConfig } from "../../src/sync/types.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(
+  overrides: Partial<SyncConfig> = {},
+  sourcesOverride?: SyncConfig["sources"],
+): SyncConfig {
+  return {
+    version: 1,
+    sources: sourcesOverride ?? [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateSyncConfig
+// ---------------------------------------------------------------------------
+
+describe("validateSyncConfig", () => {
+  test("accepts valid config with no sources", () => {
+    const config = validateSyncConfig({ version: 1, sources: [] });
+    expect(config.version).toBe(1);
+    expect(config.sources).toHaveLength(0);
+  });
+
+  test("accepts valid config with git and source entries", () => {
+    const config = validateSyncConfig({
+      version: 1,
+      sources: [
+        { name: "repo-git", type: "git", path: "." },
+        { name: "repo-src", type: "source", root: "packages/" },
+      ],
+    });
+    expect(config.sources).toHaveLength(2);
+  });
+
+  test("accepts github source with bearer auth", () => {
+    const config = validateSyncConfig({
+      version: 1,
+      sources: [
+        {
+          name: "gh",
+          type: "github",
+          scope: "owner/repo",
+          auth: { kind: "bearer", tokenEnv: "GITHUB_TOKEN" },
+        },
+      ],
+    });
+    expect(config.sources[0].auth).toEqual({
+      kind: "bearer",
+      tokenEnv: "GITHUB_TOKEN",
+    });
+  });
+
+  test("rejects non-object root", () => {
+    expect(() => validateSyncConfig(null)).toThrow(SyncConfigValidationError);
+    expect(() => validateSyncConfig([])).toThrow(SyncConfigValidationError);
+    expect(() => validateSyncConfig("string")).toThrow(
+      SyncConfigValidationError,
+    );
+  });
+
+  test("rejects missing version field", () => {
+    expect(() => validateSyncConfig({ sources: [] })).toThrow(
+      SyncConfigValidationError,
+    );
+  });
+
+  test("rejects version !== 1", () => {
+    try {
+      validateSyncConfig({ version: 2, sources: [] });
+      expect(true).toBe(false); // should not reach
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures[0].field).toBe("version");
+      expect(e.failures[0].reason).toContain("upgrade");
+    }
+  });
+
+  test("rejects missing sources field", () => {
+    expect(() => validateSyncConfig({ version: 1 })).toThrow(
+      SyncConfigValidationError,
+    );
+  });
+
+  test("rejects unknown top-level field", () => {
+    try {
+      validateSyncConfig({ version: 1, sources: [], extra: true });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures.some((f) => f.field === "extra")).toBe(true);
+    }
+  });
+
+  test("rejects duplicate source names", () => {
+    try {
+      validateSyncConfig({
+        version: 1,
+        sources: [
+          { name: "dup", type: "git" },
+          { name: "dup", type: "source" },
+        ],
+      });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures.some((f) => f.reason.includes("duplicate"))).toBe(true);
+    }
+  });
+
+  test("rejects unknown source fields (fail-closed)", () => {
+    try {
+      validateSyncConfig({
+        version: 1,
+        sources: [{ name: "s", type: "git", extraField: "bad" }],
+      });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures.some((f) => f.field.includes("extraField"))).toBe(true);
+    }
+  });
+
+  test("rejects missing source name", () => {
+    try {
+      validateSyncConfig({
+        version: 1,
+        sources: [{ type: "git" }],
+      });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures.some((f) => f.field.includes("name"))).toBe(true);
+    }
+  });
+
+  test("rejects missing source type", () => {
+    try {
+      validateSyncConfig({
+        version: 1,
+        sources: [{ name: "s" }],
+      });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures.some((f) => f.field.includes("type"))).toBe(true);
+    }
+  });
+
+  test("collects ALL validation errors, not just first", () => {
+    try {
+      validateSyncConfig({
+        version: 2, // wrong version
+        sources: [
+          { type: "git" }, // missing name
+        ],
+        badField: true, // unknown field
+      });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      // Should have multiple failures
+      expect(e.failures.length).toBeGreaterThan(1);
+    }
+  });
+
+  test("rejects unknown auth kind", () => {
+    try {
+      validateSyncConfig({
+        version: 1,
+        sources: [
+          {
+            name: "s",
+            type: "github",
+            auth: { kind: "magic", token: "x" },
+          },
+        ],
+      });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures.some((f) => f.field.includes("kind"))).toBe(true);
+    }
+  });
+
+  test("rejects unknown auth fields (fail-closed)", () => {
+    try {
+      validateSyncConfig({
+        version: 1,
+        sources: [
+          {
+            name: "s",
+            type: "github",
+            auth: { kind: "bearer", tokenEnv: "GH_TOKEN", extra: "bad" },
+          },
+        ],
+      });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures.some((f) => f.field.includes("extra"))).toBe(true);
+    }
+  });
+
+  test("rejects bearer auth missing tokenEnv", () => {
+    try {
+      validateSyncConfig({
+        version: 1,
+        sources: [
+          {
+            name: "s",
+            type: "github",
+            auth: { kind: "bearer" },
+          },
+        ],
+      });
+      expect(true).toBe(false);
+    } catch (err) {
+      expect(err).toBeInstanceOf(SyncConfigValidationError);
+      const e = err as SyncConfigValidationError;
+      expect(e.failures.some((f) => f.field.includes("tokenEnv"))).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runSync — ordering and flow control
+// ---------------------------------------------------------------------------
+
+describe("runSync", () => {
+  let graph: ReturnType<typeof createGraph>;
+
+  beforeEach(() => {
+    graph = createGraph(":memory:");
+  });
+
+  afterEach(() => {
+    try {
+      graph.db.close();
+    } catch {
+      // already closed
+    }
+  });
+
+  test("empty sources returns success with no cross-refs when --no-cross-refs", async () => {
+    const config = makeConfig({}, []);
+    const result = await runSync(graph, config, { noCrossRefs: true });
+    expect(result.status).toBe("success");
+    expect(result.sources).toHaveLength(0);
+    expect(result.crossRefs).toBeNull();
+  });
+
+  test("--only filters to named subset in declaration order", async () => {
+    // Use git sources with a real-ish path that will just fail gracefully
+    const config = makeConfig({}, [
+      { name: "a", type: "git", path: "/nonexistent-a" },
+      { name: "b", type: "git", path: "/nonexistent-b" },
+      { name: "c", type: "git", path: "/nonexistent-c" },
+    ]);
+
+    const visited: string[] = [];
+    const result = await runSync(graph, config, {
+      only: ["c", "a"], // out of declaration order — should be normalized to a, c
+      noCrossRefs: true,
+      continueOnError: true,
+      onSourceStart: (name) => visited.push(name),
+    });
+
+    // Declaration order: a before c, even though --only specified c,a
+    expect(visited).toEqual(["a", "c"]);
+    // b was not included
+    expect(result.sources.map((r) => r.name)).toEqual(["a", "c"]);
+  });
+
+  test("fail-fast: first failure aborts remaining sources", async () => {
+    const config = makeConfig({}, [
+      { name: "fail", type: "git", path: "/nonexistent-fail" },
+      { name: "should-skip", type: "git", path: "/nonexistent-skip" },
+    ]);
+
+    const visited: string[] = [];
+    const result = await runSync(graph, config, {
+      noCrossRefs: true,
+      continueOnError: false,
+      onSourceStart: (name) => visited.push(name),
+    });
+
+    expect(result.status).toBe("failed");
+    // Only the first source was attempted
+    expect(visited).toEqual(["fail"]);
+    // Second source is skipped
+    const skipResult = result.sources.find((r) => r.name === "should-skip");
+    expect(skipResult?.status).toBe("skipped");
+  });
+
+  test("--continue-on-error: runs all sources even after failure", async () => {
+    const config = makeConfig({}, [
+      { name: "fail", type: "git", path: "/nonexistent-fail" },
+      { name: "also-fail", type: "git", path: "/nonexistent-also" },
+    ]);
+
+    const visited: string[] = [];
+    const result = await runSync(graph, config, {
+      noCrossRefs: true,
+      continueOnError: true,
+      onSourceStart: (name) => visited.push(name),
+    });
+
+    expect(result.status).toBe("failed");
+    expect(visited).toHaveLength(2);
+    expect(visited).toEqual(["fail", "also-fail"]);
+  });
+
+  test("cross-refs skipped when --no-cross-refs", async () => {
+    const config = makeConfig({}, []);
+    const result = await runSync(graph, config, { noCrossRefs: true });
+    expect(result.crossRefs).toBeNull();
+  });
+
+  test("cross-refs run after empty source list", async () => {
+    const config = makeConfig({}, []);
+    const result = await runSync(graph, config, { noCrossRefs: false });
+    // With no episodes, cross-ref resolver should succeed and return zero counts
+    expect(result.crossRefs).not.toBeNull();
+    expect(result.crossRefs?.edgesCreated).toBe(0);
+  });
+
+  test("cross-refs skipped on fail-fast abort", async () => {
+    const config = makeConfig({}, [
+      { name: "fail", type: "git", path: "/nonexistent" },
+    ]);
+
+    const result = await runSync(graph, config, {
+      noCrossRefs: false,
+      continueOnError: false,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.crossRefs).toBeNull();
+  });
+
+  test("--continue-on-error: cross-refs run even with partial failure", async () => {
+    const config = makeConfig({}, [
+      { name: "fail", type: "git", path: "/nonexistent" },
+    ]);
+
+    const result = await runSync(graph, config, {
+      noCrossRefs: false,
+      continueOnError: true,
+    });
+
+    expect(result.status).toBe("failed");
+    // Cross-refs still run
+    expect(result.crossRefs).not.toBeNull();
+  });
+
+  test("dry-run: returns success without executing", async () => {
+    const config = makeConfig({}, [
+      { name: "a", type: "git", path: "/nonexistent" },
+    ]);
+
+    const result = await runSync(graph, config, {
+      dryRun: true,
+      noCrossRefs: true,
+    });
+
+    expect(result.status).toBe("success");
+    // All sources have success status in dry-run
+    for (const s of result.sources) {
+      expect(s.status).toBe("success");
+    }
+  });
+
+  test("result includes per-source elapsed time", async () => {
+    const config = makeConfig({}, [
+      { name: "a", type: "git", path: "/nonexistent" },
+    ]);
+
+    const result = await runSync(graph, config, {
+      noCrossRefs: true,
+      continueOnError: true,
+    });
+
+    expect(result.sources[0].elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("result status: success when all sources succeed", async () => {
+    // Use dry-run so no actual git calls are made
+    const config = makeConfig({}, [{ name: "a", type: "git", path: "." }]);
+    const result = await runSync(graph, config, {
+      dryRun: true,
+      noCrossRefs: true,
+    });
+    expect(result.status).toBe("success");
+  });
+
+  test("result status: failed when any source fails", async () => {
+    const config = makeConfig({}, [
+      { name: "broken", type: "git", path: "/nonexistent" },
+    ]);
+    const result = await runSync(graph, config, {
+      noCrossRefs: true,
+      continueOnError: true,
+    });
+    expect(result.status).toBe("failed");
+  });
+
+  test("missing auth env var throws SyncSourceError before any source runs", async () => {
+    // Set env to ensure the var doesn't exist
+    const envVar = "ENGRAM_TEST_MISSING_TOKEN_12345";
+    delete process.env[envVar];
+
+    const config = makeConfig({}, [
+      {
+        name: "gh",
+        type: "github",
+        scope: "owner/repo",
+        auth: { kind: "bearer", tokenEnv: envVar },
+      },
+    ]);
+
+    const { SyncSourceError } = await import("../../src/sync/errors.js");
+    await expect(
+      runSync(graph, config, { noCrossRefs: true }),
+    ).rejects.toBeInstanceOf(SyncSourceError);
+  });
+});


### PR DESCRIPTION
Closes #203

## Summary

- Adds `engram sync` CLI command that reads `.engram.config.json` and runs all configured ingesters in declaration order, then the cross-ref resolver
- Adds `runSync()` + `validateSyncConfig()` to `engram-core` public API
- Introduces `packages/engram-core/src/sync/` with `types.ts`, `errors.ts`, `run.ts`, `index.ts`
- Adds example config at `docs/examples/.engram.config.json` and spec at `docs/internal/specs/sync-orchestration.md`
- Updates `CLAUDE.md` with file organization, key files, and preferred entry point note

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| `runSync()` implemented and exported from `packages/engram-core/src/index.ts` | ✅ |
| `engram sync` command wired into root commander program | ✅ |
| Config discovery resolves in documented order; missing config exits `3` with pointer message | ✅ |
| `version: 1` enforced; mismatch fails with upgrade-path message | ✅ |
| Unknown fields at any level cause validation failure (fail-closed) | ✅ |
| `name` uniqueness enforced across sources | ✅ |
| Built-in types resolve directly; plugin types via `discoverPlugins()`; unknown types list available set | ✅ |
| Auth env vars checked before any network calls; missing env var = exit `2` naming source + var | ✅ |
| Sources run in declaration order; cross-refs run exactly once at end (unless `--no-cross-refs`) | ✅ |
| Fail-fast: first failure aborts, skips remaining, exits `1` | ✅ |
| `--continue-on-error`: all sources run, cross-refs over successful subset, exits `1` if any failed | ✅ |
| `--only`: runs named subset in declaration order; unknown name → exit `2` listing known names | ✅ |
| `--dry-run`: prints resolved plan, exits `0`, writes nothing | ✅ |
| `--format json`: emits `SyncResult` with per-source counts (episodes/entities/edges), elapsed ms, status | ✅ |
| Default output: table of per-source results + aggregate line | ✅ |
| Tests: unit tests for `runSync` ordering, fail-fast, continue-on-error, cross-ref skip; validation error tests | ✅ (29 tests) |
| `docs/internal/specs/sync-orchestration.md` — config schema, discovery, failure semantics, exit codes | ✅ |
| `docs/examples/.engram.config.json` — example config | ✅ |
| CLAUDE.md updated: file organization, key files, ingestion architecture note | ✅ |

## Test plan

- [ ] `bun test packages/engram-core/test/sync/` — all 29 tests pass
- [ ] `bun run build` — builds cleanly
- [ ] `bun run lint` — no errors
- [ ] `engram sync --help` — shows full help with discovery order, examples, exit codes
- [ ] `engram sync --dry-run --config docs/examples/.engram.config.json` — prints plan, exits 0
- [ ] Missing config → exits 3 with pointer message
- [ ] Invalid config (unknown field) → exits 2 with all field errors listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)