### PR TITLE
feat: surface design-doc rationale in context packs; wow-moment mcp fixture (P1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ bun.lock
 .worktrees/
 k8s-sidecar-containers-753.engram/
 k8s-sidecar-containers-753-runs/
+
+# Eval fixtures materialized from this repo (regenerate via materialize.sh)
+packages/engram-core/test/fixtures/eval/engram-mcp-decision.engram/
+packages/engram-core/test/fixtures/eval/*.bare-cwd/
+engram-mcp-decision.engram/

--- a/docs/internal/direction-2026-h2.md
+++ b/docs/internal/direction-2026-h2.md
@@ -211,11 +211,26 @@ write-up.
 
 ## 5. The eval, in depth — the MCP reversal as a testable surface
 
-This is the load-bearing insight: **the very decision to reverse the MCP ban is
-the cleanest possible fixture for engram's differentiator.** It is unseen
-(engram's private history), supersession-dependent by construction, falsifiable
-(bare *will* find the superseded ADR), and dogfooding (engram proving its thesis
-on its own decisions is the build-in-public story).
+> **RESULT (2026-06-29, P1 executed).** This fixture was built and run.
+> **Verdict: no differentiation — bare agentic search got the answer fully
+> right**, so the prediction in §5.2 is **falsified** for capable harnesses. The
+> answer is co-located in one grep-discoverable file (`DECISIONS.md`), and a
+> real agent reads it rather than "stopping at ADR-005." The fixture is retained
+> as a **retrieval/pack-quality regression** (the pack must lead with the ADR-009
+> episode — now verified) but is **not** the wow-moment gate. The corrected
+> hypothesis: engram beats capable agentic search only when the rationale is
+> **not readable from files** — PR/issue threads (ingested, not in the tree) or
+> co-change/ownership/supersession across many commits. Full writeup:
+> [`experiments/wow-moment-mcp/decision.md`](experiments/wow-moment-mcp/decision.md).
+> The three retrieval bugs this verification surfaced (§5.3) are fixed and are
+> the real, durable win of P1.
+
+This was the original load-bearing insight: **the very decision to reverse the
+MCP ban is the cleanest possible fixture for engram's differentiator.** It is
+unseen (engram's private history), supersession-dependent by construction, and
+dogfooding. The flaw the run exposed: "unseen" and "dispersed enough to defeat a
+capable bare agent" are *different* properties, and a small well-documented repo
+satisfies the first but not the second.
 
 ### 5.1 The frozen prompt (candidate — finalize at P1 start)
 

--- a/docs/internal/experiments/wow-moment-mcp/answer-bare.md
+++ b/docs/internal/experiments/wow-moment-mcp/answer-bare.md
@@ -1,0 +1,23 @@
+Yes — this has been considered explicitly and recently, and the answer is nuanced: MCP exposure was **rejected, then partially reversed**. The exact scenario you describe (Cursor pulling engram's context over MCP) is the *motivating case* for the reversal. Here's the decision trail:
+
+## What was rejected, and what was accepted
+
+The project split "expose over MCP" into two distinct things with **opposite rulings** (`docs/internal/DECISIONS.md`, ADR-004 → ADR-005 → ADR-009):
+
+**Rejected (and stays rejected): MCP-as-retrieval.** The original `packages/engram-mcp/` exposed graph-traversal primitives (`neighbors`, `shortest_path`, `get_edge`, …) as many model-callable tools. ADR-004 rejected this and ADR-005 deleted the package outright. The reasoning is the core thesis — **"engine decides, model executes":** the engine deterministically assembles and *bounds* the context pack; letting the model make per-call graph-traversal decisions inverts that control. This is dead and stays dead — re-adding traversal tools requires a brand-new ADR.
+
+**Accepted (as of 2026-06-29, ADR-009): MCP-as-distribution.** A *thin* MCP server exposing essentially a single endpoint — `engram context` (plus at most a small fixed set of stable read primitives: `context`, `why`, `diff`). The engine still assembles and bounds the pack; the model only elects *when* to pull it. The refined invariant: **"engine decides *what*, model decides *when*."** That doesn't invert control, because the model never drives traversal — it requests an engine-bounded pack exactly as a harness hook would.
+
+## So is it the right move for your Cursor case?
+
+Per ADR-009, **yes — that's precisely what the MCP surface is for.** The hook path (invisible force-injection via `on_user_prompt` → `engram context`) is the **primary** delivery mechanism and the canonical realization of the thesis. But Cursor's `beforeSubmitPrompt` is block/inform-only, and Antigravity/Windsurf expose no programmable per-prompt injection. MCP is the **secondary** surface explicitly for *harnesses without a force-injection hook* — Cursor named directly. It's also a deliberate positioning play: a flag in the MCP registry against the official MCP `memory` server (a flat, no-provenance, no-temporal knowledge graph that ADR-009 calls engram's "flat foil").
+
+## Two important caveats
+
+1. **It must never become the path for hook-capable harnesses.** For Claude Code / Gemini CLI / OpenCode, the hook path wins; MCP is the fallback for tools like Cursor that can't force-inject.
+
+2. **It's not built yet — it's gated.** ADR-009 sequences the MCP server *behind* the "wow-moment validation" (`docs/internal/near-term-plan.md`): the hook path proves the thesis on unseen substrate first, then the MCP server ships as a distribution follow-on. The ADR is "Accepted" but explicitly says *"Do not build it before the private-substrate wow moment lands."*
+
+One doc-hygiene note: the `CLAUDE.md` in this fixture already reflects ADR-009 (it describes the distribution-only carve-out correctly), so the older "no MCP of any kind" language ADR-009 flagged for cleanup appears to have already been updated here.
+
+Net: exposing the *full graph* over MCP for Cursor — rejected (control inversion). Exposing a *single bounded `engram context` endpoint* over MCP for Cursor — that's the sanctioned design, just not yet implemented and intentionally sequenced after the hook-path proof.

--- a/docs/internal/experiments/wow-moment-mcp/answer-with-pack.md
+++ b/docs/internal/experiments/wow-moment-mcp/answer-with-pack.md
@@ -1,0 +1,23 @@
+Short answer: **yes, it's been considered — very recently and deliberately — and your exact use case (Cursor) is the named motivation. It's accepted, but only in a specific, narrow form, and it isn't built yet.**
+
+This is settled in **ADR-009 "MCP as a distribution surface" (DECISIONS.md:404, dated 2026-06-29 — today)**, which refines the earlier blanket rejection. The history matters here, so let me lay out the full arc:
+
+## The decision was never binary — MCP got split in two
+
+ADR-004/005 originally rejected MCP wholesale and deleted the `packages/engram-mcp/` package (decommissioned in commit `67d8468c`, ADR-005). But ADR-009 argues that rejection **conflated two different things**, and rules on them oppositely:
+
+- **MCP-as-retrieval** (many graph-traversal tools the model drives — `neighbors`, `shortest_path`, `get_edge`, etc.) → **still rejected.** This was the architecture of the deleted `engram-mcp`. It inverts engram's core thesis ("engine decides, model executes") by letting the model make per-call retrieval decisions. It stays dead, and per CLAUDE.md you can't add such tools without a new ADR.
+
+- **MCP-as-distribution** (one thin server exposing essentially a *single* `engram context` endpoint, plus maybe a small fixed set like `why`/`diff`) → **now accepted.** The engine still assembles and bounds the pack; the model only elects *when* to pull it. The refined invariant is **"engine decides *what*, model decides *when*."** That doesn't invert control — the model requests an engine-bounded pack the same way a harness hook does.
+
+## Cursor is the explicit reason this path exists
+
+ADR-009 calls Cursor out by name (DECISIONS.md:455): Cursor's `beforeSubmitPrompt` hook is **block/inform-only** — it can't force-inject context the way Claude Code's `UserPromptSubmit` or Gemini CLI's `BeforeAgent` can. So harnesses *without* a force-injection hook (Cursor, Antigravity, Windsurf) are precisely the gap the MCP surface is meant to fill. There's also a competitive angle: planting a flag in the MCP registry directly against the official flat `memory` server (no temporal/provenance/evidence layer — engram's whole differentiator).
+
+## Two important caveats before you count on it
+
+1. **It's the secondary path, not the primary one.** Invisible harness-forced injection stays primary and canonical. The ADR is explicit: *"MCP must never become the path engram tells hook-capable harnesses to use."* So in Claude Code/Gemini you'd still want the hook; MCP is specifically for the harnesses that can't do that.
+
+2. **It's accepted but deliberately not built yet.** ADR-009 gates it behind the wow-moment validation: *"Do not build it before the private-substrate wow moment lands"* (DECISIONS.md:494–497). There's no MCP server in the tree today — `engram context` exists as a CLI command (`packages/engram-cli/src/commands/context.ts`) and as a harness assembler (`packages/harnesses/core/src/context-assembly.ts`), and the planned MCP server would wrap `engram context --format=json` and reuse those same assembly helpers, living under `packages/harnesses/`, not a resurrected `packages/engram-mcp/`.
+
+**So, is it the right move?** The project's answer is: yes for distribution, no for retrieval. Exposing `engram context` as a single MCP endpoint so it shows up in Cursor is exactly the sanctioned design — what you'd want to *avoid* is re-exposing graph-traversal primitives as a toolbox the model drives, which is the thing that was deliberately killed. If you want to actually stand it up, the work is unblocked by ADR-009 but sequenced after the wow-moment proof, and it should be a thin wrapper over the existing `--format=json` pack assembler.

--- a/docs/internal/experiments/wow-moment-mcp/decision.md
+++ b/docs/internal/experiments/wow-moment-mcp/decision.md
@@ -1,0 +1,80 @@
+# Wow-moment experiment — engram MCP decision (ADR-004 → 005 → 009)
+
+**Date:** 2026-06-29.
+**Fixture:** `packages/engram-core/test/fixtures/eval/engram-mcp-decision.yaml`.
+**Model (harness):** `claude -p` (agentic, file access). Gemini CLI was intended
+per the fixture but its individual free tier was decommissioned mid-run
+(`IneligibleTierError`); `claude` is an equivalent agentic harness for the
+eyeball verdict.
+**Conditions:** `bare` = agent searches a *sanitized* worktree (real code +
+`DECISIONS.md` with all ADRs + git history, minus the eval meta-docs and the
+`fixtures/eval` dir). `with_pack` = same, plus the `engram context` pack
+prepended.
+
+## Verdict: NO MEANINGFUL DIFFERENTIATION (informative negative result)
+
+Both conditions produced a **fully correct** answer: ADR-004/005 rejected MCP
+wholesale and deleted `engram-mcp`; ADR-009 (2026-06-29) reversed the *blanket*
+ban into MCP-as-distribution (single `engram context` endpoint, "engine decides
+what, model elects when") while keeping MCP-as-retrieval rejected; Cursor is the
+named motivation; the server is gated and unbuilt. See `answer-bare.md` and
+`answer-with-pack.md`.
+
+The only delta: `with_pack` cited line numbers (`DECISIONS.md:404/:455/:494`)
+and a commit SHA the pack surfaced. The *substance* was identical. The predicted
+bare failure (§5.2 of `direction-2026-h2.md`: "bare stops at ADR-005, says MCP
+was removed, don't") **did not occur.**
+
+## Why bare succeeded (the load-bearing finding)
+
+The answer is **co-located in one grep-discoverable file** (`DECISIONS.md`), and
+a capable agentic model simply reads it top-to-bottom — it does not "stop at
+ADR-005." The §5.2 prediction modeled a lazy keyword-grepper; real harnesses
+read the whole decision record. **For documented, co-located rationale, capable
+agentic search is a strong baseline that the pack does not beat.**
+
+This is consistent with ADR-004's own framing note ("agents always have file
+access; pack-vs-no-access is a straw man") — and sharpens it: the pack also does
+not beat agentic search when the rationale lives in **readable files**.
+
+## What this does and does not invalidate
+
+- **Does NOT invalidate the engine work.** Verifying this fixture surfaced three
+  real retrieval bugs, now fixed and the reason the pack *can* carry the current
+  decision at all: (1) design-doc/`document` episodes were excluded from the
+  "discussions" surface; (2) excerpts were file-head slices, never the relevant
+  section; (3) whole-file markdown episodes are poor retrieval units. See
+  `direction-2026-h2.md` §5.3 and the commit. These are general improvements to
+  engram's "surface the rationale" thesis regardless of this fixture.
+- **DOES invalidate this fixture as a wow-moment.** Self-referential ADR
+  rationale in one file cannot defeat a capable bare agent. Keep the fixture as a
+  **retrieval/pack-quality regression** (the pack must lead with ADR-009), not as
+  the differentiator gate.
+
+## Corrected hypothesis for the next cycle
+
+Engram beats capable agentic search only when the rationale is **not readable
+from files in the working tree** — i.e. it lives in:
+
+1. **PR / issue discussions** (GitHub/Gerrit API) that are *not* in the repo —
+   the agent cannot grep them; engram ingested them as episodes.
+2. **Co-change / ownership / supersession across many commits** — derivable only
+   by traversing history, which bare search does expensively or not at all.
+
+The next fixture must target a question whose answer depends on (1) or (2), on
+unseen substrate. Engram-on-engram is too small and too well-documented in-tree;
+the K8s shape (dispersed PR/KEP rationale) is right but needs the *private*-repo
+variant to stay unseen. Candidate: a "why does X depend on Y / who owns the
+decision behind Z" question answerable only from PR threads + co-change, not from
+any single file.
+
+## Status of `direction-2026-h2.md` claims
+
+- §5.1 frozen prompt — **kept** (it is a fair question; the substrate just makes
+  it answerable by bare search too).
+- §5.2 "bare fails" prediction — **falsified** for capable agentic harnesses;
+  annotated in the doc.
+- §5.3 "supersession not surfaced; minimal addition needed" — **confirmed and
+  resolved** (section ingestion + discussions-include-document + windowing).
+- Open question #1 — **answered**: whole-file doc episodes cannot surface the
+  current ADR; per-section ingestion is required and now implemented.

--- a/docs/internal/experiments/wow-moment-mcp/pack.md
+++ b/docs/internal/experiments/wow-moment-mcp/pack.md
@@ -1,0 +1,294 @@
+## Context pack
+> Query: I want coding agents to pull engram's context over MCP so it shows up in tools like Cursor. Has this been considered here, and is exposing engram over MCP the right move, or was it deliberately rejected?  Budget: 8000 tokens | Used: ~3237 | 69 results
+
+### Entities
+_Navigation aid — use as a starting point for lookup, not as authority._
+
+- `.github/pull_request_template.md` **[module]** — score 1.000 | evidence: 1 episode(s)
+- `1d41114793be31ce94807f15914fb2f51251876e` **[commit]** — score 0.711 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts` **[module]** — score 0.480 | evidence: 2 episode(s)
+- `packages/harnesses/core/src/context-assembly.ts` **[module]** — score 0.480 | evidence: 2 episode(s)
+- `packages/engram-mcp/src/tools/context.ts` **[module]** — score 0.480 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::toFtsQuery` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::estimateTokens` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::excerptEpisode` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::bestQueryWindow` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::excerptDiscussion` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::ContextOpts` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::EnrichedEntity` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::EnrichedEdge` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::EvidenceExcerpt` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::DirectEpisodeHit` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::ProjectionInPack` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::ContextPack` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::renderMarkdown` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::EntityFtsRow` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::EdgeFtsRow` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::EvidenceRow` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::isConfigNoise` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::isLowSignalEntity` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::searchEntitiesFts` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::likePatterns` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::searchEntitiesLike` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::searchEntitiesViaEpisodeFts` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::EpisodeSearchRow` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::searchEpisodesDirectly` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/engram-cli/src/commands/context.ts::searchEdgesFts` **[symbol]** — score 0.456 | evidence: 1 episode(s)
+- `packages/harnesses/core/src/events.ts::PromptContext` **[symbol]** — score 0.061 | evidence: 1 episode(s)
+- `packages/harnesses/core/src/events.ts::SessionContext` **[symbol]** — score 0.061 | evidence: 1 episode(s)
+- `packages/engram-cli/test/commands/context-sparse.test.ts` **[module]** — score 0.061 | evidence: 2 episode(s)
+- `packages/engram-cli/test/commands/context-max-flags.test.ts` **[module]** — score 0.061 | evidence: 2 episode(s)
+
+### Structural signals (verify before citing)
+_Co-change, ownership, and supersession facts derived from git history. Reflect historical patterns current code may not reveal._
+
+- .github/pull_request_template.md was authored/modified by rn.wolfe@gmail.com in commit 20d879c2 **[observed]** — score 1.000 | valid: 2026-04-07T03:27:10.000Z → present
+- .github/pull_request_template.md is likely owned by rn.wolfe@gmail.com (recency-weighted score: 0.526) **[inferred]** — score 0.947
+- packages/engram-cli/src/commands/context.ts defines toFtsQuery **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines estimateTokens **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines excerptEpisode **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines bestQueryWindow **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines excerptDiscussion **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines ContextOpts **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines EnrichedEntity **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines EnrichedEdge **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines EvidenceExcerpt **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines DirectEpisodeHit **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines ProjectionInPack **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines ContextPack **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines renderMarkdown **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines EntityFtsRow **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines EdgeFtsRow **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines EvidenceRow **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines isConfigNoise **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts defines isLowSignalEntity **[observed]** — score 0.600
+- packages/engram-cli/src/commands/context.ts and packages/engram-cli/src/commands/ingest.ts co-change frequently (5 shared commits) **[inferred]** — score 0.800
+- packages/engram-cli/src/commands/context.ts and packages/engram-cli/src/commands/search.ts co-change frequently (4 shared commits) **[inferred]** — score 0.800
+- packages/engram-cli/src/commands/context.ts and packages/engram-cli/src/commands/show.ts co-change frequently (3 shared commits) **[inferred]** — score 0.800
+- packages/engram-cli/src/commands/context.ts and packages/engram-cli/src/commands/stats.ts co-change frequently (4 shared commits) **[inferred]** — score 0.800
+- packages/engram-cli/src/commands/context.ts and packages/engram-cli/src/commands/verify.ts co-change frequently (3 shared commits) **[inferred]** — score 0.800
+- packages/engram-cli/src/commands/context.ts and packages/engram-cli/src/commands/decay.ts co-change frequently (3 shared commits) **[inferred]** — score 0.800
+- packages/engram-cli/src/commands/context.ts and packages/engram-cli/src/commands/ownership.ts co-change frequently (3 shared commits) **[inferred]** — score 0.800
+- packages/engram-mcp/src/tools/context.ts and packages/engram-mcp/src/tools/search.ts co-change frequently (3 shared commits) **[inferred]** — score 0.800
+- packages/engram-mcp/src/tools/context.ts and packages/engram-mcp/test/mcp.test.ts co-change frequently (3 shared commits) **[inferred]** — score 0.800
+- packages/engram-cli/src/commands/context.ts is likely owned by rnwolfe@users.noreply.github.com (recency-weighted score: 5.621) **[inferred]** — score 0.700
+- packages/harnesses/core/src/context-assembly.ts is likely owned by rnwolfe@users.noreply.github.com (recency-weighted score: 1.000) **[inferred]** — score 0.700
+- packages/engram-cli/test/commands/context-max-flags.test.ts is likely owned by rnwolfe@users.noreply.github.com (recency-weighted score: 0.573) **[inferred]** — score 0.700
+- packages/engram-cli/test/commands/context-sparse.test.ts is likely owned by rnwolfe@users.noreply.github.com (recency-weighted score: 0.573) **[inferred]** — score 0.700
+- packages/engram-mcp/src/tools/context.ts is likely owned by rnwolfe@users.noreply.github.com (recency-weighted score: 1.626) **[inferred]** — score 0.700
+- packages/engram-cli/src/commands/context.ts defines STOP_WORDS **[observed]** — score 0.500
+
+### Possibly relevant discussions
+_These may or may not address your question — verify by reading the source before citing._
+
+**document** `/home/rnwolfe/dev/engram/packages/engram-core/test/fixtures/eval/engram-mcp-deci` (2026-06-29) — confidence 0.975:
+```
+…wise,
+   cognee, CodeScene, Sourcegraph, AtlasMemory, the live `codebase-memory-mcp`
+   / `code-meridian` wave — ships an MCP server as its primary reach mechanism.
+2. **The official MCP `memory` server is engram's flat foil.** It is a
+   local single-file knowledge graph (entities / relations / observations in
+   one `memory.jsonl`) with **no temporal, provenance, or evidence metadata**.
+   It proves the market expects local single-file agent memory *and* leaves
+   the temporal + evidence layer — engram's exact differentiator — wide open
+   in a registry with built-in discovery.
+3. **ADR-004 conflated two uses of MCP.** "MCP" was rejected wholesale as
+   "model-callable retrieval that inverts engine-decides-model-executes." But
+   exposing engram as a *single* context endpoint is a different thing from
+   exposing graph-traversal primitives as many tools. The first preserves the
+   thesis; only the second violates it.
+
+**Decision**: Reverse the *blanket* MCP prohibition in ADR-004's "explicit nos"
+and the harness-pivot-plan out-of-scope list. Split MCP into two uses with
+opposite rulings:
+
+- **MCP-as-retrieval (many graph-traversal tools the model drives)** — still
+  rejected, unchanged from ADR-004. The model must not make per-call retrieval
+  decisions over engram's graph primitives. This was the architecture of the
+  deleted `engram-mcp` (`mcp-graph-traversal-tools.md`); it…
+```
+
+### Evidence excerpts
+_Raw source text. Citable if you verify it matches current code._
+
+**git_commit** `20d879c2f0478c692d782bcd0335f165688a385c` (2026-04-07 by rn.wolfe@gmail.com):
+```
+commit 20d879c2f0478c692d782bcd0335f165688a385c
+Author: Ryan Wolfe <rn.wolfe@gmail.com>
+Date: 2026-04-07T03:27:10.000Z
+
+chore: initialize project from forge template
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+Files:
+.claude/settings.json
+.claude/skills/autodev/SKILL.md
+.claude/skills/await-ci/SKILL.md
+.claude/skills/brainstorm/SKILL.md
+.claude/skills/dispatch/SKILL.md
+.claude/skills/draft-is…
+```
+
+**git_commit** `1d41114793be31ce94807f15914fb2f51251876e` (2026-04-07 by rnwolfe@users.noreply.github.com):
+```
+commit 1d41114793be31ce94807f15914fb2f51251876e
+Author: Ryan <rnwolfe@users.noreply.github.com>
+Date: 2026-04-07T10:23:42.000Z
+
+fix: add pull-requests:read permission to commitlint CI job (#33)
+
+
+Files:
+.github/workflows/ci.yml
+docs/internal/STATUS.md
+```
+
+**git_commit** `6b8490220d35d048754c617b19c9c30a0f5c2acb` (2026-06-29 by rnwolfe@users.noreply.github.com):
+```
+commit 6b8490220d35d048754c617b19c9c30a0f5c2acb
+Author: Ryan <rnwolfe@users.noreply.github.com>
+Date: 2026-06-29T11:48:37.000Z
+
+feat: wow-moment cycle, plus 2026-h2 direction re-aim and adr-009 (#279)
+
+Implementation (wow-moment cycle):
+- eval fixture harness (packages/engram-core/test/fixtures/eval) + k8s
+  KEP-753 fixture and runner
+- module_overview projection kind, end-to-end with staleness pl…
+```
+
+**source** `packages/engram-cli/src/commands/context.ts@2569768c7d7902c4` (2026-06-29):
+```
+/**
+ * context.ts — `engram context` command.
+ *
+ * Assembles a token-budgeted context pack from the knowledge graph for a
+ * given query and writes it to stdout. Intended for injection into agent
+ * prompts via harness plugins or manual use.
+ *
+ * Output includes: ranked entities (with type), edges (with kind), and
+ * evidence excerpts from backing episodes. A budget accounting line at the
+ * top lets the consumer know how much was truncated.
+ */
+
+import * as path from "node:path";
+import type …
+```
+
+**source** `packages/harnesses/core/src/context-assembly.ts@8c44ef029123` (2026-06-29):
+```
+import { execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getDeadlineMs } from "./deadline.js";
+
+function findEngramDb(cwd: string): string | null {
+  const candidate = path.join(cwd, ".engram");
+  if (fs.existsSync(candidate)) return candidate;
+  return null;
+}
+
+function findEngramCli(): string {
+  return "engram";
+}
+
+export async function assembleContextPack(
+  cwd: string,
+  prompt: string,
+): Promise<string | null> {
+  const db …
+```
+
+**git_commit** `67d8468c6a617209fba792ab23601a46ed20720e` (2026-04-17 by rnwolfe@users.noreply.github.com):
+```
+commit 67d8468c6a617209fba792ab23601a46ed20720e
+Author: Ryan <rnwolfe@users.noreply.github.com>
+Date: 2026-04-17T17:36:28.000Z
+
+chore: decommission engram-mcp (ADR-005) (#136)
+
+* chore: decommission engram-mcp and remove serve command
+
+Deletes packages/engram-mcp/ per ADR-005, removes the engram serve
+placeholder command, and cleans up all MCP references from CLAUDE.md,
+README.md, and the CLI comm…
+```
+
+**source** `packages/harnesses/core/src/events.ts@8ebe0cf03f3ad0741efa99` (2026-06-29):
+```
+export interface SessionContext {
+  cwd: string;
+  sessionId?: string;
+}
+
+export interface PromptContext extends SessionContext {
+  prompt: string;
+}
+
+export type HookResult = { ok: true } | { ok: false; error: string };
+```
+
+**git_commit** `792ea8fe468bd0a3da279ccc42d006f7909d456c` (2026-04-18 by rnwolfe@users.noreply.github.com):
+```
+commit 792ea8fe468bd0a3da279ccc42d006f7909d456c
+Author: Ryan <rnwolfe@users.noreply.github.com>
+Date: 2026-04-18T04:14:49.000Z
+
+fix(cli): gate sparse-results note on --verbose or stderr TTY (#174)
+
+The diagnostic note emitted when fewer than 3 entities are found was
+unconditionally written to stderr, causing constant noise in CI pipelines
+that redirect stderr. Gate it behind opts.verbose || proces…
+```
+
+**source** `packages/engram-cli/test/commands/context-sparse.test.ts@2e6` (2026-06-29):
+```
+/**
+ * context-sparse.test.ts — Tests that the sparse-results diagnostic note on
+ * stderr is gated on --verbose or process.stderr.isTTY.
+ *
+ * Issue #155: the note was unconditionally written, causing noise in CI.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { createGraph } from "engram-core";
+import { registerContext } from "../../src/commands/co…
+```
+
+**git_commit** `af53636b0dd5a5b9aebee0b86656518cad4352d3` (2026-04-18 by rnwolfe@users.noreply.github.com):
+```
+commit af53636b0dd5a5b9aebee0b86656518cad4352d3
+Author: Ryan <rnwolfe@users.noreply.github.com>
+Date: 2026-04-18T04:47:05.000Z
+
+feat(cli): add --max-entities and --max-edges to context command (#181)
+
+* feat(cli): add --max-entities and --max-edges to context command
+
+Add optional hard-cap flags that apply as secondary filters after
+the token budget, capping the entity and edge candidate sets befo…
+```
+
+**source** `packages/engram-cli/test/commands/context-max-flags.test.ts@` (2026-06-29):
+```
+/**
+ * context-max-flags.test.ts — Tests for --max-entities and --max-edges
+ * hard-cap flags on `engram context`.
+ *
+ * Issue #162: flags apply as secondary filters after the token budget,
+ * limiting candidate sets before the budget loop.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { addEdge, addEntity, addEpisode, createGraph } from "engram-cor…
+```
+

--- a/packages/engram-cli/src/commands/context.ts
+++ b/packages/engram-cli/src/commands/context.ts
@@ -151,13 +151,72 @@ function excerptEpisode(ep: Episode): string {
 const DISCUSSION_EXCERPT_CHARS: Record<string, number> = {
   github_pr: 1200,
   github_issue: 1000,
+  // Design docs / ADRs are large multi-section files; give the matched section
+  // generous space (a single ADR is ~1-2k chars).
+  document: 1400,
   git_commit: 600,
 };
 
-function excerptDiscussion(content: string, sourceType: string): string {
+/**
+ * Find the best `limit`-wide window in `text` — the one containing the densest
+ * cluster of query-term matches. Long episodes (a multi-section design doc, an
+ * ADR file) carry the answer deep in the file; excerpting the file head would
+ * surface the wrong section. Returns null when no term matches (caller falls
+ * back to a head slice). Terms shorter than 3 chars are ignored as noise.
+ */
+function bestQueryWindow(
+  text: string,
+  queryTerms: string[] | undefined,
+  limit: number,
+): { start: number; end: number } | null {
+  if (!queryTerms || queryTerms.length === 0) return null;
+  const hay = text.toLowerCase();
+  const positions: number[] = [];
+  for (const term of queryTerms) {
+    const t = term.toLowerCase();
+    if (t.length < 3) continue;
+    let idx = hay.indexOf(t);
+    while (idx !== -1) {
+      positions.push(idx);
+      idx = hay.indexOf(t, idx + t.length);
+    }
+  }
+  if (positions.length === 0) return null;
+  positions.sort((a, b) => a - b);
+  let bestStart = positions[0];
+  let bestCount = 0;
+  for (const p of positions) {
+    const windowEnd = p + limit;
+    let count = 0;
+    for (const q of positions) {
+      if (q < p) continue;
+      if (q >= windowEnd) break;
+      count++;
+    }
+    if (count > bestCount) {
+      bestCount = count;
+      bestStart = p;
+    }
+  }
+  const start = Math.max(0, bestStart - 80);
+  const end = Math.min(text.length, start + limit);
+  return { start, end };
+}
+
+function excerptDiscussion(
+  content: string,
+  sourceType: string,
+  queryTerms?: string[],
+): string {
   const limit = DISCUSSION_EXCERPT_CHARS[sourceType] ?? 800;
   const trimmed = content.trim();
   if (trimmed.length <= limit) return trimmed;
+  const window = bestQueryWindow(trimmed, queryTerms, limit);
+  if (window) {
+    const prefix = window.start > 0 ? "…" : "";
+    const suffix = window.end < trimmed.length ? "…" : "";
+    return `${prefix}${trimmed.slice(window.start, window.end)}${suffix}`;
+  }
   return `${trimmed.slice(0, limit)}…`;
 }
 
@@ -729,13 +788,14 @@ function searchEpisodesDirectly(
          FROM episodes_fts
          JOIN episodes ON episodes._rowid = episodes_fts.rowid
          WHERE episodes_fts MATCH ?
-           AND episodes.source_type IN ('github_pr', 'github_issue', 'git_commit')
+           AND episodes.source_type IN ('github_pr', 'github_issue', 'document', 'git_commit')
            AND episodes.status = 'active'
          ORDER BY
            CASE episodes.source_type
              WHEN 'github_pr'    THEN 0
              WHEN 'github_issue' THEN 1
-             ELSE                     2
+             WHEN 'document'     THEN 2
+             ELSE                     3
            END ASC,
            rank ASC
          LIMIT ${limit}`,
@@ -784,6 +844,9 @@ function searchEdgesFts(
 const SOURCE_TYPE_PRIOR: Record<string, number> = {
   github_pr: 1.0,
   github_issue: 0.9,
+  // Design docs / ADRs / KEPs ingested as markdown carry deliberate, durable
+  // rationale — the highest-signal "why" source alongside PR/issue discussion.
+  document: 0.9,
   git_commit: 0.7,
 };
 
@@ -920,6 +983,10 @@ async function assembleContextPack(
 
   // Stop-word filtered query for FTS; original query preserved in output.
   const ftsQuery = toFtsQuery(query);
+
+  // Raw terms for query-aware excerpt windowing (surface the matched section of
+  // a long design-doc episode rather than its head).
+  const queryTerms = ftsQuery.split(/\s+/).filter((t) => t.length > 2);
 
   // Build FTS5 MATCH expression.
   // Single term: exact phrase match ("supersedeEdge").
@@ -1178,7 +1245,7 @@ async function assembleContextPack(
     // than a misleading one.
     if (confidence < opts.minConfidence) continue;
 
-    const excerpt = excerptDiscussion(row.content, row.source_type);
+    const excerpt = excerptDiscussion(row.content, row.source_type, queryTerms);
     const epTokens = estimateTokens(excerpt) + 30;
     if (discussionsUsed + epTokens > discussionsBudget) break;
 
@@ -1207,7 +1274,9 @@ async function assembleContextPack(
       if (
         !ep ||
         ep.status !== "active" ||
-        !["github_pr", "github_issue", "git_commit"].includes(ep.source_type)
+        !["github_pr", "github_issue", "document", "git_commit"].includes(
+          ep.source_type,
+        )
       ) {
         continue;
       }
@@ -1220,7 +1289,7 @@ async function assembleContextPack(
       );
       if (confidence < opts.minConfidence) continue;
 
-      const excerpt = excerptDiscussion(ep.content, ep.source_type);
+      const excerpt = excerptDiscussion(ep.content, ep.source_type, queryTerms);
       const epTokens = estimateTokens(excerpt) + 30;
       if (discussionsUsed + epTokens > discussionsBudget) break;
 

--- a/packages/engram-cli/test/commands/context-document-discussions.test.ts
+++ b/packages/engram-cli/test/commands/context-document-discussions.test.ts
@@ -1,0 +1,101 @@
+/**
+ * context-document-discussions.test.ts
+ *
+ * Regression for the wow-moment retrieval fixes (2026-06-29): design-doc
+ * (`source_type='document'`) episodes must surface in the "Possibly relevant
+ * discussions" section, and a query that matches a deep section of a long doc
+ * must excerpt THAT section (query-windowed), not the file head.
+ *
+ * Before the fix: `searchEpisodesDirectly` filtered to PR/issue/commit, so docs
+ * never appeared; and excerpts were `slice(0, limit)`, so only the file head
+ * showed. A current decision buried deep in a decision record was unreachable.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Command } from "commander";
+import { addEpisode, closeGraph, createGraph } from "engram-core";
+import { registerContext } from "../../src/commands/context.js";
+
+async function runContextStdout(
+  dbPath: string,
+  query: string,
+): Promise<string> {
+  const program = new Command().exitOverride();
+  registerContext(program);
+
+  const writes: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => {
+    writes.push(args.map((a) => String(a)).join(" "));
+  };
+  try {
+    await program.parseAsync(
+      ["node", "engram", "context", query, "--db", dbPath],
+      { from: "node" },
+    );
+  } finally {
+    console.log = origLog;
+  }
+  return writes.join("\n");
+}
+
+describe("context — document discussions + query windowing", () => {
+  it("surfaces a deep doc section that matches the query, not the file head", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "engram-ctx-doc-"));
+    const dbPath = path.join(tmpDir, "test.engram");
+    try {
+      const graph = createGraph(dbPath);
+
+      // A long decision record. The query-relevant content (zorptulate) is in
+      // a deep section; the file head is about an unrelated topic.
+      const padding = "Filler sentence about unrelated background. ".repeat(40);
+      const doc = [
+        "# Decision Record",
+        "",
+        "## ADR-001 early decision about widgets",
+        "",
+        padding,
+        "We chose widgets over gadgets for the frobnicator subsystem.",
+        padding,
+        "",
+        "## ADR-009 the zorptulate reversal",
+        "",
+        "Decision: reverse the earlier ban and adopt zorptulate as the current",
+        "approach. This supersedes the widget decision.",
+        padding,
+        "",
+      ].join("\n");
+      // One whole-file `document` episode (the windowing case): the excerpt
+      // must window onto the deep matching section, not the file head.
+      addEpisode(graph, {
+        source_type: "document",
+        source_ref: path.join(tmpDir, "DECISIONS.md"),
+        content: doc,
+        timestamp: "2026-06-29T00:00:00.000Z",
+      });
+      // A second, unrelated doc so FTS rank normalization has a range.
+      addEpisode(graph, {
+        source_type: "document",
+        source_ref: path.join(tmpDir, "OTHER.md"),
+        content:
+          "# Other\n\n## Unrelated\n\nA note about quokkas and platypuses.",
+        timestamp: "2026-06-28T00:00:00.000Z",
+      });
+      closeGraph(graph);
+
+      const out = await runContextStdout(dbPath, "zorptulate reversal");
+
+      // The doc surfaces as a discussion...
+      expect(out).toContain("Possibly relevant discussions");
+      expect(out).toContain("document");
+      // ...and the excerpt is the matching (deep) section, carrying the answer.
+      expect(out.toLowerCase()).toContain("zorptulate");
+      expect(out).toContain("reverse the earlier ban");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/engram-core/src/ingest/markdown.ts
+++ b/packages/engram-core/src/ingest/markdown.ts
@@ -26,6 +26,27 @@ export interface MarkdownIngestOpts {
   actor?: string;
   /** AI provider for post-ingest embedding generation (best-effort, never blocks ingest) */
   provider?: AIProvider;
+  /**
+   * Split a document into one episode per top-level (`##`) section instead of
+   * one episode per file. Default true. A whole-file episode is a poor
+   * retrieval unit for long design docs / ADRs: FTS ranks the file by aggregate
+   * term density, so a query that matches one section surfaces the file's
+   * densest (often oldest) section, and the excerpt shows the file head — the
+   * relevant section is never reached. Per-section episodes let each section
+   * (e.g. one ADR) rank and excerpt on its own. Falls back to a single
+   * whole-file episode when the document has fewer than two `##` sections, so
+   * simple notes keep file-level `source_ref` semantics.
+   */
+  sectionize?: boolean;
+}
+
+// One ingestable unit of a markdown file: either the whole file or one section.
+interface MarkdownUnit {
+  /** Unique source_ref for dedup: the file path, or `<path>#<idx>-<slug>`. */
+  sourceRef: string;
+  content: string;
+  /** Section heading when this unit is a section; undefined for whole-file. */
+  heading?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -90,6 +111,60 @@ function computeHash(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
+function slugify(heading: string): string {
+  return (
+    heading
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || "section"
+  );
+}
+
+/**
+ * Split a markdown document into ingestable units, one per top-level (`##`)
+ * section, plus a leading preamble unit if there is content before the first
+ * `##`. Returns a single whole-file unit (source_ref = file path) when the
+ * document has fewer than two `##` sections, preserving file-level semantics
+ * for simple notes. `sourceRef` is unique per unit for idempotent dedup.
+ */
+function splitMarkdownUnits(
+  absolutePath: string,
+  content: string,
+): MarkdownUnit[] {
+  const lines = content.split("\n");
+  const headingIdx: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^##\s+/.test(lines[i])) headingIdx.push(i);
+  }
+  if (headingIdx.length === 0) {
+    return [{ sourceRef: absolutePath, content }];
+  }
+
+  const units: MarkdownUnit[] = [];
+  const preamble = lines.slice(0, headingIdx[0]).join("\n");
+  if (preamble.trim().length > 0) {
+    units.push({ sourceRef: `${absolutePath}#0-preamble`, content: preamble });
+  }
+  headingIdx.forEach((start, idx) => {
+    const end =
+      idx + 1 < headingIdx.length ? headingIdx[idx + 1] : lines.length;
+    const heading = lines[start].replace(/^#+\s+/, "").trim();
+    units.push({
+      sourceRef: `${absolutePath}#${idx + 1}-${slugify(heading)}`,
+      content: lines.slice(start, end).join("\n"),
+      heading,
+    });
+  });
+
+  // A single section with no preamble is effectively a whole-file doc — keep
+  // file-level source_ref so dedup and downstream references stay stable.
+  if (units.length < 2) {
+    return [{ sourceRef: absolutePath, content }];
+  }
+  return units;
+}
+
 // ---------------------------------------------------------------------------
 // Main ingestion function
 // ---------------------------------------------------------------------------
@@ -98,8 +173,10 @@ function computeHash(content: string): string {
  * Ingests one or more markdown files into an EngramGraph.
  *
  * - Accepts a file path or glob pattern.
- * - Creates one episode per file with source_type='document'.
- * - source_ref is the absolute file path for idempotent dedup.
+ * - Creates one episode per `##` section (source_type='document'), or one
+ *   whole-file episode for section-less docs / when `opts.sectionize === false`.
+ * - source_ref is `<absPath>` (whole-file) or `<absPath>#<idx>-<slug>` (section),
+ *   for idempotent dedup.
  * - Returns IngestResult.
  */
 export async function ingestMarkdown(
@@ -135,39 +212,47 @@ export async function ingestMarkdown(
       continue;
     }
 
-    // Check for existing episode by source_ref (idempotent)
-    const existing = graph.db
-      .query<{ id: string }, [string, string]>(
-        "SELECT id FROM episodes WHERE source_type = ? AND source_ref = ?",
-      )
-      .get(EPISODE_SOURCE_TYPES.DOCUMENT, absolutePath);
-
-    if (existing) {
-      counts.episodesSkipped++;
-      continue;
-    }
-
     // Read file content (exact, no normalization)
     const content = fs.readFileSync(absolutePath, "utf-8");
     const timestamp = stat.mtime.toISOString();
 
-    const episode = addEpisode(graph, {
-      source_type: EPISODE_SOURCE_TYPES.DOCUMENT,
-      source_ref: absolutePath,
-      content,
-      actor: opts.actor,
-      timestamp,
-      owner_id: opts.owner_id,
-      extractor_version: ENGINE_VERSION,
-      metadata: {
-        file_path: absolutePath,
-        content_hash: computeHash(content),
-        size_bytes: stat.size,
-      },
-    });
+    const units =
+      opts.sectionize === false
+        ? [{ sourceRef: absolutePath, content }]
+        : splitMarkdownUnits(absolutePath, content);
 
-    newEpisodeIds.push(episode.id);
-    counts.episodesCreated++;
+    for (const unit of units) {
+      // Check for existing episode by source_ref (idempotent, per unit)
+      const existing = graph.db
+        .query<{ id: string }, [string, string]>(
+          "SELECT id FROM episodes WHERE source_type = ? AND source_ref = ?",
+        )
+        .get(EPISODE_SOURCE_TYPES.DOCUMENT, unit.sourceRef);
+
+      if (existing) {
+        counts.episodesSkipped++;
+        continue;
+      }
+
+      const episode = addEpisode(graph, {
+        source_type: EPISODE_SOURCE_TYPES.DOCUMENT,
+        source_ref: unit.sourceRef,
+        content: unit.content,
+        actor: opts.actor,
+        timestamp,
+        owner_id: opts.owner_id,
+        extractor_version: ENGINE_VERSION,
+        metadata: {
+          file_path: absolutePath,
+          content_hash: computeHash(unit.content),
+          size_bytes: Buffer.byteLength(unit.content, "utf-8"),
+          ...(unit.heading ? { section_heading: unit.heading } : {}),
+        },
+      });
+
+      newEpisodeIds.push(episode.id);
+      counts.episodesCreated++;
+    }
   }
 
   // Post-ingest: generate embeddings for new episodes (best-effort, never blocks)

--- a/packages/engram-core/test/fixtures/eval/engram-mcp-decision.yaml
+++ b/packages/engram-core/test/fixtures/eval/engram-mcp-decision.yaml
@@ -1,0 +1,95 @@
+fixture:
+  name: engram-mcp-decision
+  description: >
+    Engram's own MCP decision, reversed over time: ADR-004/005 decommissioned
+    `engram-mcp` and banned MCP wholesale; ADR-009 (2026-06-29) reversed the
+    *blanket* ban to allow a distribution-only single-endpoint MCP server while
+    still rejecting model-driven graph-traversal MCP. The wow-moment target:
+    an engram-equipped agent surfaces the CURRENT decision (ADR-009) and the
+    retrieval-vs-distribution distinction, where bare search stops at the
+    superseded ADR-005 "decommission" and answers "MCP was removed, don't."
+    Unseen substrate by construction — the model cannot have memorized
+    engram's private decision history.
+
+  # Self-referential: the substrate is this repository. No external clone.
+  source:
+    type: git
+    repo: .
+    pin: HEAD
+
+# Materialization is deterministic and scripted — see materialize.sh in this
+# directory. The runner expects <name>.engram to already exist.
+#
+# IMPORTANT (eval integrity): only legitimate decision records are ingested.
+# The eval meta-docs (docs/internal/direction-2026-h2.md, near-term-plan.md)
+# are EXCLUDED — they quote this prompt and spell out the answer, which would
+# leak the answer key into both the pack and any bare agent reading the tree.
+ingest:
+  - name: engram-git
+    type: git
+    path: RUNNER_POPULATED        # full history: ADR-009 commit, engram-mcp removal (#136)
+  - name: engram-decisions
+    type: md
+    glob: docs/internal/DECISIONS.md          # the ADR record (sectioned per ADR at ingest)
+  - name: engram-pivot
+    type: md
+    glob: docs/internal/harness-pivot-plan.md # historical "No MCP layer of any kind"
+
+evaluation:
+  model:
+    provider: gemini
+    model_id: gemini-2.5-pro
+    cli_command: gemini
+    cli_flags: ["-p"]
+
+  # The bare condition must run against a SANITIZED checkout (repo minus the eval
+  # meta-docs and minus this fixtures/ directory) so a bare agent cannot read the
+  # answer key. materialize.sh produces that checkout under
+  # <name>.engram-bare-cwd/. Run the bare condition with that as cwd.
+  conditions:
+    - id: bare
+      description: >
+        Agent answers from raw file search alone, in a sanitized checkout that
+        contains the real code + DECISIONS.md (all ADRs) + git history, but NOT
+        the eval meta-docs that state the answer.
+    - id: with_pack
+      description: >
+        Agent receives the `engram context` pack (assembled against the
+        fixture .engram) prepended to the prompt. Pack leads with the ADR-009
+        episode (current decision) as the top discussion.
+
+  prompts:
+    - id: prompt-001
+      text: |
+        I want coding agents to pull engram's context over MCP so it shows up in
+        tools like Cursor. Has this been considered here, and is exposing engram
+        over MCP the right move, or was it deliberately rejected?
+      ground_truth:
+        # The decision record sections that carry the correct, current answer.
+        files:
+          - docs/internal/DECISIONS.md   # ADR-004, ADR-005 (superseded), ADR-009 (current)
+        rationale_sources:
+          - "ADR-009 — MCP as a distribution surface (refines ADR-004)"
+          - "ADR-005 — Decommission engram-mcp and engramark (superseded blanket ban)"
+        expected_answer_summary: |
+          Yes — but as a distribution-only, single-endpoint MCP server, NOT the
+          model-driven graph-traversal tools that were removed. The blanket "no
+          MCP" of ADR-004/005 was reversed by ADR-009 (2026-06-29): MCP-as-
+          retrieval (many model-elected tools over graph primitives) stays
+          rejected because it inverts engine-decides-model-executes; MCP-as-
+          distribution (one `engram context` endpoint — engine decides what,
+          model elects when) is now accepted, precisely for hook-less harnesses
+          like Cursor. The primary delivery path remains harness hooks; MCP is a
+          gated, secondary distribution surface.
+        # Predicted bare failure (recorded before running, per spec §5.2): bare
+        # search hits ADR-005 "Decommission engram-mcp" and harness-pivot-plan
+        # "No MCP layer of any kind" and concludes "MCP was deliberately removed;
+        # don't." If bare instead reads DECISIONS.md top-to-bottom and finds
+        # ADR-009, that is itself a result — the answer is co-located, so this
+        # fixture leans on bare search MISSING the most-recent section in a large
+        # decision record. Escalate to a more dispersed chain (direction-2026-h2
+        # §5.4) if bare reliably succeeds.
+        predicted_bare_failure: |
+          "Exposing engram over MCP was deliberately rejected — ADR-005
+          decommissioned the engram-mcp package and the harness pivot plan
+          explicitly lists 'No MCP layer of any kind'. Don't reintroduce it."

--- a/packages/engram-core/test/fixtures/eval/materialize.sh
+++ b/packages/engram-core/test/fixtures/eval/materialize.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Deterministically materialize an engram-on-engram eval fixture.
+#
+#   ./materialize.sh engram-mcp-decision
+#
+# Produces, next to <name>.yaml:
+#   <name>.engram/            the knowledge graph (git + sectioned decision docs)
+#   <name>.bare-cwd/          a sanitized worktree for the bare condition — the
+#                             real tree minus the eval meta-docs and the eval
+#                             fixtures dir, so a bare agent cannot read the
+#                             answer key. Has .git, so `git log` still works.
+#
+# Both artifacts are .gitignore'd — regenerate on demand rather than committing a
+# graph derived from the repo itself.
+#
+# Requires: the workspace `engram` binary on PATH (bun link --cwd packages/engram-cli).
+set -euo pipefail
+
+NAME="${1:-engram-mcp-decision}"
+FIXTURE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$FIXTURE_DIR" rev-parse --show-toplevel)"
+ENGRAM="${ENGRAM:-engram}"
+
+DB="$FIXTURE_DIR/$NAME.engram"
+# bare-cwd lives OUTSIDE the repo: it is a full source checkout, and a copy of
+# the tree inside the tree breaks biome ("nested root configuration") and makes
+# `bun test` discover duplicate test files.
+BARE_CWD="${TMPDIR:-/tmp}/engram-eval-$NAME.bare-cwd"
+
+echo "Materializing $NAME"
+echo "  repo:   $REPO_ROOT"
+echo "  engram: $("$ENGRAM" --version 2>/dev/null || echo MISSING)"
+
+# ---------------------------------------------------------------------------
+# 1. Sanitized checkout. The graph is built FROM this tree so source ingestion
+#    never sees the eval meta-docs (direction-2026-h2.md, near-term-plan.md) —
+#    they quote the prompt and state the answer. Git history is shared with the
+#    real repo via the worktree, so commit-message rationale is preserved.
+# ---------------------------------------------------------------------------
+git -C "$REPO_ROOT" worktree remove --force "$BARE_CWD" 2>/dev/null || true
+rm -rf "$BARE_CWD"
+git -C "$REPO_ROOT" worktree add --quiet --detach "$BARE_CWD" HEAD
+rm -f "$BARE_CWD/docs/internal/direction-2026-h2.md" \
+      "$BARE_CWD/docs/internal/near-term-plan.md"
+rm -rf "$BARE_CWD/packages/engram-core/test/fixtures/eval"
+echo "  bare:   $BARE_CWD (meta-docs + eval fixtures removed)"
+
+# ---------------------------------------------------------------------------
+# 2. Knowledge graph — built with cwd = the sanitized tree so BOTH git history
+#    and source ingestion (which walks cwd) see only sanitized content. Git
+#    history still contains the meta-doc commits, but only their commit messages
+#    (not the answer-key prose) become substrate.
+# ---------------------------------------------------------------------------
+rm -rf "$DB"
+( cd "$BARE_CWD" && \
+  "$ENGRAM" init --yes --embedding-model none --db "$DB" --from-git . >/dev/null && \
+  "$ENGRAM" ingest md "docs/internal/DECISIONS.md" --db "$DB" >/dev/null && \
+  "$ENGRAM" ingest md "docs/internal/harness-pivot-plan.md" --db "$DB" >/dev/null )
+echo "  graph:  $(sqlite3 "$DB/engram.db" 'SELECT count(*) FROM episodes;') episodes"
+
+echo "Done. Run: bun run eval --fixture $NAME   (bare cwd: $BARE_CWD)"

--- a/packages/engram-core/test/ingest/markdown.test.ts
+++ b/packages/engram-core/test/ingest/markdown.test.ts
@@ -163,3 +163,95 @@ describe("ingestMarkdown — glob patterns", () => {
     expect(result.episodesSkipped).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Section-aware ingestion (one episode per `##` section)
+// ---------------------------------------------------------------------------
+
+describe("ingestMarkdown — sectioning", () => {
+  const multiSection = [
+    "# Decisions",
+    "",
+    "Intro preamble before the first section.",
+    "",
+    "## ADR-001 first decision",
+    "",
+    "Body of the first decision.",
+    "",
+    "## ADR-002 second decision",
+    "",
+    "Body of the second decision.",
+    "",
+  ].join("\n");
+
+  test("splits a multi-section doc into one episode per ## section plus preamble", async () => {
+    const filePath = path.join(tmpDir, "decisions.md");
+    fs.writeFileSync(filePath, multiSection);
+
+    const result = await ingestMarkdown(graph, filePath);
+
+    // preamble + 2 sections = 3 episodes
+    expect(result.episodesCreated).toBe(3);
+
+    const refs = graph.db
+      .query<{ source_ref: string }, []>(
+        "SELECT source_ref FROM episodes ORDER BY source_ref",
+      )
+      .all()
+      .map((r) => r.source_ref);
+    expect(refs).toContain(`${filePath}#0-preamble`);
+    expect(refs.some((r) => r.includes("adr-001-first-decision"))).toBe(true);
+    expect(refs.some((r) => r.includes("adr-002-second-decision"))).toBe(true);
+
+    // Each section episode contains only its own body — so FTS ranks and
+    // excerpts each section independently.
+    const adr2 = graph.db
+      .query<{ content: string }, [string]>(
+        "SELECT content FROM episodes WHERE source_ref LIKE ?",
+      )
+      .get(`%adr-002-second-decision`);
+    expect(adr2?.content).toContain("## ADR-002 second decision");
+    expect(adr2?.content).not.toContain("ADR-001");
+  });
+
+  test("records the section heading in metadata", async () => {
+    const filePath = path.join(tmpDir, "decisions.md");
+    fs.writeFileSync(filePath, multiSection);
+    await ingestMarkdown(graph, filePath);
+
+    const row = graph.db
+      .query<{ metadata: string }, [string]>(
+        "SELECT metadata FROM episodes WHERE source_ref LIKE ?",
+      )
+      .get(`%adr-001-first-decision`);
+    expect(JSON.parse(row?.metadata ?? "{}").section_heading).toBe(
+      "ADR-001 first decision",
+    );
+  });
+
+  test("falls back to a single whole-file episode when there are no ## sections", async () => {
+    const filePath = path.join(tmpDir, "flat.md");
+    fs.writeFileSync(filePath, "# Title\n\nNo level-2 sections here.");
+
+    const result = await ingestMarkdown(graph, filePath);
+
+    expect(result.episodesCreated).toBe(1);
+    const ref = graph.db
+      .query<{ source_ref: string }, []>("SELECT source_ref FROM episodes")
+      .get()?.source_ref;
+    expect(ref).toBe(filePath); // file-level source_ref preserved
+  });
+
+  test("sectionize:false forces a single whole-file episode", async () => {
+    const filePath = path.join(tmpDir, "decisions.md");
+    fs.writeFileSync(filePath, multiSection);
+
+    const result = await ingestMarkdown(graph, filePath, { sectionize: false });
+
+    expect(result.episodesCreated).toBe(1);
+    const ref = graph.db
+      .query<{ source_ref: string }, []>("SELECT source_ref FROM episodes")
+      .get()?.source_ref;
+    expect(ref).toBe(filePath);
+  });
+});


### PR DESCRIPTION
Executes **P1** of `docs/internal/direction-2026-h2.md` (the unseen-substrate wow-moment proof) and, by verifying claims along the way, fixes three real retrieval gaps it surfaced.

## The engine fixes (the durable win)

Verifying the fixture showed `engram context` could not surface a *current* decision buried in a design doc. Three independent gaps, all fixed:

1. **Design docs were excluded from discussions.** `searchEpisodesDirectly` admitted only `github_pr`/`github_issue`/`git_commit`; ADRs/KEPs (`source_type='document'`) could never appear. Now admitted (prior 0.9, ranked above commits).
2. **Excerpts were file-head slices.** A 34k ADR doc always showed its top, never the relevant section. Added **query-windowed** excerpting (`bestQueryWindow`).
3. **Whole-file markdown episodes are poor retrieval units.** `ingestMarkdown` is now **section-aware** (one episode per `##` section), gated to ≥2 sections so simple notes keep file-level `source_ref` semantics — existing tests unchanged.

Net: a query about a superseded-then-reversed decision now leads with the **current** ADR, windowed onto its Decision text. Verified on engram's own ADR-004→005→009 MCP chain.

## The experiment (honest negative result)

`engram-mcp-decision.yaml` + `materialize.sh` build the graph from a **sanitized worktree** so eval meta-docs never leak. The recorded verdict (`experiments/wow-moment-mcp/decision.md`):

> **No differentiation — bare agentic search (claude) got the answer fully right.** The §5.2 "bare fails / says MCP was removed" prediction is **falsified** for capable harnesses, because the answer is co-located in `DECISIONS.md` and a real agent reads it.

The fixture is retained as a **retrieval/pack-quality regression**, not the wow-moment gate. **Corrected hypothesis:** engram beats capable agentic search only when rationale is **not readable from files** — PR/issue threads (ingested, not in the tree) or co-change/ownership/supersession across many commits. `direction-2026-h2.md` §5 is annotated with this.

## Tests
- `markdown.test.ts`: section-aware ingestion (split, metadata, fallback, opt-out).
- `context-document-discussions.test.ts`: document episodes surface + deep-section windowing.
- Full suite: **1622 pass / 0 fail**; lint clean; build green.

## Note
Gemini CLI's individual free tier was decommissioned mid-run (`IneligibleTierError`); `claude -p` was used as the agentic harness. The fixture still names gemini; a per-condition-cwd enhancement to `run.ts` is noted as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)